### PR TITLE
resource scope potential 1 - for #194

### DIFF
--- a/kube/examples/crd_api.rs
+++ b/kube/examples/crd_api.rs
@@ -41,7 +41,7 @@ async fn main() -> anyhow::Result<()> {
     let namespace = std::env::var("NAMESPACE").unwrap_or("default".into());
 
     // Manage CRDs first
-    let crds: Api<CustomResourceDefinition> = Api::all(client.clone());
+    let crds: Api<CustomResourceDefinition> = Api::cluster(client.clone());
 
     // Delete any old versions of it first:
     let dp = DeleteParams::default();

--- a/kube/src/api/crds.rs
+++ b/kube/src/api/crds.rs
@@ -110,13 +110,18 @@ impl CrBuilder {
 /// Make Resource useable on CRDs without k8s_openapi
 impl From<CustomResource> for Resource {
     fn from(c: CustomResource) -> Self {
+        use crate::api::resource::ResourceScope;
+        let scope = if let Some(ns) = c.namespace {
+            ResourceScope::Namespace(ns)
+        } else {
+            ResourceScope::All
+        };
         Self {
             api_version: c.api_version,
             kind: c.kind,
             group: c.group,
             version: c.version,
-            namespace: c.namespace, // yeah, needs to be merged into scope
-            scope: crate::api::resource::ResourceScope::Namespace, // otherwise can clash with ::All
+            scope,
         }
     }
 }

--- a/kube/src/api/crds.rs
+++ b/kube/src/api/crds.rs
@@ -115,7 +115,8 @@ impl From<CustomResource> for Resource {
             kind: c.kind,
             group: c.group,
             version: c.version,
-            namespace: c.namespace,
+            namespace: c.namespace, // yeah, needs to be merged into scope
+            scope: crate::api::resource::ResourceScope::Namespace, // otherwise can clash with ::All
         }
     }
 }

--- a/kube/src/api/crds.rs
+++ b/kube/src/api/crds.rs
@@ -168,7 +168,6 @@ mod test {
         };
         let client = Client::try_default().await.unwrap();
         let r1: Api<Foo> = Api::namespaced(client.clone(), "myns");
-        impl crate::api::resource::NamespaceScopedResource for Foo {} // TODO: This in kube-derive
 
         let r2: Api<Foo> = CustomResource::kind("Foo")
             .group("clux.dev")

--- a/kube/src/api/crds.rs
+++ b/kube/src/api/crds.rs
@@ -162,6 +162,7 @@ mod test {
         };
         let client = Client::try_default().await.unwrap();
         let r1: Api<Foo> = Api::namespaced(client.clone(), "myns");
+        impl crate::api::resource::NamespaceScopedResource for Foo {} // TODO: This in kube-derive
 
         let r2: Api<Foo> = CustomResource::kind("Foo")
             .group("clux.dev")

--- a/kube/src/api/resource.rs
+++ b/kube/src/api/resource.rs
@@ -37,8 +37,8 @@ pub enum ResourceScope {
 
 
 // Try Arnavion's first suggestion
-pub trait ClusterScopedResource: k8s_openapi::Resource { }
-pub trait NamespaceScopedResource: k8s_openapi::Resource { }
+pub trait ClusterScopedResource: k8s_openapi::Resource {}
+pub trait NamespaceScopedResource: k8s_openapi::Resource {}
 use k8s::{
     admissionregistration::v1beta1 as adregv1beta1,
     apps::v1 as appsv1,
@@ -64,8 +64,9 @@ impl NamespaceScopedResource for appsv1::ReplicaSet {}
 impl NamespaceScopedResource for networkingv1beta1::Ingress {}
 impl NamespaceScopedResource for appsv1::DaemonSet {}
 
-use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1 as apiextsv1;
-use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1beta1 as apiextsv1beta1;
+use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::{
+    v1 as apiextsv1, v1beta1 as apiextsv1beta1,
+};
 
 impl ClusterScopedResource for storagev1::VolumeAttachment {}
 impl ClusterScopedResource for adregv1beta1::ValidatingWebhookConfiguration {}
@@ -74,7 +75,6 @@ impl ClusterScopedResource for apiextsv1::CustomResourceDefinition {}
 impl ClusterScopedResource for corev1::Namespace {}
 impl ClusterScopedResource for apiextsv1beta1::CustomResourceDefinition {}
 impl ClusterScopedResource for corev1::Node {}
-
 
 
 impl Resource {
@@ -99,7 +99,7 @@ impl Resource {
             kind: K::KIND.to_string(),
             group: K::GROUP.to_string(),
             version: K::VERSION.to_string(),
-            scope: ResourceScope::All
+            scope: ResourceScope::All,
         }
     }
 
@@ -833,7 +833,7 @@ mod test {
         assert_eq!(req.method(), "PUT");
     }
 
-/*    #[test]
+    /*    #[test]
     #[should_panic] - compile fails now!
     fn all_resources_not_namespaceable() {
         Resource::namespaced::<corev1::Node>("ns");

--- a/kube/src/api/resource.rs
+++ b/kube/src/api/resource.rs
@@ -27,6 +27,15 @@ pub struct Resource {
 
     /// The namespace if the resource resides (if namespaced)
     pub namespace: Option<String>,
+
+    pub scope: ResourceScope,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum ResourceScope {
+    Cluster,
+    Namespace, // could maybe put the resource.namespace string in here
+    All,
 }
 
 
@@ -80,10 +89,14 @@ impl Resource {
             group: K::GROUP.to_string(),
             version: K::VERSION.to_string(),
             namespace: None,
+            scope: ResourceScope::Cluster,
         }
     }
 
     /// Namespaced resources viewed across all namespaces
+    ///
+    /// This does not let you read / get individual objects
+    /// because the resources still need to know the underlying namespace.
     pub fn all<K: NamespaceScopedResource>() -> Self {
         Self {
             api_version: K::API_VERSION.to_string(),
@@ -91,6 +104,7 @@ impl Resource {
             group: K::GROUP.to_string(),
             version: K::VERSION.to_string(),
             namespace: None,
+            scope: ResourceScope::All
         }
     }
 
@@ -102,6 +116,7 @@ impl Resource {
             group: K::GROUP.to_string(),
             version: K::VERSION.to_string(),
             namespace: Some(ns.to_string()),
+            scope: ResourceScope::Namespace,
         }
     }
 }

--- a/kube/src/api/resource.rs
+++ b/kube/src/api/resource.rs
@@ -25,16 +25,13 @@ pub struct Resource {
     /// The version of the resource.
     pub version: String,
 
-    /// The namespace if the resource resides (if namespaced)
-    pub namespace: Option<String>,
-
     pub scope: ResourceScope,
 }
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum ResourceScope {
     Cluster,
-    Namespace, // could maybe put the resource.namespace string in here
+    Namespace(String),
     All,
 }
 
@@ -88,7 +85,6 @@ impl Resource {
             kind: K::KIND.to_string(),
             group: K::GROUP.to_string(),
             version: K::VERSION.to_string(),
-            namespace: None,
             scope: ResourceScope::Cluster,
         }
     }
@@ -103,7 +99,6 @@ impl Resource {
             kind: K::KIND.to_string(),
             group: K::GROUP.to_string(),
             version: K::VERSION.to_string(),
-            namespace: None,
             scope: ResourceScope::All
         }
     }
@@ -115,8 +110,7 @@ impl Resource {
             kind: K::KIND.to_string(),
             group: K::GROUP.to_string(),
             version: K::VERSION.to_string(),
-            namespace: Some(ns.to_string()),
-            scope: ResourceScope::Namespace,
+            scope: ResourceScope::Namespace(ns.to_string()),
         }
     }
 }
@@ -125,7 +119,7 @@ impl Resource {
 
 impl Resource {
     pub(crate) fn make_url(&self) -> String {
-        let n = if let Some(ns) = &self.namespace {
+        let n = if let ResourceScope::Namespace(ns) = &self.scope {
             format!("namespaces/{}/", ns)
         } else {
             "".into()

--- a/kube/src/api/resource.rs
+++ b/kube/src/api/resource.rs
@@ -35,47 +35,19 @@ pub enum ResourceScope {
     All,
 }
 
+// Traits we hope can be exported upstream
+// See https://github.com/clux/kube-rs/issues/194
+// TODO: stop exporting these temporary traits
 
-// Try Arnavion's first suggestion
+/// Temporarily exported trait - do not import
 pub trait ClusterScopedResource: k8s_openapi::Resource {}
+/// Temporarily exported trait - do not import
 pub trait NamespaceScopedResource: k8s_openapi::Resource {}
-use k8s::{
-    admissionregistration::v1beta1 as adregv1beta1,
-    apps::v1 as appsv1,
-    authorization::v1 as authv1,
-    autoscaling::v1 as autoscalingv1,
-    batch::v1beta1 as batchv1beta1,
-    core::v1 as corev1,
-    extensions::v1beta1 as extsv1beta1,
-    networking::{v1 as networkingv1, v1beta1 as networkingv1beta1},
-    rbac::v1 as rbacv1,
-    storage::v1 as storagev1,
-};
-use k8s_openapi::api as k8s;
-impl NamespaceScopedResource for corev1::Secret {}
-impl NamespaceScopedResource for rbacv1::Role {}
-impl NamespaceScopedResource for batchv1beta1::CronJob {}
-impl NamespaceScopedResource for autoscalingv1::HorizontalPodAutoscaler {}
-impl NamespaceScopedResource for networkingv1::NetworkPolicy {}
-impl NamespaceScopedResource for extsv1beta1::Ingress {}
-impl NamespaceScopedResource for appsv1::Deployment {}
-impl NamespaceScopedResource for corev1::Pod {}
-impl NamespaceScopedResource for appsv1::ReplicaSet {}
-impl NamespaceScopedResource for networkingv1beta1::Ingress {}
-impl NamespaceScopedResource for appsv1::DaemonSet {}
 
-use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::{
-    v1 as apiextsv1, v1beta1 as apiextsv1beta1,
-};
-
-impl ClusterScopedResource for storagev1::VolumeAttachment {}
-impl ClusterScopedResource for adregv1beta1::ValidatingWebhookConfiguration {}
-impl ClusterScopedResource for authv1::SelfSubjectRulesReview {}
-impl ClusterScopedResource for apiextsv1::CustomResourceDefinition {}
-impl ClusterScopedResource for corev1::Namespace {}
-impl ClusterScopedResource for apiextsv1beta1::CustomResourceDefinition {}
-impl ClusterScopedResource for corev1::Node {}
-
+// For now - we can'd distinguish between the two types
+impl<T: k8s_openapi::Resource> ClusterScopedResource for T {}
+impl<T: k8s_openapi::Resource> NamespaceScopedResource for T {}
+// TODO: impl NamespaceScopedResource in kube_derive in the future
 
 impl Resource {
     /// Cluster level resources,

--- a/kube/src/api/typed.rs
+++ b/kube/src/api/typed.rs
@@ -92,6 +92,7 @@ where
     /// }
     /// ```
     pub async fn get(&self, name: &str) -> Result<K> {
+        assert!(self.api.scope != crate::api::resource::ResourceScope::All);
         let req = self.api.get(name)?;
         self.client.request::<K>(req).await
     }
@@ -139,7 +140,7 @@ where
     where
         K: Serialize,
     {
-        // TODO: assert self.resource is not a Resource::all
+        assert!(self.api.scope != crate::api::resource::ResourceScope::All);
         let bytes = serde_json::to_vec(&data)?;
         let req = self.api.create(&pp, bytes)?;
         self.client.request::<K>(req).await

--- a/kube/src/api/typed.rs
+++ b/kube/src/api/typed.rs
@@ -29,7 +29,7 @@ pub struct Api<K> {
     pub(crate) phantom: PhantomData<K>,
 }
 
-use crate::api::resource::{NamespaceScopedResource, ClusterScopedResource};
+use crate::api::resource::{ClusterScopedResource, NamespaceScopedResource};
 
 /// Expose same interface as Api for controlling scope/group/versions/ns
 impl<K> Api<K>
@@ -38,7 +38,8 @@ where
 {
     /// Cluster level resources
     pub fn cluster(client: Client) -> Self
-    where K: ClusterScopedResource
+    where
+        K: ClusterScopedResource,
     {
         let api = Resource::cluster::<K>();
         Self {
@@ -50,7 +51,8 @@ where
 
     /// Namespaced resources viewed across all namespaces
     pub fn all(client: Client) -> Self
-    where K: NamespaceScopedResource
+    where
+        K: NamespaceScopedResource,
     {
         let api = Resource::all::<K>();
         Self {
@@ -62,7 +64,8 @@ where
 
     /// Namespaced resource within a given namespace
     pub fn namespaced(client: Client, ns: &str) -> Self
-    where K: NamespaceScopedResource
+    where
+        K: NamespaceScopedResource,
     {
         let api = Resource::namespaced::<K>(ns);
         Self {

--- a/kube/src/runtime/reflector.rs
+++ b/kube/src/runtime/reflector.rs
@@ -97,9 +97,15 @@ where
     /// If you are using a non-namespaced resources with name clashes,
     /// Try `Reflector::get_within` instead.
     pub fn get(&self, name: &str) -> Result<Option<K>> {
+        use crate::api::resource::ResourceScope;
+        let namespace = match &self.resource.scope {
+            ResourceScope::Namespace(ns) => Some(ns.to_owned()),
+            _ => None,
+        };
         let id = ObjectId {
             name: name.into(),
-            namespace: self.resource.namespace.clone(),
+            // TODO: impl From<Resource> for ObjectId
+            namespace,
         };
 
         futures::executor::block_on(async { Ok(self.state.lock().await.data.get(&id).map(Clone::clone)) })


### PR DESCRIPTION
Tries the first of Arnavion's potentials via https://github.com/Arnavion/k8s-openapi/issues/65#issuecomment-601839119

It's assumed that k8s-openapi actually fills in these traits rather than me inlining them, but this is for our tests/experimentation atm.

I don't see a good way to get compile time prevention of using `Api::create` if you're inside a `Resource::all` view, but we  can at least assert here. Not bad at all.