### PR TITLE
File config serialization should skip None values

### DIFF
--- a/kube/src/config/file_config.rs
+++ b/kube/src/config/file_config.rs
@@ -41,7 +41,7 @@ pub struct Kubeconfig {
 }
 
 /// Preferences stores extensions for cli.
-#[derive(Clone, Debug, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Preferences {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub colors: Option<bool>,
@@ -50,21 +50,21 @@ pub struct Preferences {
 }
 
 /// NamedExtention associates name with extension.
-#[derive(Clone, Debug, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct NamedExtension {
     pub name: String,
     pub extension: serde_json::Value,
 }
 
 /// NamedCluster associates name with cluster.
-#[derive(Clone, Debug, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct NamedCluster {
     pub name: String,
     pub cluster: Cluster,
 }
 
 /// Cluster stores information to connect Kubernetes cluster.
-#[derive(Clone, Debug, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Cluster {
     /// The address of the kubernetes cluster (https://hostname:port).
     pub server: String,
@@ -89,7 +89,7 @@ pub struct Cluster {
 }
 
 /// NamedAuthInfo associates name with authentication.
-#[derive(Clone, Debug, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct NamedAuthInfo {
     pub name: String,
     #[serde(rename = "user")]
@@ -152,14 +152,14 @@ pub struct AuthInfo {
 }
 
 /// AuthProviderConfig stores auth for specified cloud provider.
-#[derive(Clone, Debug, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct AuthProviderConfig {
     pub name: String,
     pub config: HashMap<String, String>,
 }
 
 /// ExecConfig stores credential-plugin configuration.
-#[derive(Clone, Debug, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ExecConfig {
     /// Preferred input version of the ExecInfo.
     ///
@@ -180,14 +180,14 @@ pub struct ExecConfig {
 }
 
 /// NamedContext associates name with context.
-#[derive(Clone, Debug, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct NamedContext {
     pub name: String,
     pub context: Context,
 }
 
 /// Context stores tuple of cluster and user information.
-#[derive(Clone, Debug, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Context {
     /// Name of the cluster for this context
     pub cluster: String,

--- a/kube/src/config/file_config.rs
+++ b/kube/src/config/file_config.rs
@@ -12,7 +12,7 @@ use std::{collections::HashMap, fs, path::Path};
 ///
 /// [`Config`][crate::Config] is the __intended__ developer interface to help create a [`Client`][crate::Client],
 /// and this will handle the difference between in-cluster deployment and local development.
-#[derive(Clone, Debug, Default, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, Serialize, Deserialize, Default)]
 pub struct Kubeconfig {
     /// General information to be use for cli interactions
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -41,7 +41,7 @@ pub struct Kubeconfig {
 }
 
 /// Preferences stores extensions for cli.
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, Default)]
 pub struct Preferences {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub colors: Option<bool>,
@@ -50,21 +50,21 @@ pub struct Preferences {
 }
 
 /// NamedExtention associates name with extension.
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, Default)]
 pub struct NamedExtension {
     pub name: String,
     pub extension: serde_json::Value,
 }
 
 /// NamedCluster associates name with cluster.
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, Default)]
 pub struct NamedCluster {
     pub name: String,
     pub cluster: Cluster,
 }
 
 /// Cluster stores information to connect Kubernetes cluster.
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, Default)]
 pub struct Cluster {
     /// The address of the kubernetes cluster (https://hostname:port).
     pub server: String,
@@ -89,7 +89,7 @@ pub struct Cluster {
 }
 
 /// NamedAuthInfo associates name with authentication.
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, Default)]
 pub struct NamedAuthInfo {
     pub name: String,
     #[serde(rename = "user")]
@@ -97,7 +97,7 @@ pub struct NamedAuthInfo {
 }
 
 /// AuthInfo stores information to tell cluster who you are.
-#[derive(Clone, Debug, Default, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, Serialize, Deserialize, Default)]
 pub struct AuthInfo {
     /// The username for basic authentication to the kubernetes cluster.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -152,14 +152,14 @@ pub struct AuthInfo {
 }
 
 /// AuthProviderConfig stores auth for specified cloud provider.
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, Default)]
 pub struct AuthProviderConfig {
     pub name: String,
     pub config: HashMap<String, String>,
 }
 
 /// ExecConfig stores credential-plugin configuration.
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, Default)]
 pub struct ExecConfig {
     /// Preferred input version of the ExecInfo.
     ///
@@ -180,14 +180,14 @@ pub struct ExecConfig {
 }
 
 /// NamedContext associates name with context.
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, Default)]
 pub struct NamedContext {
     pub name: String,
     pub context: Context,
 }
 
 /// Context stores tuple of cluster and user information.
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, Default)]
 pub struct Context {
     /// Name of the cluster for this context
     pub cluster: String,

--- a/kube/src/config/file_config.rs
+++ b/kube/src/config/file_config.rs
@@ -12,9 +12,10 @@ use std::{collections::HashMap, fs, path::Path};
 ///
 /// [`Config`][crate::Config] is the __intended__ developer interface to help create a [`Client`][crate::Client],
 /// and this will handle the difference between in-cluster deployment and local development.
-#[derive(Clone, Debug, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, Default)]
 pub struct Kubeconfig {
     /// General information to be use for cli interactions
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub preferences: Option<Preferences>,
     /// Referencable names to cluster configs
     pub clusters: Vec<NamedCluster>,
@@ -25,59 +26,70 @@ pub struct Kubeconfig {
     pub contexts: Vec<NamedContext>,
     /// The name of the context that you would like to use by default
     #[serde(rename = "current-context")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub current_context: Option<String>,
     /// Additional information for extenders so that reads and writes don't clobber unknown fields.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub extensions: Option<Vec<NamedExtension>>,
 
     // legacy fields TODO: remove
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub kind: Option<String>,
     #[serde(rename = "apiVersion")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub api_version: Option<String>,
 }
 
 /// Preferences stores extensions for cli.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct Preferences {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub colors: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub extensions: Option<Vec<NamedExtension>>,
 }
 
 /// NamedExtention associates name with extension.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct NamedExtension {
     pub name: String,
     pub extension: serde_json::Value,
 }
 
 /// NamedCluster associates name with cluster.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct NamedCluster {
     pub name: String,
     pub cluster: Cluster,
 }
 
 /// Cluster stores information to connect Kubernetes cluster.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct Cluster {
     /// The address of the kubernetes cluster (https://hostname:port).
     pub server: String,
     #[serde(rename = "insecure-skip-tls-verify")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub insecure_skip_tls_verify: Option<bool>,
     /// The path to a cert file for the certificate authority.
     #[serde(rename = "certificate-authority")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub certificate_authority: Option<String>,
     /// PEM-encoded certificate authority certificates. Overrides `certificate_authority`
     #[serde(rename = "certificate-authority-data")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub certificate_authority_data: Option<String>,
     /// URL to the proxy to be used for all requests.
     #[serde(rename = "proxy-url")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub proxy_url: Option<String>,
     /// Additional information for extenders so that reads and writes don't clobber unknown fields
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub extensions: Option<Vec<NamedExtension>>,
 }
 
 /// NamedAuthInfo associates name with authentication.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct NamedAuthInfo {
     pub name: String,
     #[serde(rename = "user")]
@@ -85,90 +97,107 @@ pub struct NamedAuthInfo {
 }
 
 /// AuthInfo stores information to tell cluster who you are.
-#[derive(Clone, Debug, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, Default)]
 pub struct AuthInfo {
     /// The username for basic authentication to the kubernetes cluster.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub username: Option<String>,
     /// The password for basic authentication to the kubernetes cluster.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub password: Option<String>,
 
     /// The bearer token for authentication to the kubernetes cluster.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub token: Option<String>,
     /// Pointer to a file that contains a bearer token (as described above). If both `token` and token_file` are present, `token` takes precedence.
     #[serde(rename = "tokenFile")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub token_file: Option<String>,
 
     /// Path to a client cert file for TLS.
     #[serde(rename = "client-certificate")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub client_certificate: Option<String>,
     /// PEM-encoded data from a client cert file for TLS. Overrides `client_certificate`
     #[serde(rename = "client-certificate-data")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub client_certificate_data: Option<String>,
 
     /// Path to a client key file for TLS.
     #[serde(rename = "client-key")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub client_key: Option<String>,
     /// PEM-encoded data from a client key file for TLS. Overrides `client_key`
     #[serde(rename = "client-key-data")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub client_key_data: Option<String>,
 
     /// The username to act-as.
     #[serde(rename = "as")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub impersonate: Option<String>,
     /// The groups to imperonate.
     #[serde(rename = "as-groups")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub impersonate_groups: Option<Vec<String>>,
 
     /// Specifies a custom authentication plugin for the kubernetes cluster.
     #[serde(rename = "auth-provider")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub auth_provider: Option<AuthProviderConfig>,
 
     /// Specifies a custom exec-based authentication plugin for the kubernetes cluster.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub exec: Option<ExecConfig>,
 }
 
 /// AuthProviderConfig stores auth for specified cloud provider.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct AuthProviderConfig {
     pub name: String,
     pub config: HashMap<String, String>,
 }
 
 /// ExecConfig stores credential-plugin configuration.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct ExecConfig {
     /// Preferred input version of the ExecInfo.
     ///
     /// The returned ExecCredentials MUST use the same encoding version as the input.
     #[serde(rename = "apiVersion")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub api_version: Option<String>,
     /// Command to execute.
     pub command: String,
     /// Arguments to pass to the command when executing it.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub args: Option<Vec<String>>,
     /// Env defines additional environment variables to expose to the process.
     ///
     /// TODO: These are unioned with the host's environment, as well as variables client-go uses to pass argument to the plugin.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub env: Option<Vec<HashMap<String, String>>>,
 }
 
 /// NamedContext associates name with context.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct NamedContext {
     pub name: String,
     pub context: Context,
 }
 
 /// Context stores tuple of cluster and user information.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct Context {
     /// Name of the cluster for this context
     pub cluster: String,
     /// Name of the `AuthInfo` for this context
     pub user: String,
     /// The default namespace to use on unspecified requests
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub namespace: Option<String>,
     /// Additional information for extenders so that reads and writes don't clobber unknown fields
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub extensions: Option<Vec<NamedExtension>>,
 }
 


### PR DESCRIPTION
I would like to round trip the kube config file and not introduce a bunch of `value: ~` for None values. This instructs serde to skip serializing None values.

Closes #612.