### PR TITLE
cncf code of conduct

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,0 +1,3 @@
+# Community Code of Conduct
+
+kube-rs follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).


### PR DESCRIPTION
taken from helm. hotlinks to [cncf coc](https://github.com/cncf/foundation/blob/master/code-of-conduct.md). seems best practice to just link here, and use lowercase naming (both helm and kubernetes/client-go does this)