### PR TITLE
Add a dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"


### PR DESCRIPTION
I'm not sure if you're even interested in this but it's been useful for us.
Dependabot automatically checks for dependency updates for cargo and github actions (looking at the workflows I already see what it's going to complain about :) )

I've set the interval to weekly, daily is a bit too annyoing :)
I also added a label that doesn't exist yet so if you like the idea clux needs to add the label.

If you don't want dependabot I'm happy to close the PR again.