### PR TITLE
Project Neokubism

### DIFF
--- a/kube-core/src/object.rs
+++ b/kube-core/src/object.rs
@@ -16,11 +16,8 @@ use std::borrow::Cow;
 /// and is generally produced from list/watch/delete collection queries on an [`Resource`](super::Resource).
 ///
 /// This is almost equivalent to [`k8s_openapi::List<T>`](k8s_openapi::List), but iterable.
-#[derive(Deserialize, Debug)]
-pub struct ObjectList<T>
-where
-    T: Clone,
-{
+#[derive(Clone, Deserialize, Debug)]
+pub struct ObjectList<T> {
     // NB: kind and apiVersion can be set here, but no need for it atm
     /// ListMeta - only really used for its `resourceVersion`
     ///
@@ -32,7 +29,7 @@ where
     pub items: Vec<T>,
 }
 
-impl<T: Clone> ObjectList<T> {
+impl<T> ObjectList<T> {
     /// `iter` returns an Iterator over the elements of this ObjectList
     ///
     /// # Example
@@ -75,7 +72,7 @@ impl<T: Clone> ObjectList<T> {
     }
 }
 
-impl<T: Clone> IntoIterator for ObjectList<T> {
+impl<T> IntoIterator for ObjectList<T> {
     type IntoIter = ::std::vec::IntoIter<Self::Item>;
     type Item = T;
 
@@ -84,7 +81,7 @@ impl<T: Clone> IntoIterator for ObjectList<T> {
     }
 }
 
-impl<'a, T: Clone> IntoIterator for &'a ObjectList<T> {
+impl<'a, T> IntoIterator for &'a ObjectList<T> {
     type IntoIter = ::std::slice::Iter<'a, T>;
     type Item = &'a T;
 
@@ -93,7 +90,7 @@ impl<'a, T: Clone> IntoIterator for &'a ObjectList<T> {
     }
 }
 
-impl<'a, T: Clone> IntoIterator for &'a mut ObjectList<T> {
+impl<'a, T> IntoIterator for &'a mut ObjectList<T> {
     type IntoIter = ::std::slice::IterMut<'a, T>;
     type Item = &'a mut T;
 

--- a/kube-core/src/resource.rs
+++ b/kube-core/src/resource.rs
@@ -22,7 +22,7 @@ pub trait Resource {
     /// as type of this information.
     ///
     /// See [`DynamicObject`](crate::dynamic::DynamicObject) for a valid implementation of non-k8s-openapi resources.
-    type DynamicType: Send + Sync + 'static;
+    type DynamicType: Clone + Send + Sync + 'static;
 
     /// Returns kind of this object
     fn kind(dt: &Self::DynamicType) -> Cow<'_, str>;

--- a/kube/Cargo.toml
+++ b/kube/Cargo.toml
@@ -71,6 +71,7 @@ tame-oauth = { version = "0.4.7", features = ["gcp"], optional = true }
 pin-project = { version = "1.0.4", optional = true }
 rand = { version = "0.8.3", optional = true }
 tracing = { version = "0.1.25", features = ["log"], optional = true }
+snafu = "0.6.10"
 
 [dependencies.k8s-openapi]
 version = "0.12.0"

--- a/kube/src/api/mod.rs
+++ b/kube/src/api/mod.rs
@@ -8,8 +8,8 @@ mod core_methods;
 mod subresource;
 #[cfg(feature = "ws")]
 #[cfg_attr(docsrs, doc(cfg(feature = "ws")))]
-pub use subresource::{AttachParams, Attach, Execute};
-pub use subresource::{EvictParams, Evict, LogParams, Log, ScaleSpec, ScaleStatus};
+pub use subresource::{Attach, AttachParams, Execute};
+pub use subresource::{Evict, EvictParams, Log, LogParams, ScaleSpec, ScaleStatus};
 
 // Re-exports from kube-core
 #[cfg(feature = "admission")]
@@ -29,7 +29,10 @@ pub use params::{
     DeleteParams, ListParams, Patch, PatchParams, PostParams, Preconditions, PropagationPolicy,
 };
 
-use crate::Client;
+use crate::{
+    client::scope::{ClusterScope, DynamicScope, NamespaceScope},
+    Client,
+};
 /// The generic Api abstraction
 ///
 /// This abstracts over a [`Request`] and a type `K` so that
@@ -37,9 +40,11 @@ use crate::Client;
 /// implemented by the dynamic [`Resource`].
 #[cfg_attr(docsrs, doc(cfg(feature = "client")))]
 #[derive(Clone)]
-pub struct Api<K> {
+pub struct Api<K: Resource> {
     /// The request builder object with its resource dependent url
     pub(crate) request: Request,
+    pub(crate) scope: DynamicScope,
+    pub(crate) dyn_type: K::DynamicType,
     /// The client to use (from this library)
     pub(crate) client: Client,
     /// Note: Using `iter::Empty` over `PhantomData`, because we never actually keep any
@@ -55,10 +60,12 @@ impl<K: Resource> Api<K> {
     /// Cluster level resources, or resources viewed across all namespaces
     ///
     /// This function accepts `K::DynamicType` so it can be used with dynamic resources.
-    pub fn all_with(client: Client, dyntype: &K::DynamicType) -> Self {
-        let url = K::url_path(dyntype, None);
+    pub fn all_with(client: Client, dyn_type: &K::DynamicType) -> Self {
+        let url = K::url_path(dyn_type, None);
         Self {
             client,
+            scope: DynamicScope::Cluster(ClusterScope),
+            dyn_type: dyn_type.clone(),
             request: Request::new(url),
             phantom: std::iter::empty(),
         }
@@ -67,10 +74,14 @@ impl<K: Resource> Api<K> {
     /// Namespaced resource within a given namespace
     ///
     /// This function accepts `K::DynamicType` so it can be used with dynamic resources.
-    pub fn namespaced_with(client: Client, ns: &str, dyntype: &K::DynamicType) -> Self {
-        let url = K::url_path(dyntype, Some(ns));
+    pub fn namespaced_with(client: Client, ns: &str, dyn_type: &K::DynamicType) -> Self {
+        let url = K::url_path(dyn_type, Some(ns));
         Self {
             client,
+            scope: DynamicScope::Namespace(NamespaceScope {
+                namespace: ns.to_string(),
+            }),
+            dyn_type: dyn_type.clone(),
             request: Request::new(url),
             phantom: std::iter::empty(),
         }
@@ -82,13 +93,9 @@ impl<K: Resource> Api<K> {
     ///
     /// Unless configured explicitly, the default namespace is either "default"
     /// out of cluster, or the service account's namespace in cluster.
-    pub fn default_namespaced_with(client: Client, dyntype: &K::DynamicType) -> Self {
-        let url = K::url_path(dyntype, Some(client.default_ns()));
-        Self {
-            client,
-            request: Request::new(url),
-            phantom: std::iter::empty(),
-        }
+    pub fn default_namespaced_with(client: Client, dyn_type: &K::DynamicType) -> Self {
+        let ns = client.default_ns().to_string();
+        Self::namespaced_with(client, &ns, dyn_type)
     }
 
     /// Consume self and return the [`Client`]
@@ -112,22 +119,12 @@ where
 {
     /// Cluster level resources, or resources viewed across all namespaces
     pub fn all(client: Client) -> Self {
-        let url = K::url_path(&Default::default(), None);
-        Self {
-            client,
-            request: Request::new(url),
-            phantom: std::iter::empty(),
-        }
+        Self::all_with(client, &K::DynamicType::default())
     }
 
     /// Namespaced resource within a given namespace
     pub fn namespaced(client: Client, ns: &str) -> Self {
-        let url = K::url_path(&Default::default(), Some(ns));
-        Self {
-            client,
-            request: Request::new(url),
-            phantom: std::iter::empty(),
-        }
+        Self::namespaced_with(client, ns, &K::DynamicType::default())
     }
 
     /// Namespaced resource within the default namespace
@@ -135,16 +132,11 @@ where
     /// Unless configured explicitly, the default namespace is either "default"
     /// out of cluster, or the service account's namespace in cluster.
     pub fn default_namespaced(client: Client) -> Self {
-        let url = K::url_path(&Default::default(), Some(client.default_ns()));
-        Self {
-            client,
-            request: Request::new(url),
-            phantom: std::iter::empty(),
-        }
+        Self::default_namespaced_with(client, &K::DynamicType::default())
     }
 }
 
-impl<K> From<Api<K>> for Client {
+impl<K: Resource> From<Api<K>> for Client {
     fn from(api: Api<K>) -> Self {
         api.client
     }

--- a/kube/src/api/subresource.rs
+++ b/kube/src/api/subresource.rs
@@ -8,8 +8,8 @@ use crate::{
     Result,
 };
 
-use kube_core::response::Status;
 pub use kube_core::subresource::{EvictParams, LogParams};
+use kube_core::{response::Status, Resource};
 
 #[cfg(feature = "ws")]
 #[cfg_attr(docsrs, doc(cfg(feature = "ws")))]
@@ -22,7 +22,7 @@ pub use k8s_openapi::api::autoscaling::v1::{Scale, ScaleSpec, ScaleStatus};
 /// Methods for [scale subresource](https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#scale-subresource).
 impl<K> Api<K>
 where
-    K: Clone + DeserializeOwned,
+    K: Clone + DeserializeOwned + Resource,
 {
     /// Fetch the scale subresource
     pub async fn get_scale(&self, name: &str) -> Result<Scale> {
@@ -58,7 +58,7 @@ where
 /// Methods for [status subresource](https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#status-subresource).
 impl<K> Api<K>
 where
-    K: DeserializeOwned,
+    K: DeserializeOwned + Resource,
 {
     /// Get the named resource with a status subresource
     ///
@@ -153,7 +153,7 @@ impl Log for k8s_openapi::api::core::v1::Pod {}
 
 impl<K> Api<K>
 where
-    K: DeserializeOwned + Log,
+    K: DeserializeOwned + Log + Resource,
 {
     /// Fetch logs as a string
     pub async fn logs(&self, name: &str, lp: &LogParams) -> Result<String> {
@@ -191,7 +191,7 @@ impl Evict for k8s_openapi::api::core::v1::Pod {}
 
 impl<K> Api<K>
 where
-    K: DeserializeOwned + Evict,
+    K: DeserializeOwned + Evict + Resource,
 {
     /// Create an eviction
     pub async fn evict(&self, name: &str, ep: &EvictParams) -> Result<Status> {
@@ -235,7 +235,7 @@ impl Attach for k8s_openapi::api::core::v1::Pod {}
 #[cfg_attr(docsrs, doc(cfg(feature = "ws")))]
 impl<K> Api<K>
 where
-    K: Clone + DeserializeOwned + Attach,
+    K: Clone + DeserializeOwned + Attach + Resource,
 {
     /// Attach to pod
     pub async fn attach(&self, name: &str, ap: &AttachParams) -> Result<AttachedProcess> {
@@ -281,7 +281,7 @@ impl Execute for k8s_openapi::api::core::v1::Pod {}
 #[cfg_attr(docsrs, doc(cfg(feature = "ws")))]
 impl<K> Api<K>
 where
-    K: Clone + DeserializeOwned + Execute,
+    K: Clone + DeserializeOwned + Execute + Resource,
 {
     /// Execute a command in a pod
     pub async fn exec<I: Debug, T>(

--- a/kube/src/client/decoder/mod.rs
+++ b/kube/src/client/decoder/mod.rs
@@ -1,3 +1,7 @@
+//! Decode the result of a [`Verb`]
+//!
+//! You typically don't need to interact with this directly, unless you are implementing a custom [`Verb`]
+
 pub mod single;
 pub mod stream;
 

--- a/kube/src/client/decoder/mod.rs
+++ b/kube/src/client/decoder/mod.rs
@@ -1,0 +1,5 @@
+pub mod single;
+pub mod stream;
+
+pub use single::DecodeSingle;
+pub use stream::DecodeStream;

--- a/kube/src/client/decoder/single.rs
+++ b/kube/src/client/decoder/single.rs
@@ -1,0 +1,85 @@
+use bytes::{Buf, Bytes};
+use futures::{ready, Future, StreamExt};
+use http::Response;
+use hyper::Body;
+use serde::de::DeserializeOwned;
+use snafu::{ResultExt, Snafu};
+use std::{io::Read, marker::PhantomData, task::Poll};
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("read failed: {}", source))]
+    ReadFailed { source: hyper::Error },
+    #[snafu(display("deserialize failed: {}", source))]
+    DeserializeFailed { source: serde_json::Error },
+}
+
+pub struct DecodeSingle<K> {
+    tpe: PhantomData<*const K>,
+    chunks: Vec<Bytes>,
+    body: Body,
+}
+
+impl<K> From<Response<Body>> for DecodeSingle<K> {
+    fn from(res: Response<Body>) -> Self {
+        Self {
+            tpe: PhantomData,
+            chunks: Vec::new(),
+            body: res.into_body(),
+        }
+    }
+}
+
+impl<K: DeserializeOwned> Future for DecodeSingle<K> {
+    type Output = Result<K, Error>;
+
+    fn poll(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Self::Output> {
+        loop {
+            break match ready!(self.body.poll_next_unpin(cx)) {
+                Some(Ok(chunk)) => {
+                    self.chunks.push(chunk);
+                    continue;
+                }
+                Some(Err(err)) => Poll::Ready(Err(err).context(ReadFailed)),
+                None => Poll::Ready(
+                    serde_json::from_reader(BytesVecCursor::from(std::mem::take(&mut self.chunks)))
+                        .context(DeserializeFailed),
+                ),
+            };
+        }
+    }
+}
+
+struct BytesVecCursor {
+    cur_chunk: bytes::buf::Reader<Bytes>,
+    chunks: std::vec::IntoIter<Bytes>,
+}
+
+impl Read for BytesVecCursor {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        loop {
+            break Ok(match self.cur_chunk.read(buf)? {
+                0 => match self.chunks.next() {
+                    Some(chunk) => {
+                        self.cur_chunk = chunk.reader();
+                        continue;
+                    }
+                    None => 0,
+                },
+                n => n,
+            });
+        }
+    }
+}
+
+impl From<Vec<Bytes>> for BytesVecCursor {
+    fn from(vec: Vec<Bytes>) -> Self {
+        BytesVecCursor {
+            cur_chunk: Bytes::new().reader(),
+            chunks: vec.into_iter(),
+        }
+    }
+}

--- a/kube/src/client/decoder/stream.rs
+++ b/kube/src/client/decoder/stream.rs
@@ -1,0 +1,82 @@
+use bytes::Bytes;
+use futures::{ready, stream::MapErr, Future, Stream, StreamExt, TryStreamExt};
+use http::Response;
+use hyper::Body;
+use serde::de::DeserializeOwned;
+use snafu::{ResultExt, Snafu};
+use std::{convert::Infallible, marker::PhantomData, task::Poll};
+use tokio_util::{
+    codec::{FramedRead, LinesCodec, LinesCodecError},
+    io::StreamReader,
+};
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("read failed: {}", source))]
+    ReadFailed { source: LinesCodecError },
+    #[snafu(display("deserialize failed: {}", source))]
+    DeserializeFailed { source: serde_json::Error },
+}
+
+pub struct DecodeStream<K> {
+    tpe: PhantomData<*const K>,
+    body: Option<Body>,
+}
+
+impl<K> Future for DecodeStream<K> {
+    type Output = Result<DecodeStreamStream<K>, Infallible>;
+
+    fn poll(
+        mut self: std::pin::Pin<&mut Self>,
+        _cx: &mut std::task::Context<'_>,
+    ) -> Poll<Self::Output> {
+        Poll::Ready(Ok(DecodeStreamStream {
+            tpe: self.tpe,
+            body: FramedRead::new(
+                StreamReader::new(
+                    self.body
+                        .take()
+                        .expect("DecodeStream may not be polled again after resolving")
+                        .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err)),
+                ),
+                LinesCodec::new(),
+            ),
+        }))
+    }
+}
+
+impl<K> From<Response<Body>> for DecodeStream<K> {
+    fn from(res: Response<Body>) -> Self {
+        Self {
+            tpe: PhantomData,
+            body: Some(res.into_body()),
+        }
+    }
+}
+
+pub struct DecodeStreamStream<K> {
+    tpe: PhantomData<*const K>,
+    #[allow(clippy::type_complexity)]
+    body: FramedRead<
+        StreamReader<MapErr<Body, fn(hyper::Error) -> std::io::Error>, Bytes>,
+        LinesCodec,
+    >,
+}
+
+impl<K: DeserializeOwned> Stream for DecodeStreamStream<K> {
+    type Item = Result<K, Error>;
+
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        match ready!(self.body.poll_next_unpin(cx)) {
+            Some(frame) => Poll::Ready(Some(read_frame(frame))),
+            None => Poll::Ready(None),
+        }
+    }
+}
+
+fn read_frame<K: DeserializeOwned>(frame: Result<String, LinesCodecError>) -> Result<K, Error> {
+    serde_json::from_str(&frame.context(ReadFailed)?).context(DeserializeFailed)
+}

--- a/kube/src/client/scope.rs
+++ b/kube/src/client/scope.rs
@@ -1,0 +1,38 @@
+use k8s_openapi::{ClusterResourceScope, NamespaceResourceScope};
+
+pub trait Scope {
+    fn path_segment(&self) -> String;
+    fn namespace(&self) -> Option<&str>;
+}
+
+pub struct ClusterScope;
+pub struct NamespaceScope {
+    pub namespace: String,
+}
+
+impl Scope for ClusterScope {
+    fn path_segment(&self) -> String {
+        String::new()
+    }
+
+    fn namespace(&self) -> Option<&str> {
+        None
+    }
+}
+impl Scope for NamespaceScope {
+    fn path_segment(&self) -> String {
+        format!("namespaces/{}/", self.namespace)
+    }
+
+    fn namespace(&self) -> Option<&str> {
+        Some(&self.namespace)
+    }
+}
+
+pub trait NativeScope<Kind>: Scope {}
+impl<Kind: k8s_openapi::Resource<Scope = NamespaceResourceScope>> NativeScope<Kind> for NamespaceScope {}
+impl<Kind: k8s_openapi::Resource<Scope = ClusterResourceScope>> NativeScope<Kind> for ClusterScope {}
+
+pub trait ListScope<Kind>: Scope {}
+impl<Kind: k8s_openapi::Resource<Scope = NamespaceResourceScope>> ListScope<Kind> for NamespaceScope {}
+impl<Kind: k8s_openapi::Resource> ListScope<Kind> for ClusterScope {}

--- a/kube/src/client/scope.rs
+++ b/kube/src/client/scope.rs
@@ -1,38 +1,65 @@
+//! Scopes delimiting which objects an API call applies to
+
 use k8s_openapi::{ClusterResourceScope, NamespaceResourceScope};
 
+/// A scope for interacting with Kubernetes objects
 pub trait Scope {
-    fn path_segment(&self) -> String;
+    /// The namespace associated with the [`Scope`], if any
     fn namespace(&self) -> Option<&str>;
 }
 
+/// Access all objects in the cluster (that the user has permission to access)
+#[derive(Clone, Debug)]
 pub struct ClusterScope;
+/// Access all objects in one namespace (that the user has permission to access)
+#[derive(Clone, Debug)]
 pub struct NamespaceScope {
+    /// Namespace that access is limited to
     pub namespace: String,
+}
+/// A [`Scope`] that is resolved at runtime
+///
+/// NOTE: By using [`DynamicScope`] you opt out of Kube's ability to validate that the scope is valid for a given operation
+#[derive(Clone, Debug)]
+pub enum DynamicScope {
+    /// Access all objects in the cluster (that the user has permission to access)
+    Cluster(ClusterScope),
+    /// Access all objects in one namespace (that the user has permission to access)
+    Namespace(NamespaceScope),
 }
 
 impl Scope for ClusterScope {
-    fn path_segment(&self) -> String {
-        String::new()
-    }
-
     fn namespace(&self) -> Option<&str> {
         None
     }
 }
 impl Scope for NamespaceScope {
-    fn path_segment(&self) -> String {
-        format!("namespaces/{}/", self.namespace)
-    }
-
     fn namespace(&self) -> Option<&str> {
         Some(&self.namespace)
     }
 }
+impl Scope for DynamicScope {
+    fn namespace(&self) -> Option<&str> {
+        self.inner().namespace()
+    }
+}
+impl DynamicScope {
+    fn inner(&self) -> &dyn Scope {
+        match self {
+            DynamicScope::Cluster(scope) => scope,
+            DynamicScope::Namespace(scope) => scope,
+        }
+    }
+}
 
+/// Scope where a [`Resource`]'s objects can be read from or written to
 pub trait NativeScope<Kind>: Scope {}
 impl<Kind: k8s_openapi::Resource<Scope = NamespaceResourceScope>> NativeScope<Kind> for NamespaceScope {}
 impl<Kind: k8s_openapi::Resource<Scope = ClusterResourceScope>> NativeScope<Kind> for ClusterScope {}
+impl<Kind> NativeScope<Kind> for DynamicScope {}
 
+/// Scope where a [`Resource`]'s objects can be listed from
 pub trait ListScope<Kind>: Scope {}
 impl<Kind: k8s_openapi::Resource<Scope = NamespaceResourceScope>> ListScope<Kind> for NamespaceScope {}
 impl<Kind: k8s_openapi::Resource> ListScope<Kind> for ClusterScope {}
+impl<Kind> ListScope<Kind> for DynamicScope {}

--- a/kube/src/client/verb.rs
+++ b/kube/src/client/verb.rs
@@ -1,37 +1,55 @@
-use std::ops::Deref;
+//! Operations supported by kube
 
 use futures::TryFuture;
 use http::{Request, Response};
 use hyper::Body;
-use kube_core::{Resource, WatchEvent};
-use serde::{de::DeserializeOwned, Deserialize};
-use snafu::{ResultExt, Snafu};
+use kube_core::{object::ObjectList, Resource, WatchEvent};
+use serde::{de::DeserializeOwned, Serialize};
+use snafu::{OptionExt, ResultExt, Snafu};
 
 use crate::client::{
     decoder::{DecodeSingle, DecodeStream},
     scope::{self, NativeScope},
-    Config,
 };
 
 #[derive(Snafu, Debug)]
+#[allow(missing_docs)]
+/// Failed to create a [`Request`] for a given [`Verb`]
 pub enum Error {
+    /// Verb tried to create invalid HTTP request
     #[snafu(display("verb created invalid http request: {}", source))]
     BuildRequestFailed { source: http::Error },
+    /// Failed to serialize object
+    #[snafu(display("failed to serialize object: {}", source))]
+    SerializeFailed { source: serde_json::Error },
+    // Object has no name
+    #[snafu(display("object has no name"))]
+    UnnamedObject,
 }
 type Result<T, E = Error> = std::result::Result<T, E>;
 
+/// An action that Kube can take
 pub trait Verb {
+    /// Decodes the response given from the server
+    /// Will typically be [`DecodeSingle`]
     type ResponseDecoder: TryFuture + From<Response<Body>>;
 
+    /// Prepare a HTTP request that takes the action
+    ///
+    /// Should include request-specific options, but not global options (such as the base URI or authentication tokens)
     fn to_http_request(&self) -> Result<Request<Body>>;
 }
 
-pub struct Get<Kind: Resource, Scope> {
-    pub name: String,
-    pub scope: Scope,
-    pub dyn_type: Kind::DynamicType,
+/// Get a single object
+pub struct Get<'a, Kind: Resource, Scope> {
+    /// The name of the object
+    pub name: &'a str,
+    /// The scope that the object will be queried from
+    pub scope: &'a Scope,
+    /// The type of the object
+    pub dyn_type: &'a Kind::DynamicType,
 }
-impl<Kind: Resource + DeserializeOwned, Scope: NativeScope<Kind>> Verb for Get<Kind, Scope> {
+impl<'a, Kind: Resource + DeserializeOwned, Scope: NativeScope<Kind>> Verb for Get<'a, Kind, Scope> {
     type ResponseDecoder = DecodeSingle<Kind>;
 
     fn to_http_request(&self) -> Result<Request<Body>> {
@@ -45,11 +63,14 @@ impl<Kind: Resource + DeserializeOwned, Scope: NativeScope<Kind>> Verb for Get<K
     }
 }
 
-pub struct List<Kind: Resource, Scope> {
-    pub scope: Scope,
-    pub dyn_type: Kind::DynamicType,
+/// List all objects of a resource type
+pub struct List<'a, Kind: Resource, Scope> {
+    /// The scope that the objects will be queried from
+    pub scope: &'a Scope,
+    /// The type of the objects
+    pub dyn_type: &'a Kind::DynamicType,
 }
-impl<Kind: Resource + DeserializeOwned, Scope: scope::Scope> Verb for List<Kind, Scope> {
+impl<'a, Kind: Resource + DeserializeOwned, Scope: scope::Scope> Verb for List<'a, Kind, Scope> {
     type ResponseDecoder = DecodeSingle<ObjectList<Kind>>;
 
     fn to_http_request(&self) -> Result<Request<Body>> {
@@ -58,16 +79,15 @@ impl<Kind: Resource + DeserializeOwned, Scope: scope::Scope> Verb for List<Kind,
             .context(BuildRequestFailed)
     }
 }
-#[derive(Deserialize)]
-pub struct ObjectList<Kind> {
-    pub items: Vec<Kind>,
-}
 
-pub struct Watch<Kind: Resource, Scope> {
-    pub scope: Scope,
-    pub dyn_type: Kind::DynamicType,
+/// Watch all objects of a resource type for modifications
+pub struct Watch<'a, Kind: Resource, Scope> {
+    /// The scope that the objects will be queried from
+    pub scope: &'a Scope,
+    /// The type of the objects
+    pub dyn_type: &'a Kind::DynamicType,
 }
-impl<Kind: Resource, Scope: scope::Scope> Verb for Watch<Kind, Scope> {
+impl<'a, Kind: Resource, Scope: scope::Scope> Verb for Watch<'a, Kind, Scope> {
     type ResponseDecoder = DecodeStream<WatchEvent<Kind>>;
 
     fn to_http_request(&self) -> Result<Request<Body>> {
@@ -77,5 +97,85 @@ impl<Kind: Resource, Scope: scope::Scope> Verb for Watch<Kind, Scope> {
         ))
         .body(Body::empty())
         .context(BuildRequestFailed)
+    }
+}
+
+/// Create a new object
+pub struct Create<'a, Kind: Resource, Scope> {
+    /// The object to be created
+    pub object: &'a Kind,
+    /// The scope for the object to be created in
+    pub scope: &'a Scope,
+    /// The type of the object
+    pub dyn_type: &'a Kind::DynamicType,
+}
+impl<'a, Kind: Resource + Serialize, Scope: scope::Scope> Verb for Create<'a, Kind, Scope> {
+    type ResponseDecoder = DecodeStream<Kind>;
+
+    fn to_http_request(&self) -> Result<Request<Body>> {
+        Request::post(format!(
+            "{}/{}",
+            Kind::url_path(&self.dyn_type, self.scope.namespace()),
+            self.object.meta().name.as_ref().context(UnnamedObject)?
+        ))
+        .body(Body::from(
+            serde_json::to_vec(self.object).context(SerializeFailed)?,
+        ))
+        .context(BuildRequestFailed)
+    }
+}
+
+/// Get the API server's version
+pub struct GetApiserverVersion;
+impl Verb for GetApiserverVersion {
+    type ResponseDecoder = DecodeSingle<k8s_openapi::apimachinery::pkg::version::Info>;
+
+    fn to_http_request(&self) -> Result<Request<Body>> {
+        Request::get("/version")
+            .body(Body::empty())
+            .context(BuildRequestFailed)
+    }
+}
+
+/// Get all API groups supported by the API server
+pub struct ListApiGroups;
+impl Verb for ListApiGroups {
+    type ResponseDecoder = DecodeSingle<k8s_openapi::apimachinery::pkg::apis::meta::v1::APIGroupList>;
+
+    fn to_http_request(&self) -> Result<Request<Body>> {
+        Request::get("/apis")
+            .body(Body::empty())
+            .context(BuildRequestFailed)
+    }
+}
+
+/// Get all supported versions of the legacy core API group
+pub struct ListCoreApiVersions;
+impl Verb for ListCoreApiVersions {
+    type ResponseDecoder = DecodeSingle<k8s_openapi::apimachinery::pkg::apis::meta::v1::APIVersions>;
+
+    fn to_http_request(&self) -> Result<Request<Body>> {
+        Request::get("/api")
+            .body(Body::empty())
+            .context(BuildRequestFailed)
+    }
+}
+
+/// Get all resources supported by the API server for a given API group and version
+pub struct ListApiGroupResources<'a> {
+    /// The API group, use `""` for the legacy core group
+    pub group: &'a str,
+    /// THe API version
+    pub version: &'a str,
+}
+impl<'a> Verb for ListApiGroupResources<'a> {
+    type ResponseDecoder = DecodeSingle<k8s_openapi::apimachinery::pkg::apis::meta::v1::APIResourceList>;
+
+    fn to_http_request(&self) -> Result<Request<Body>> {
+        let path = match self.group {
+            "" => format!("/api/{}", self.version),
+            group => format!("/apis/{}/{}", group, self.version),
+        };
+        Request::get(path).body(Body::empty()).context(BuildRequestFailed)
     }
 }

--- a/kube/src/client/verb.rs
+++ b/kube/src/client/verb.rs
@@ -1,0 +1,81 @@
+use std::ops::Deref;
+
+use futures::TryFuture;
+use http::{Request, Response};
+use hyper::Body;
+use kube_core::{Resource, WatchEvent};
+use serde::{de::DeserializeOwned, Deserialize};
+use snafu::{ResultExt, Snafu};
+
+use crate::client::{
+    decoder::{DecodeSingle, DecodeStream},
+    scope::{self, NativeScope},
+    Config,
+};
+
+#[derive(Snafu, Debug)]
+pub enum Error {
+    #[snafu(display("verb created invalid http request: {}", source))]
+    BuildRequestFailed { source: http::Error },
+}
+type Result<T, E = Error> = std::result::Result<T, E>;
+
+pub trait Verb {
+    type ResponseDecoder: TryFuture + From<Response<Body>>;
+
+    fn to_http_request(&self) -> Result<Request<Body>>;
+}
+
+pub struct Get<Kind: Resource, Scope> {
+    pub name: String,
+    pub scope: Scope,
+    pub dyn_type: Kind::DynamicType,
+}
+impl<Kind: Resource + DeserializeOwned, Scope: NativeScope<Kind>> Verb for Get<Kind, Scope> {
+    type ResponseDecoder = DecodeSingle<Kind>;
+
+    fn to_http_request(&self) -> Result<Request<Body>> {
+        Request::get(format!(
+            "{}/{}",
+            Kind::url_path(&self.dyn_type, self.scope.namespace()),
+            self.name
+        ))
+        .body(Body::empty())
+        .context(BuildRequestFailed)
+    }
+}
+
+pub struct List<Kind: Resource, Scope> {
+    pub scope: Scope,
+    pub dyn_type: Kind::DynamicType,
+}
+impl<Kind: Resource + DeserializeOwned, Scope: scope::Scope> Verb for List<Kind, Scope> {
+    type ResponseDecoder = DecodeSingle<ObjectList<Kind>>;
+
+    fn to_http_request(&self) -> Result<Request<Body>> {
+        Request::get(Kind::url_path(&self.dyn_type, self.scope.namespace()))
+            .body(Body::empty())
+            .context(BuildRequestFailed)
+    }
+}
+#[derive(Deserialize)]
+pub struct ObjectList<Kind> {
+    pub items: Vec<Kind>,
+}
+
+pub struct Watch<Kind: Resource, Scope> {
+    pub scope: Scope,
+    pub dyn_type: Kind::DynamicType,
+}
+impl<Kind: Resource, Scope: scope::Scope> Verb for Watch<Kind, Scope> {
+    type ResponseDecoder = DecodeStream<WatchEvent<Kind>>;
+
+    fn to_http_request(&self) -> Result<Request<Body>> {
+        Request::get(format!(
+            "{}?watch=1",
+            Kind::url_path(&self.dyn_type, self.scope.namespace()),
+        ))
+        .body(Body::empty())
+        .context(BuildRequestFailed)
+    }
+}

--- a/kube/src/error.rs
+++ b/kube/src/error.rs
@@ -17,6 +17,10 @@ pub enum Error {
     #[error("ApiError: {0} ({0:?})")]
     Api(#[source] ErrorResponse),
 
+    /// Call failed
+    #[error("CallError: {0}")]
+    ClientCall(#[from] crate::client::CallError),
+
     /// ConnectionError for when TcpStream fails to connect.
     #[error("ConnectionError: {0}")]
     Connection(std::io::Error),


### PR DESCRIPTION
Based on the spike at https://gitlab.com/teozkr/neokubism/, this turns the `VerbParams` objects into the "canonical" representation of an action. This means that it becomes possible to extend `Client` with native-feeling custom subresources, avoids the need for temporary `Api` objects, and lets us validate that that a given `(scope, resource, verb)` tuple is legal at compile-time.

It also starts the SNAFUfication (#453) of `kube`.

This is a pretty huge break-the-world change, but we should be able to keep `Api` around as a deprecated facade for now.

- [X] Spike regular verb
- [X] Spike watch verb
- [ ] Spike websocket verb
- [ ] Implement all verbs
- [ ] Implement verb params
- [ ] Subresources
- [ ] Deprecate untyped `Client` API
- [ ] Deprecated `Api`
- [ ] Clean up documentation
- [ ] Changelog
- [ ] Test
- [ ] Clean up old errors
- [ ] Migrate kube-runtime
- [ ] Migrate examples