### PR TITLE
fix release script generator and offload work to a script - fixes #601

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -1,7 +1,4 @@
 on:
-  push:
-    branches-ignore:
-      - 'master'
   pull_request:
 name: clippy
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,15 +11,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Extract release info from CHANGELOG
-        run: grep $(date +%Y-%m-%d) -A 250 CHANGELOG.md | tail -n +3 | sed '1,/===================/!d' | head -n -3 > release.txt
-      - name: Add links to critical bugs
-        run: |
-          if (( $(curl -sSL -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/kube-rs/kube-rs/issues?labels=critical | jq length) > 0 )); then
-            echo -e "\n### Known Issues" >> release.txt
-            curl -sSL -H "Accept: application/vnd.github.v3+json"   https://api.github.com/repos/kube-rs/kube-rs/issues?labels=critical | jq '.[] | "- \(.title) - #[\(.number)](\(.url))"' -r >> release.txt
-          fi
-      run:
+      - name: Generate release info
+        run: ./scripts/release-gh.sh
       - name: Release
         uses: softprops/action-gh-release@v1
         env:

--- a/release.toml
+++ b/release.toml
@@ -5,7 +5,7 @@
 # 3a. await publishing - failures can happen due to https://github.com/sunng87/cargo-release/issues/224 (but should not with sufficient grace-sleep)
 # 3b. if failures from 3a; (resume publishing manually, cd into next dir, cargo publish, wait, continue for next in line)
 # 4. git amend consolidated commit and add the unified version https://github.com/sunng87/cargo-release/issues/222
-# 5. ./postrelease.sh
+# 5. ./scripts/release-post.sh
 
 # Reference
 # https://github.com/sunng87/cargo-release/blob/master/docs/reference.md
@@ -13,7 +13,7 @@
 
 consolidate-commits = true
 no-dev-version = true # bumps happen right before release
-pre-release-hook = ["../prerelease.sh"]
+pre-release-hook = ["../scripts/release-pre.sh"]
 pre-release-commit-message = "release"
 # leave tagging to postrelease script (due to potential failures in 3 and 4)
 disable-push = true

--- a/scripts/release-gh.sh
+++ b/scripts/release-gh.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+main() {
+  cd "$(dirname "${BASH_SOURCE[0]}")" && cd .. # aka $WORKSPACE_ROOT
+
+  # allow passing in date so we can test this
+  local -r DATE=${1:-$(date +%Y-%m-%d)}
+  # extract a dated release between equals dividers (assuming consistent whitespace)
+  grep "${DATE}" -A 250 CHANGELOG.md \
+    | tail -n +3 \
+    | sed '1,/===================/!d' \
+    | head -n -3 > release.txt
+
+  # Add links to critical bugs
+  local -r CRITISSUES="$(curl -sSL -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/kube-rs/kube-rs/issues?labels=critical)"
+  if (( $(echo "${CRITISSUES}" | jq length) > 0 )); then
+    echo -e "\n### Known Issues" >> release.txt
+    echo "${CRITISSUES}" | jq '.[] | "- \(.title) - #[\(.number)](\(.url))"' -r >> release.txt
+  fi
+}
+
+# shellcheck disable=SC2068
+main $@

--- a/scripts/release-post.sh
+++ b/scripts/release-post.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 main() {
+  cd "$(dirname "${BASH_SOURCE[0]}")" && cd .. # aka $WORKSPACE_ROOT
   local -r CURRENT_VER="$(rg "kube =" README.md | head -n 1 | awk -F"\"" '{print $2}')"
   git tag -a "${CURRENT_VER}" -m "${CURRENT_VER}"
   git push

--- a/scripts/release-pre.sh
+++ b/scripts/release-pre.sh
@@ -27,7 +27,7 @@ sanity() {
 
 main() {
   # We only want this to run ONCE at workspace level
-  cd "$(dirname "${BASH_SOURCE[0]}")" # aka $WORKSPACE_ROOT
+  cd "$(dirname "${BASH_SOURCE[0]}")" && cd .. # aka $WORKSPACE_ROOT
   local -r CURRENT_VER="$(rg "kube =" README.md | head -n 1 | awk -F"\"" '{print $2}')"
 
   # If the main README has been bumped, assume we are done:


### PR DESCRIPTION
creates a script dedicated for what the release action was doing (for some reason it didn't like my indent, and it's awkward to have that much shell in there anyway).

to avoid shell script sprawl, this also adds a scripts dir for these things, and standardises on naming.

[think it's fine to depend on jq in the action](https://github.com/actions/virtual-environments/blob/72813adbe7adf46b4bcc2514221de8f937d4d7ea/images/linux/scripts/base/apt.sh)