### PR TITLE
test out enum variants in jsonschemas

### DIFF
--- a/examples/crd_derive_schema.rs
+++ b/examples/crd_derive_schema.rs
@@ -81,6 +81,9 @@ pub struct FooSpec {
     // Listable field with specified 'set' merge strategy
     #[serde(default)]
     set_listable: SetListable,
+
+    // List of enum variants
+    variants: Vec<VariantType>,
 }
 #[derive(Serialize, Deserialize, Debug, Default, PartialEq, Eq, Clone)]
 struct SetListable(Vec<u32>);
@@ -104,6 +107,11 @@ impl JsonSchema for SetListable {
         .unwrap()
     }
 }
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, JsonSchema)]
+enum VariantType {
+    VaraintA(u32),
+    VariantB(String),
+}
 
 fn default_value() -> String {
     "default_value".into()
@@ -122,7 +130,7 @@ async fn main() -> Result<()> {
     println!("Creating CRD v1");
     let client = Client::try_default().await?;
     delete_crd(client.clone()).await?;
-    assert!(create_crd(client.clone()).await.is_ok());
+    create_crd(client.clone()).await?;
 
     // Test creating Foo resource.
     let namespace = std::env::var("NAMESPACE").unwrap_or("default".into());
@@ -149,6 +157,8 @@ async fn main() -> Result<()> {
         // Empty listables to be patched in later
         default_listable: Default::default(),
         set_listable: Default::default(),
+        // empty variants
+        variants: vec![],
     });
 
     // Set up dynamic resource to test using raw values.


### PR DESCRIPTION
Indeed correct what is said in https://github.com/clux/kube-rs/issues/129#issuecomment-773436096
By default, enum variants is not well-received by kubernetes api, as they are not [structural](https://kubernetes.io/blog/2019/06/20/crd-structural-schema/):

```
Error: ApiError: CustomResourceDefinition.apiextensions.k8s.io "foos.clux.dev" is invalid: [spec.validation.openAPIV3Schema.properties[spec].properties[variants].items.anyOf[0].properties[VaraintA].type: Forbidden: must be empty to be structural, spec.validation.openAPIV3Schema.properties[spec].properties[variants].items.anyOf[0].type: Forbidden: must be empty to be structural, spec.validation.openAPIV3Schema.properties[spec].properties[variants].items.anyOf[1].properties[VariantB].type: Forbidden: must be empty to be structural, spec.validation.openAPIV3Schema.properties[spec].properties[variants].items.anyOf[1].type: Forbidden: must be empty to be structural, spec.validation.openAPIV3Schema.properties[spec].properties[variants].items.type: Required value: must not be empty for specified array items]: Invalid (ErrorResponse { status: "Failure", message: "CustomResourceDefinition.apiextensions.k8s.io \"foos.clux.dev\" is invalid: [spec.validation.openAPIV3Schema.properties[spec].properties[variants].items.anyOf[0].properties[VaraintA].type: Forbidden: must be empty to be structural, spec.validation.openAPIV3Schema.properties[spec].properties[variants].items.anyOf[0].type: Forbidden: must be empty to be structural, spec.validation.openAPIV3Schema.properties[spec].properties[variants].items.anyOf[1].properties[VariantB].type: Forbidden: must be empty to be structural, spec.validation.openAPIV3Schema.properties[spec].properties[variants].items.anyOf[1].type: Forbidden: must be empty to be structural, spec.validation.openAPIV3Schema.properties[spec].properties[variants].items.type: Required value: must not be empty for specified array items]", reason: "Invalid", code: 422 })
```