### PR TITLE
Changelog fix: Controller::owns now restricts the DynamicType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ UNRELEASED
   - BREAKING: `scheduler` now shuts down immediately when `requests` terminates, rather than waiting for the pending reconciliations to drain
  * `kube-runtime` added tracking for reconciliation reason
   - Added: `Controller::owns_with` and `Controller::watches_with` to pass a `dyntype` argument for dynamic `Api`s - [#575](https://github.com/kube-rs/kube-rs/issues/575)
+  - BREAKING: `Controller::owns` signature changed to not allow `DynamicType`s.
   - BREAKING: `controller::trigger_*` now returns a `ReconcileRequest` rather than `ObjectRef`. The `ObjectRef` can be accessed via the `obj_ref` field
 
 ### Known Issues

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ UNRELEASED
   - BREAKING: `scheduler` now shuts down immediately when `requests` terminates, rather than waiting for the pending reconciliations to drain
  * `kube-runtime` added tracking for reconciliation reason
   - Added: `Controller::owns_with` and `Controller::watches_with` to pass a `dyntype` argument for dynamic `Api`s - [#575](https://github.com/kube-rs/kube-rs/issues/575)
-  - BREAKING: `Controller::owns` signature changed to not allow `DynamicType`s.
+  - BREAKING: `Controller::owns` signature changed to not allow `DynamicType`s
   - BREAKING: `controller::trigger_*` now returns a `ReconcileRequest` rather than `ObjectRef`. The `ObjectRef` can be accessed via the `obj_ref` field
 
 ### Known Issues


### PR DESCRIPTION
This can lead to errors like this:

```
error[E0271]: type mismatch resolving `<Child as kube::Resource>::DynamicType == ()`
   --> src/controller.rs:235:53
    |
235 |         self.kube_controller = self.kube_controller.owns(api, lp);
    |                                                     ^^^^ expected associated type, found `()`
    |
    = note: expected associated type `<Child as kube::Resource>::DynamicType`
                     found unit type `()`
help: consider constraining the associated type `<Child as kube::Resource>::DynamicType` to `()`
    |
232 |         Child: Clone + Debug + Resource<DynamicType = ()> + DeserializeOwned + Send + 'static,
    |                                        ^^^^^^^^^^^^^^^^^^
error: aborting due to previous error

```

We had a wrapper around `owns` with this signature:

```
    pub fn owns<Child>(mut self, api: Api<Child>, lp: ListParams) -> Self
    where
        Child: Clone + Debug + Resource + DeserializeOwned + Send + 'static,
        <Child as Resource>::DynamicType: Clone + Debug + Eq + Hash,
```