### PR TITLE
Add port forward

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -155,6 +155,10 @@ name = "pod_portforward"
 path = "pod_portforward.rs"
 
 [[example]]
+name = "pod_portforward_hyper_http"
+path = "pod_portforward_hyper_http.rs"
+
+[[example]]
 name = "pod_reflector"
 path = "pod_reflector.rs"
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -151,6 +151,10 @@ name = "pod_shell"
 path = "pod_shell.rs"
 
 [[example]]
+name = "pod_portforward"
+path = "pod_portforward.rs"
+
+[[example]]
 name = "pod_reflector"
 path = "pod_reflector.rs"
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -159,6 +159,10 @@ name = "pod_portforward_hyper_http"
 path = "pod_portforward_hyper_http.rs"
 
 [[example]]
+name = "pod_portforward_bind"
+path = "pod_portforward_bind.rs"
+
+[[example]]
 name = "pod_reflector"
 path = "pod_reflector.rs"
 

--- a/examples/pod_portforward.rs
+++ b/examples/pod_portforward.rs
@@ -1,0 +1,80 @@
+#[macro_use] extern crate log;
+
+use futures::{StreamExt, TryStreamExt};
+use k8s_openapi::api::core::v1::Pod;
+
+use kube::{
+    api::{Api, DeleteParams, ListParams, PostParams, WatchEvent},
+    Client, ResourceExt,
+};
+
+use tokio::io::AsyncWriteExt;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    std::env::set_var("RUST_LOG", "info,kube=debug");
+    env_logger::init();
+    let client = Client::try_default().await?;
+    let namespace = std::env::var("NAMESPACE").unwrap_or_else(|_| "default".into());
+
+    let p: Pod = serde_json::from_value(serde_json::json!({
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": { "name": "example" },
+        "spec": {
+            "containers": [{
+                "name": "nginx",
+                "image": "nginx",
+            }],
+        }
+    }))?;
+
+    let pods: Api<Pod> = Api::namespaced(client, &namespace);
+    // Stop on error including a pod already exists or is still being deleted.
+    pods.create(&PostParams::default(), &p).await?;
+
+    // Wait until the pod is running, otherwise we get 500 error.
+    let lp = ListParams::default().fields("metadata.name=example").timeout(10);
+    let mut stream = pods.watch(&lp, "0").await?.boxed();
+    while let Some(status) = stream.try_next().await? {
+        match status {
+            WatchEvent::Added(o) => {
+                info!("Added {}", o.name());
+            }
+            WatchEvent::Modified(o) => {
+                let s = o.status.as_ref().expect("status exists on pod");
+                if s.phase.clone().unwrap_or_default() == "Running" {
+                    break;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let mut pf = pods.portforward("example", &[80]).await?;
+    let mut ports = pf.ports().unwrap();
+    let mut port = ports[0].stream().unwrap();
+    port.write_all(b"GET / HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\nAccept: */*\r\n\r\n")
+        .await?;
+    let mut rstream = tokio_util::io::ReaderStream::new(port);
+    if let Some(res) = rstream.next().await {
+        match res {
+            Ok(bytes) => {
+                let response = std::str::from_utf8(&bytes[..]).unwrap();
+                println!("{}", response);
+                assert!(response.contains("Welcome to nginx!"));
+            }
+            Err(err) => eprintln!("{:?}", err),
+        }
+    }
+
+    // Delete it
+    println!("deleting");
+    pods.delete("example", &DeleteParams::default())
+        .await?
+        .map_left(|pdel| {
+            assert_eq!(pdel.name(), "example");
+        });
+
+    Ok(())
+}

--- a/examples/pod_portforward.rs
+++ b/examples/pod_portforward.rs
@@ -37,7 +37,7 @@ async fn main() -> anyhow::Result<()> {
     let _ = tokio::time::timeout(std::time::Duration::from_secs(15), running).await?;
 
     let mut pf = pods.portforward("example", &[80]).await?;
-    let mut ports = pf.ports().unwrap();
+    let ports = pf.ports();
     let mut port = ports[0].stream().unwrap();
     port.write_all(b"GET / HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\nAccept: */*\r\n\r\n")
         .await?;

--- a/examples/pod_portforward_bind.rs
+++ b/examples/pod_portforward_bind.rs
@@ -1,0 +1,113 @@
+// Example to listen on port 8080 locally, forwarding to port 80 in the example pod.
+// Similar to `kubectl port-forward pod/example 8080:80`.
+use std::{convert::Infallible, net::SocketAddr, sync::Arc};
+
+use futures::FutureExt;
+use hyper::{
+    service::{make_service_fn, service_fn},
+    Body, Request, Response, Server,
+};
+use tokio::sync::Mutex;
+use tower::ServiceExt;
+
+use k8s_openapi::api::core::v1::Pod;
+use kube::{
+    api::{Api, DeleteParams, PostParams},
+    runtime::wait::{await_condition, conditions::is_pod_running},
+    Client, ResourceExt,
+};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    std::env::set_var("RUST_LOG", "info,kube=debug");
+    env_logger::init();
+    let client = Client::try_default().await?;
+    let namespace = std::env::var("NAMESPACE").unwrap_or_else(|_| "default".into());
+
+    let p: Pod = serde_json::from_value(serde_json::json!({
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": { "name": "example" },
+        "spec": {
+            "containers": [{
+                "name": "nginx",
+                "image": "nginx",
+            }],
+        }
+    }))?;
+
+    let pods: Api<Pod> = Api::namespaced(client, &namespace);
+    // Stop on error including a pod already exists or is still being deleted.
+    pods.create(&PostParams::default(), &p).await?;
+
+    // Wait until the pod is running, otherwise we get 500 error.
+    let running = await_condition(pods.clone(), "example", is_pod_running());
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(30), running).await?;
+
+    // Get `Portforwarder` that handles the WebSocket connection.
+    // There's no need to spawn a task to drive this, but it can be awaited to be notified on error.
+    let mut forwarder = pods.portforward("example", &[80]).await?;
+    let port = forwarder.ports()[0].stream().unwrap();
+
+    // let hyper drive the HTTP state in our DuplexStream via a task
+    let (sender, connection) = hyper::client::conn::handshake(port).await?;
+    tokio::spawn(async move {
+        if let Err(e) = connection.await {
+            log::error!("error in connection: {}", e);
+        }
+    });
+    // The following task is only used to show any error from the forwarder.
+    // This example can be stopped with Ctrl-C if anything happens.
+    tokio::spawn(async move {
+        if let Err(e) = forwarder.await {
+            log::error!("forwarder errored: {}", e);
+        }
+    });
+
+    // Shared `SendRequest<Body>` to relay the request.
+    let context = Arc::new(Mutex::new(sender));
+    let make_service = make_service_fn(move |_conn| {
+        let context = context.clone();
+        let service = service_fn(move |req| handle(context.clone(), req));
+        async move { Ok::<_, Infallible>(service) }
+    });
+
+    let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+    let addr = SocketAddr::from(([127, 0, 0, 1], 8080));
+    let server = Server::bind(&addr)
+        .serve(make_service)
+        .with_graceful_shutdown(async {
+            rx.await.ok();
+        });
+    println!("Forwarding http://{} to port 80 in the pod", addr);
+    println!("Try opening http://{0} in a browser, or `curl http://{0}`", addr);
+    println!("Use Ctrl-C to stop the server and delete the pod");
+    // Stop the server and delete the pod on Ctrl-C.
+    tokio::spawn(async move {
+        tokio::signal::ctrl_c().map(|_| ()).await;
+        log::info!("stopping the server");
+        let _ = tx.send(());
+    });
+    if let Err(e) = server.await {
+        log::error!("server error: {}", e);
+    }
+
+    log::info!("deleting the pod");
+    pods.delete("example", &DeleteParams::default())
+        .await?
+        .map_left(|pdel| {
+            assert_eq!(pdel.name(), "example");
+        });
+
+    Ok(())
+}
+
+// Simply forwards the request to the port through the shared `SendRequest<Body>`.
+async fn handle(
+    context: Arc<Mutex<hyper::client::conn::SendRequest<hyper::Body>>>,
+    req: Request<Body>,
+) -> Result<Response<Body>, Infallible> {
+    let mut sender = context.lock().await;
+    let response = sender.ready().await.unwrap().send_request(req).await.unwrap();
+    Ok(response)
+}

--- a/examples/pod_portforward_hyper_http.rs
+++ b/examples/pod_portforward_hyper_http.rs
@@ -39,9 +39,8 @@ async fn main() -> anyhow::Result<()> {
     let ports = pf.ports();
     let port = ports[0].stream().unwrap();
 
-    let (mut sender, connection) = client::conn::handshake(port).await?;
-
-    // spawn a task to poll the connection and drive the HTTP state
+    // let hyper drive the HTTP state in our DuplexStream via a task
+    let (mut sender, connection) = hyper::client::conn::handshake(port).await?;
     tokio::spawn(async move {
         if let Err(e) = connection.await {
             eprintln!("Error in connection: {}", e);

--- a/examples/pod_portforward_hyper_http.rs
+++ b/examples/pod_portforward_hyper_http.rs
@@ -36,7 +36,7 @@ async fn main() -> anyhow::Result<()> {
     let _ = tokio::time::timeout(std::time::Duration::from_secs(15), running).await?;
 
     let mut pf = pods.portforward("example", &[80]).await?;
-    let mut ports = pf.ports().unwrap();
+    let ports = pf.ports();
     let port = ports[0].stream().unwrap();
 
     let (mut sender, connection) = client::conn::handshake(port).await?;

--- a/examples/pod_portforward_hyper_http.rs
+++ b/examples/pod_portforward_hyper_http.rs
@@ -1,0 +1,91 @@
+#[macro_use] extern crate log;
+
+use futures::{StreamExt, TryStreamExt};
+use k8s_openapi::api::core::v1::Pod;
+
+use kube::{
+    api::{Api, DeleteParams, ListParams, PostParams, WatchEvent},
+    Client, ResourceExt,
+};
+
+use hyper::{body, client, Body, Request};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    std::env::set_var("RUST_LOG", "info,kube=debug");
+    env_logger::init();
+    let client = Client::try_default().await?;
+    let namespace = std::env::var("NAMESPACE").unwrap_or_else(|_| "default".into());
+
+    let p: Pod = serde_json::from_value(serde_json::json!({
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": { "name": "example" },
+        "spec": {
+            "containers": [{
+                "name": "nginx",
+                "image": "nginx",
+            }],
+        }
+    }))?;
+
+    let pods: Api<Pod> = Api::namespaced(client, &namespace);
+    // Stop on error including a pod already exists or is still being deleted.
+    pods.create(&PostParams::default(), &p).await?;
+
+    // Wait until the pod is running, otherwise we get 500 error.
+    let lp = ListParams::default().fields("metadata.name=example").timeout(10);
+    let mut stream = pods.watch(&lp, "0").await?.boxed();
+    while let Some(status) = stream.try_next().await? {
+        match status {
+            WatchEvent::Added(o) => {
+                info!("Added {}", o.name());
+            }
+            WatchEvent::Modified(o) => {
+                let s = o.status.as_ref().expect("status exists on pod");
+                if s.phase.clone().unwrap_or_default() == "Running" {
+                    break;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let mut pf = pods.portforward("example", &[80]).await?;
+    let mut ports = pf.ports().unwrap();
+    let port = ports[0].stream().unwrap();
+
+    let (mut sender, connection) = client::conn::handshake(port).await?;
+
+    // spawn a task to poll the connection and drive the HTTP state
+    tokio::spawn(async move {
+        if let Err(e) = connection.await {
+            eprintln!("Error in connection: {}", e);
+        }
+    });
+
+    let http_req = Request::builder()
+        .uri("/")
+        .header("Connection", "close")
+        .header("Host", "127.0.0.1")
+        .method("GET")
+        .body(Body::from(""))
+        .unwrap();
+
+    let (parts, body) = sender.send_request(http_req).await.unwrap().into_parts();
+    assert!(parts.status == 200);
+
+    let body_bytes = body::to_bytes(body).await.unwrap();
+    let body_str = std::str::from_utf8(&body_bytes).unwrap();
+    assert!(body_str.contains("Welcome to nginx!"));
+
+    // Delete it
+    println!("deleting");
+    pods.delete("example", &DeleteParams::default())
+        .await?
+        .map_left(|pdel| {
+            assert_eq!(pdel.name(), "example");
+        });
+
+    Ok(())
+}

--- a/examples/pod_portforward_hyper_http.rs
+++ b/examples/pod_portforward_hyper_http.rs
@@ -6,7 +6,7 @@ use kube::{
     Client, ResourceExt,
 };
 
-use hyper::{body, client, Body, Request};
+use hyper::{body, Body, Request};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {

--- a/kube-client/src/api/mod.rs
+++ b/kube-client/src/api/mod.rs
@@ -4,11 +4,13 @@
 mod core_methods;
 #[cfg(feature = "ws")] mod remote_command;
 #[cfg(feature = "ws")] pub use remote_command::AttachedProcess;
+#[cfg(feature = "ws")] mod portforward;
+#[cfg(feature = "ws")] pub use portforward::Portforwarder;
 
 mod subresource;
 #[cfg(feature = "ws")]
 #[cfg_attr(docsrs, doc(cfg(feature = "ws")))]
-pub use subresource::{Attach, AttachParams, Execute};
+pub use subresource::{Attach, AttachParams, Execute, Portforward};
 pub use subresource::{Evict, EvictParams, Log, LogParams, ScaleSpec, ScaleStatus};
 
 mod util;

--- a/kube-client/src/api/portforward.rs
+++ b/kube-client/src/api/portforward.rs
@@ -1,0 +1,225 @@
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::{Arc, Mutex},
+    task::{Context, Poll, Waker},
+};
+
+use futures::{
+    channel::{mpsc, oneshot},
+    FutureExt, SinkExt, StreamExt,
+};
+use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt, DuplexStream};
+use tokio_tungstenite::{tungstenite as ws, WebSocketStream};
+
+type ErrorReceiver = oneshot::Receiver<String>;
+type ErrorSender = oneshot::Sender<String>;
+
+enum Message {
+    FromPod(Vec<u8>),
+    ToPod(Vec<u8>),
+}
+
+struct PortforwarderState {
+    waker: Option<Waker>,
+    finished: bool,
+    ports: Option<Vec<Port>>,
+}
+
+// Provides `AsyncRead + AsyncWrite` for each port and **does not** bind to local ports.
+// Error channel for each port is only written by the server when there's an exception and
+// the port cannot be used (didn't initialize or can't be used anymore).
+/// Manage port forwarding.
+pub struct Portforwarder {
+    state: Arc<Mutex<PortforwarderState>>,
+}
+
+impl Portforwarder {
+    pub(crate) fn new<S>(stream: WebSocketStream<S>, port_nums: &[u16]) -> Self
+    where
+        S: AsyncRead + AsyncWrite + Unpin + Sized + Send + 'static,
+    {
+        let mut ports = Vec::new();
+        let mut errors = Vec::new();
+        let mut duplexes = Vec::new();
+        for _ in port_nums.iter() {
+            let (a, b) = tokio::io::duplex(1024 * 1024);
+            let (tx, rx) = oneshot::channel();
+            ports.push(Port::new(a, rx));
+            errors.push(Some(tx));
+            duplexes.push(b);
+        }
+
+        let state = Arc::new(Mutex::new(PortforwarderState {
+            waker: None,
+            finished: false,
+            ports: Some(ports),
+        }));
+        let shared_state = state.clone();
+        let port_nums = port_nums.to_owned();
+        tokio::spawn(async move {
+            start_message_loop(stream, &port_nums, duplexes, errors).await;
+
+            let mut shared = shared_state.lock().unwrap();
+            shared.finished = true;
+            if let Some(waker) = shared.waker.take() {
+                waker.wake()
+            }
+        });
+        Portforwarder { state }
+    }
+
+    /// Get streams for forwarded ports.
+    pub fn ports(&mut self) -> Option<Vec<Port>> {
+        let mut state = self.state.lock().unwrap();
+        state.ports.take()
+    }
+}
+
+impl Future for Portforwarder {
+    type Output = ();
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let mut state = self.state.lock().unwrap();
+        if state.finished {
+            return Poll::Ready(());
+        }
+
+        if let Some(waker) = &state.waker {
+            if waker.will_wake(cx.waker()) {
+                return Poll::Pending;
+            }
+        }
+
+        state.waker = Some(cx.waker().clone());
+        Poll::Pending
+    }
+}
+
+pub struct Port {
+    // Data pipe.
+    stream: Option<DuplexStream>,
+    // Error channel.
+    error: Option<ErrorReceiver>,
+}
+
+impl Port {
+    pub(crate) fn new(stream: DuplexStream, error: ErrorReceiver) -> Self {
+        Port {
+            stream: Some(stream),
+            error: Some(error),
+        }
+    }
+
+    /// Data pipe for sending to and receiving from the forwarded port.
+    pub fn stream(&mut self) -> Option<impl AsyncRead + AsyncWrite + Unpin> {
+        self.stream.take()
+    }
+
+    /// Future that resolves with any error message or when the error sender is dropped.
+    /// When this resolves, the port should be considered no longer usable.
+    pub fn error(&mut self) -> Option<impl Future<Output = Option<String>>> {
+        // Ignore Cancellation error.
+        self.error.take().map(|recv| recv.map(|res| res.ok()))
+    }
+}
+
+async fn start_message_loop<S>(
+    stream: WebSocketStream<S>,
+    ports: &[u16],
+    duplexes: Vec<DuplexStream>,
+    mut errors: Vec<Option<ErrorSender>>,
+) where
+    S: AsyncRead + AsyncWrite + Unpin + Sized + Send + 'static,
+{
+    let mut writers = Vec::new();
+    let (tx, mut rx) = mpsc::channel::<Message>(1);
+    for (i, (r, w)) in duplexes.into_iter().map(tokio::io::split).enumerate() {
+        writers.push(w);
+        {
+            // Each port uses 2 channels. Duplex data channel and error.
+            let ch = 2 * (i as u8);
+            let mut read_stream = tokio_util::io::ReaderStream::new(r);
+            let mut txr = tx.clone();
+            tokio::spawn(async move {
+                while let Some(res) = read_stream.next().await {
+                    match res {
+                        Ok(bytes) => {
+                            if !bytes.is_empty() {
+                                // Prefix the message with its channel byte.
+                                let mut vec = Vec::with_capacity(bytes.len() + 1);
+                                vec.push(ch);
+                                vec.extend_from_slice(&bytes[..]);
+                                // TODO Maybe use one shot to check for error and break
+                                txr.send(Message::ToPod(vec)).await.expect("send message")
+                            }
+                        }
+                        Err(err) => panic!("{}", err),
+                    }
+                }
+            });
+        }
+    }
+
+    let (mut server_send, mut server_recv) = stream.split();
+    {
+        let mut txs = tx.clone();
+        tokio::spawn(async move {
+            while let Some(res) = server_recv.next().await {
+                match res {
+                    Ok(ws::Message::Binary(bin)) if bin.len() > 1 => {
+                        txs.send(Message::FromPod(bin)).await.unwrap()
+                    }
+                    Ok(_) => {}
+                    Err(err) => panic!("{}", err),
+                }
+            }
+        });
+    }
+    // Drop the original so the stream terminates.
+    drop(tx);
+
+    // Keep track if the channel has received initialization frame.
+    let mut initialized = vec![false; 2 * ports.len()];
+    while let Some(msg) = rx.next().await {
+        match msg {
+            Message::FromPod(bin) => {
+                let ch = bin[0] as usize;
+                if ch >= initialized.len() {
+                    panic!("Unexpected channel {}", ch);
+                }
+
+                // Odd channels are for errors for (n - 1)/2 th port
+                let is_error = ch % 2 == 1;
+                let port_index = ch / 2;
+                if !initialized[ch] {
+                    if bin.len() != 3 {
+                        panic!("Unexpected initial channel frame size");
+                    }
+
+                    let port = u16::from_le_bytes([bin[1], bin[2]]);
+                    if port != ports[port_index] {
+                        panic!(
+                            "Unexpected port number in initial frame ({} != {})",
+                            port, ports[port_index]
+                        );
+                    }
+
+                    initialized[ch] = true;
+                } else if !is_error {
+                    writers[port_index].write_all(&bin[1..]).await.expect("writable");
+                } else if let Some(sender) = errors[port_index].take() {
+                    let s = String::from_utf8(bin[1..].to_vec()).expect("valid error message");
+                    sender.send(s).expect("send error");
+                }
+            }
+
+            Message::ToPod(bin) => {
+                server_send
+                    .send(ws::Message::binary(bin))
+                    .await
+                    .expect("send to pod");
+            }
+        }
+    }
+}

--- a/kube-client/src/api/portforward.rs
+++ b/kube-client/src/api/portforward.rs
@@ -5,24 +5,77 @@ use std::{
     task::{Context, Poll, Waker},
 };
 
+use bytes::{Buf, Bytes};
 use futures::{
     channel::{mpsc, oneshot},
-    FutureExt, SinkExt, StreamExt,
+    future, FutureExt, SinkExt, StreamExt,
 };
+use thiserror::Error;
 use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt, DuplexStream};
 use tokio_tungstenite::{tungstenite as ws, WebSocketStream};
+use tokio_util::io::ReaderStream;
+
+/// Errors from Portforwarder.
+#[derive(Debug, Error)]
+pub enum Error {
+    /// Received invalid channel in WebSocket message.
+    #[error("received invalid channel {0}")]
+    InvalidChannel(usize),
+
+    /// Received initial frame with invalid size. The initial frame must be 3 bytes, including the channel prefix.
+    #[error("received initial frame with invalid size")]
+    InvalidInitialFrameSize,
+
+    /// Received initial frame with invalid port mapping.
+    /// The port included in the initial frame did not match the port number associated with the channel.
+    #[error("invalid port mapping in initial frame, got {actual}, expected {expected}")]
+    InvalidPortMapping { actual: u16, expected: u16 },
+
+    /// Failed to forward bytes from Pod.
+    #[error("failed to forward bytes from Pod: {0}")]
+    ForwardFromPod(#[source] futures::channel::mpsc::SendError),
+
+    /// Failed to forward bytes to Pod.
+    #[error("failed to forward bytes to Pod: {0}")]
+    ForwardToPod(#[source] futures::channel::mpsc::SendError),
+
+    /// Failed to write bytes from Pod.
+    #[error("failed to write bytes from Pod: {0}")]
+    WriteBytesFromPod(#[source] std::io::Error),
+
+    /// Failed to read bytes to send to Pod.
+    #[error("failed to read bytes to send to Pod: {0}")]
+    ReadBytesToSend(#[source] std::io::Error),
+
+    /// Received an error message from pod that is not a valid UTF-8.
+    #[error("received invalid error message from Pod: {0}")]
+    InvalidErrorMessage(#[source] std::string::FromUtf8Error),
+
+    /// Failed to forward an error message from pod.
+    #[error("failed to forward an error message {0:?}")]
+    ForwardErrorMessage(String),
+
+    /// Failed to send a WebSocket message to the server.
+    #[error("failed to send a WebSocket message: {0}")]
+    SendWebSocketMessage(#[source] ws::Error),
+
+    /// Failed to receive a WebSocket message from the server.
+    #[error("failed to receive a WebSocket message: {0}")]
+    ReceiveWebSocketMessage(#[source] ws::Error),
+}
 
 type ErrorReceiver = oneshot::Receiver<String>;
 type ErrorSender = oneshot::Sender<String>;
 
+// Internal message used by the futures to communicate with each other.
 enum Message {
-    FromPod(Vec<u8>),
-    ToPod(Vec<u8>),
+    FromPod(u8, Bytes),
+    ToPod(u8, Bytes),
 }
 
 struct PortforwarderState {
     waker: Option<Waker>,
-    finished: bool,
+    result: Option<Result<(), Error>>,
 }
 
 // Provides `AsyncRead + AsyncWrite` for each port and **does not** bind to local ports.
@@ -52,15 +105,15 @@ impl Portforwarder {
 
         let state = Arc::new(Mutex::new(PortforwarderState {
             waker: None,
-            finished: false,
+            result: None,
         }));
         let shared_state = state.clone();
         let port_nums = port_nums.to_owned();
         tokio::spawn(async move {
-            start_message_loop(stream, &port_nums, duplexes, errors).await;
+            let result = start_message_loop(stream, port_nums, duplexes, errors).await;
 
             let mut shared = shared_state.lock().unwrap();
-            shared.finished = true;
+            shared.result = Some(result);
             if let Some(waker) = shared.waker.take() {
                 waker.wake()
             }
@@ -75,12 +128,12 @@ impl Portforwarder {
 }
 
 impl Future for Portforwarder {
-    type Output = ();
+    type Output = Result<(), Error>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let mut state = self.state.lock().unwrap();
-        if state.finished {
-            return Poll::Ready(());
+        if let Some(result) = state.result.take() {
+            return Poll::Ready(result);
         }
 
         if let Some(waker) = &state.waker {
@@ -117,9 +170,9 @@ impl Port {
     }
 
     /// Future that resolves with any error message or when the error sender is dropped.
+    /// When the future resolves, the port should be considered no longer usable.
     ///
     /// This returns a `Some` on the first call, then a `None` on every subsequent call
-    /// When the future resolves, the port should be considered no longer usable.
     pub fn error(&mut self) -> Option<impl Future<Output = Option<String>>> {
         // Ignore Cancellation error.
         self.error.take().map(|recv| recv.map(|res| res.ok()))
@@ -128,100 +181,155 @@ impl Port {
 
 async fn start_message_loop<S>(
     stream: WebSocketStream<S>,
-    ports: &[u16],
+    ports: Vec<u16>,
     duplexes: Vec<DuplexStream>,
-    mut errors: Vec<Option<ErrorSender>>,
-) where
+    error_senders: Vec<Option<ErrorSender>>,
+) -> Result<(), Error>
+where
     S: AsyncRead + AsyncWrite + Unpin + Sized + Send + 'static,
 {
     let mut writers = Vec::new();
-    let (tx, mut rx) = mpsc::channel::<Message>(1);
+    // Loops to run concurrently.
+    // We can spawn tasks to run `to_pod_loop` in parallel and flatten the errors, but the other 2 loops
+    // are over a single WebSocket connection and cannot process each port in parallel.
+    let mut loops = Vec::with_capacity(ports.len() + 2);
+    // Channel to communicate with the main loop
+    let (sender, receiver) = mpsc::channel::<Message>(1);
     for (i, (r, w)) in duplexes.into_iter().map(tokio::io::split).enumerate() {
         writers.push(w);
-        {
-            // Each port uses 2 channels. Duplex data channel and error.
-            let ch = 2 * (i as u8);
-            let mut read_stream = tokio_util::io::ReaderStream::new(r);
-            let mut txr = tx.clone();
-            tokio::spawn(async move {
-                while let Some(res) = read_stream.next().await {
-                    match res {
-                        Ok(bytes) => {
-                            if !bytes.is_empty() {
-                                // Prefix the message with its channel byte.
-                                let mut vec = Vec::with_capacity(bytes.len() + 1);
-                                vec.push(ch);
-                                vec.extend_from_slice(&bytes[..]);
-                                // TODO Maybe use one shot to check for error and break
-                                txr.send(Message::ToPod(vec)).await.expect("send message")
-                            }
-                        }
-                        Err(err) => panic!("{}", err),
-                    }
-                }
-            });
+        // Each port uses 2 channels. Duplex data channel and error.
+        let ch = 2 * (i as u8);
+        loops.push(to_pod_loop(ch, r, sender.clone()).boxed());
+    }
+
+    let (ws_sink, ws_stream) = stream.split();
+    loops.push(from_pod_loop(ws_stream, sender).boxed());
+    loops.push(forwarder_loop(&ports, receiver, ws_sink, writers, error_senders).boxed());
+
+    future::try_join_all(loops).await.map(|_| ())
+}
+
+async fn to_pod_loop(
+    ch: u8,
+    reader: tokio::io::ReadHalf<DuplexStream>,
+    mut sender: mpsc::Sender<Message>,
+) -> Result<(), Error> {
+    let mut read_stream = ReaderStream::new(reader);
+    while let Some(bytes) = read_stream
+        .next()
+        .await
+        .transpose()
+        .map_err(Error::ReadBytesToSend)?
+    {
+        if !bytes.is_empty() {
+            sender
+                .send(Message::ToPod(ch, bytes))
+                .await
+                .map_err(Error::ForwardToPod)?;
         }
     }
+    Ok(())
+}
 
-    let (mut server_send, mut server_recv) = stream.split();
+async fn from_pod_loop<S>(
+    mut ws_stream: futures::stream::SplitStream<WebSocketStream<S>>,
+    mut sender: mpsc::Sender<Message>,
+) -> Result<(), Error>
+where
+    S: AsyncRead + AsyncWrite + Unpin + Sized + Send + 'static,
+{
+    while let Some(msg) = ws_stream
+        .next()
+        .await
+        .transpose()
+        .map_err(Error::ReceiveWebSocketMessage)?
     {
-        let mut txs = tx.clone();
-        tokio::spawn(async move {
-            while let Some(res) = server_recv.next().await {
-                match res {
-                    Ok(ws::Message::Binary(bin)) if bin.len() > 1 => {
-                        txs.send(Message::FromPod(bin)).await.unwrap()
-                    }
-                    Ok(_) => {}
-                    Err(err) => panic!("{}", err),
-                }
-            }
-        });
-    }
-    // Drop the original so the stream terminates.
-    drop(tx);
-
-    // Keep track if the channel has received initialization frame.
-    let mut initialized = vec![false; 2 * ports.len()];
-    while let Some(msg) = rx.next().await {
         match msg {
-            Message::FromPod(bin) => {
-                let ch = bin[0] as usize;
+            ws::Message::Binary(bin) if bin.len() > 1 => {
+                let mut bytes = Bytes::from(bin);
+                let ch = bytes.split_to(1)[0];
+                sender
+                    .send(Message::FromPod(ch, bytes))
+                    .await
+                    .map_err(Error::ForwardFromPod)?;
+            }
+            // REVIEW should we error on unexpected websocket message?
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+// Start a loop to handle messages received from other futures.
+// On `Message::ToPod(ch, bytes)`, a WebSocket message is sent with the channel prefix.
+// On `Message::FromPod(ch, bytes)` with an even `ch`, `bytes` are written to the port's sink.
+// On `Message::FromPod(ch, bytes)` with an odd `ch`, an error message is sent to the error channel of the port.
+async fn forwarder_loop<S>(
+    ports: &[u16],
+    mut receiver: mpsc::Receiver<Message>,
+    mut ws_sink: futures::stream::SplitSink<WebSocketStream<S>, ws::Message>,
+    mut writers: Vec<tokio::io::WriteHalf<DuplexStream>>,
+    mut error_senders: Vec<Option<ErrorSender>>,
+) -> Result<(), Error>
+where
+    S: AsyncRead + AsyncWrite + Unpin + Sized + Send + 'static,
+{
+    // Keep track if the channel has received the initialization frame.
+    let mut initialized = vec![false; 2 * ports.len()];
+    while let Some(msg) = receiver.next().await {
+        match msg {
+            Message::FromPod(ch, mut bytes) => {
+                let ch = ch as usize;
                 if ch >= initialized.len() {
-                    panic!("Unexpected channel {}", ch);
+                    return Err(Error::InvalidChannel(ch));
                 }
 
-                // Odd channels are for errors for (n - 1)/2 th port
-                let is_error = ch % 2 == 1;
                 let port_index = ch / 2;
+                // Initialization
                 if !initialized[ch] {
-                    if bin.len() != 3 {
-                        panic!("Unexpected initial channel frame size");
+                    // The initial message must be 3 bytes including the channel prefix.
+                    if bytes.len() != 2 {
+                        return Err(Error::InvalidInitialFrameSize);
                     }
 
-                    let port = u16::from_le_bytes([bin[1], bin[2]]);
+                    let port = bytes.get_u16_le();
                     if port != ports[port_index] {
-                        panic!(
-                            "Unexpected port number in initial frame ({} != {})",
-                            port, ports[port_index]
-                        );
+                        return Err(Error::InvalidPortMapping {
+                            actual: port,
+                            expected: ports[port_index],
+                        });
                     }
 
                     initialized[ch] = true;
-                } else if !is_error {
-                    writers[port_index].write_all(&bin[1..]).await.expect("writable");
-                } else if let Some(sender) = errors[port_index].take() {
-                    let s = String::from_utf8(bin[1..].to_vec()).expect("valid error message");
-                    sender.send(s).expect("send error");
+                    continue;
+                }
+
+                // Odd channels are for errors for (n - 1)/2 th port
+                if ch % 2 != 0 {
+                    // A port sends at most one error message because it's considered unusable after this.
+                    if let Some(sender) = error_senders[port_index].take() {
+                        let s = String::from_utf8(bytes.into_iter().collect())
+                            .map_err(Error::InvalidErrorMessage)?;
+                        sender.send(s).map_err(Error::ForwardErrorMessage)?;
+                    }
+                } else {
+                    writers[port_index]
+                        .write_all(&bytes)
+                        .await
+                        .map_err(Error::WriteBytesFromPod)?;
                 }
             }
 
-            Message::ToPod(bin) => {
-                server_send
+            Message::ToPod(ch, bytes) => {
+                let mut bin = Vec::with_capacity(bytes.len() + 1);
+                bin.push(ch);
+                bin.extend(bytes.into_iter());
+                ws_sink
                     .send(ws::Message::binary(bin))
                     .await
-                    .expect("send to pod");
+                    .map_err(Error::SendWebSocketMessage)?;
             }
         }
     }
+    Ok(())
 }

--- a/kube-client/src/api/portforward.rs
+++ b/kube-client/src/api/portforward.rs
@@ -110,12 +110,16 @@ impl Port {
     }
 
     /// Data pipe for sending to and receiving from the forwarded port.
+    ///
+    /// This returns a `Some` on the first call, then a `None` on every subsequent call
     pub fn stream(&mut self) -> Option<impl AsyncRead + AsyncWrite + Unpin> {
         self.stream.take()
     }
 
     /// Future that resolves with any error message or when the error sender is dropped.
-    /// When this resolves, the port should be considered no longer usable.
+    ///
+    /// This returns a `Some` on the first call, then a `None` on every subsequent call
+    /// When the future resolves, the port should be considered no longer usable.
     pub fn error(&mut self) -> Option<impl Future<Output = Option<String>>> {
         // Ignore Cancellation error.
         self.error.take().map(|recv| recv.map(|res| res.ok()))

--- a/kube-client/src/api/portforward.rs
+++ b/kube-client/src/api/portforward.rs
@@ -23,7 +23,6 @@ enum Message {
 struct PortforwarderState {
     waker: Option<Waker>,
     finished: bool,
-    ports: Option<Vec<Port>>,
 }
 
 // Provides `AsyncRead + AsyncWrite` for each port and **does not** bind to local ports.
@@ -31,6 +30,7 @@ struct PortforwarderState {
 // the port cannot be used (didn't initialize or can't be used anymore).
 /// Manage port forwarding.
 pub struct Portforwarder {
+    ports: Vec<Port>,
     state: Arc<Mutex<PortforwarderState>>,
 }
 
@@ -53,7 +53,6 @@ impl Portforwarder {
         let state = Arc::new(Mutex::new(PortforwarderState {
             waker: None,
             finished: false,
-            ports: Some(ports),
         }));
         let shared_state = state.clone();
         let port_nums = port_nums.to_owned();
@@ -66,13 +65,12 @@ impl Portforwarder {
                 waker.wake()
             }
         });
-        Portforwarder { state }
+        Portforwarder { ports, state }
     }
 
     /// Get streams for forwarded ports.
-    pub fn ports(&mut self) -> Option<Vec<Port>> {
-        let mut state = self.state.lock().unwrap();
-        state.ports.take()
+    pub fn ports(&mut self) -> &mut [Port] {
+        self.ports.as_mut_slice()
     }
 }
 

--- a/kube-core/src/subresource.rs
+++ b/kube-core/src/subresource.rs
@@ -371,3 +371,45 @@ mod test {
         assert_eq!(req.uri(), "/api/v1/namespaces/ns/pods/mypod/log?&container=nginx&follow=true&limitBytes=10485760&pretty=true&previous=true&sinceSeconds=3600&tailLines=4096&timestamps=true");
     }
 }
+
+// ----------------------------------------------------------------------------
+// Portforward subresource
+// ----------------------------------------------------------------------------
+#[cfg(feature = "ws")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ws")))]
+impl Request {
+    /// Request to forward ports of a pod
+    pub fn portforward(&self, name: &str, ports: &[u16]) -> Result<http::Request<Vec<u8>>, Error> {
+        if ports.is_empty() {
+            return Err(Error::Validation("ports cannot be empty".into()));
+        }
+        if ports.len() > 128 {
+            return Err(Error::Validation(
+                "the number of ports cannot be more than 128".into(),
+            ));
+        }
+
+        if ports.len() > 1 {
+            let mut seen = std::collections::HashSet::with_capacity(ports.len());
+            for port in ports.iter() {
+                if seen.contains(port) {
+                    return Err(Error::Validation(format!(
+                        "ports must be unique, found multiple {}",
+                        port
+                    )));
+                }
+                seen.insert(port);
+            }
+        }
+
+        let base_url = format!("{}/{}/portforward?", self.url_path, name);
+        let mut qp = form_urlencoded::Serializer::new(base_url);
+        qp.append_pair(
+            "ports",
+            &ports.iter().map(|p| p.to_string()).collect::<Vec<_>>().join(","),
+        );
+
+        let req = http::Request::get(qp.finish());
+        req.body(vec![]).map_err(Error::BuildRequest)
+    }
+}


### PR DESCRIPTION
Super rough sketch I mentioned almost 2 months ago. https://github.com/clux/kube-rs/issues/127#issuecomment-754399865

I don't like this at all, but an example with Nginx (from [Python client example](https://github.com/kubernetes-client/python/blob/2febc697157fa57bb9a5bd5ab2f7b9fa4d13c151/examples/pod_portforward.py#L97-L117)) works and can be a starting point for discussion. Any feedback/ideas are appreciated, but I honestly don't remember much, so I might not be able to answer "why?".

#### Protocol

WebSocket messages are binary (`[channel, ...data]`) like `/attach` and `/exec`.

For `/portforward`, channels are associated with the specified ports and each port uses 2 channels: a duplex data channel (`2*i`) and a read-only error channel (`2*i + 1`) for `i`th port.

The first message for a channel is always 3 bytes and describes this association:

1. channel (u8)
2. port number (u16 LE)

#### Idea

EDIT: Maybe this can be done on top of the lower level API provided by kube in this PR. I won't be trying this for now.

Make `Portforwarder` [`tower::MakeService`](https://docs.rs/tower/0.4.6/tower/trait.MakeService.html) (`Service` of `Service`)? I haven't tried, but it might be possible, and it'll make it a lot more usable.

```rust
let portforwarder = pods.portforward("example", &[80]).await?;
// takes port and returns Service<Request<Body>>
let mut forwarder = portforwarder.into_service();
let mut svc = forwarder.call(port).await?;
let response = svc.call(request).await?;
```

---

- [x] Error handling
- [x] Add example similar to `kubectl port-forward example local_port:remote_port`.