### PR TITLE
Add cargo-deny, clippy and rustfmt to CI - try #2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,3 +102,36 @@ jobs:
           kubectl wait --for=condition=complete job/dapp -n apps --timeout=50s || kubectl logs -f job/dapp -n apps
           kubectl get all -n apps
           kubectl wait --for=condition=complete job/dapp -n apps --timeout=10s || kubectl get pods -n apps | grep dapp | grep Completed
+
+  cargo-deny:
+    name: Run cargo deny
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        checks:
+          - advisories
+          - bans licenses sources
+
+    # Prevent sudden announcement of a new advisory from failing ci:
+    continue-on-error: ${{ matrix.checks == 'advisories' }}
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: EmbarkStudios/cargo-deny-action@v1
+        with:
+          command: check ${{ matrix.checks }}
+
+  rustfmt:
+    name: Run rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1.0.7
+        with:
+          profile: minimal
+          toolchain: nightly
+          components: rustfmt
+          override: true
+      - name: Run rustfmt
+        id: rustfmt
+        run: rustfmt +nightly --edition 2018 --check $(find . -type f -iname *.rs)

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -1,4 +1,6 @@
-on: push
+on:
+  push:
+  pull_request:
 name: clippy
 jobs:
   clippy_nightly:

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -1,8 +1,8 @@
 on:
   push:
-  pull_request:
     branches-ignore:
       - 'master'
+  pull_request:
 name: clippy
 jobs:
   clippy_nightly:

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -1,6 +1,8 @@
 on:
   push:
   pull_request:
+    branches-ignore:
+      - 'master'
 name: clippy
 jobs:
   clippy_nightly:

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,51 @@
+[advisories]
+db-path = "~/.cargo/advisory-db"
+db-urls = ["https://github.com/rustsec/advisory-db"]
+vulnerability = "deny"
+unmaintained = "warn"
+yanked = "warn"
+notice = "warn"
+
+
+[licenses]
+# See https://spdx.org/licenses/ for list of possible licenses
+# [possible values: any SPDX 3.11 short identifier (+ optional exception)].
+
+confidence-threshold = 1.0
+copyleft = "deny"
+default = "deny"
+unlicensed = "deny"
+
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "BSD-3-Clause",
+    "ISC",
+    "LicenseRef-ring",
+    "LicenseRef-webpki"
+]
+
+
+[[licenses.clarify]]
+name = "ring"
+expression = "LicenseRef-ring"
+license-files = [
+    { path = "LICENSE", hash = 0xbd0eed23 },
+]
+
+[[licenses.clarify]]
+name = "webpki"
+expression = "LicenseRef-webpki"
+license-files = [
+    { path = "LICENSE", hash = 0x001c7e6c },
+]
+
+
+[sources]
+unknown-registry = "warn"
+unknown-git = "warn"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []
+
+[sources.allow-org]
+github = ["kube-rs"]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -8,6 +8,7 @@ authors = [
 ]
 publish = false
 edition = "2018"
+license = "Apache-2.0"
 
 [package.metadata.release]
 disable-release = true

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["clux <sszynrae@gmail.com>"]
 publish = false
 edition = "2018"
+license = "Apache-2.0"
 
 [package.metadata.release]
 disable-release = true


### PR DESCRIPTION
The previous PR #607 had issues (I couldn't get DCO right) so I created a new one.

This adds cargo-deny (for license checks and security advisories), rustfmt and clippy to the CI run for Pull Requests