### PR TITLE
support v1_22 by feature gating crd v1beta1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         run: cargo test -p examples --example crd_derive_no_schema --no-default-features --features=native-tls
         if: matrix.os == 'ubuntu-latest'
       - name: Test crd_api example with deprecated crd
-        run: cargo test -p examples --example crd_api--no-default-features --features=deprecated,kubederive,native-tls
+        run: cargo test -p examples --example crd_api --no-default-features --features=deprecated,kubederive,native-tls
         if: matrix.os == 'ubuntu-latest'
 
   integration:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
       # Feature tests in examples
       - name: Test crd_derive_no_schema example
-        run: cargo test -p examples --example crd_derive_no_schema --no-default-features --features=native-tls
+        run: cargo test -p examples --example crd_derive_no_schema --no-default-features --features=native-tls,latest
         if: matrix.os == 'ubuntu-latest'
       - name: Test crd_api example with deprecated crd
         run: cargo test -p examples --example crd_api --no-default-features --features=deprecated,kubederive,native-tls

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,9 @@ jobs:
       - name: Test crd_derive_no_schema example
         run: cargo test -p examples --example crd_derive_no_schema --no-default-features --features=native-tls
         if: matrix.os == 'ubuntu-latest'
+      - name: Test crd_api example with deprecated crd
+        run: cargo test -p examples --example crd_api--no-default-features --features=deprecated,kubederive,native-tls
+        if: matrix.os == 'ubuntu-latest'
 
   integration:
     # Integration tests are linux only

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Select a version of `kube` along with the generated [k8s-openapi](https://github
 [dependencies]
 kube = "0.59.0"
 kube-runtime = "0.59.0"
-k8s-openapi = { version = "0.13.0", default-features = false, features = ["v1_21"] }
+k8s-openapi = { version = "0.13.0", default-features = false, features = ["v1_22"] }
 ```
 
 [Features are available](https://github.com/kube-rs/kube-rs/blob/master/kube/Cargo.toml#L18).
@@ -159,7 +159,7 @@ Kube has basic support ([with caveats](https://github.com/kube-rs/kube-rs/issues
 [dependencies]
 kube = { version = "0.59.0", default-features = false, features = ["client", "rustls-tls"] }
 kube-runtime = { version = "0.59.0" }
-k8s-openapi = { version = "0.13.0", default-features = false, features = ["v1_21"] }
+k8s-openapi = { version = "0.13.0", default-features = false, features = ["v1_22"] }
 ```
 
 This will pull in `rustls` and `hyper-rustls`.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Select a version of `kube` along with the generated [k8s-openapi](https://github
 [dependencies]
 kube = "0.59.0"
 kube-runtime = "0.59.0"
-k8s-openapi = { version = "0.13.0", default-features = false, features = ["v1_20"] }
+k8s-openapi = { version = "0.13.0", default-features = false, features = ["v1_21"] }
 ```
 
 [Features are available](https://github.com/kube-rs/kube-rs/blob/master/kube/Cargo.toml#L18).
@@ -159,7 +159,7 @@ Kube has basic support ([with caveats](https://github.com/kube-rs/kube-rs/issues
 [dependencies]
 kube = { version = "0.59.0", default-features = false, features = ["client", "rustls-tls"] }
 kube-runtime = { version = "0.59.0" }
-k8s-openapi = { version = "0.13.0", default-features = false, features = ["v1_20"] }
+k8s-openapi = { version = "0.13.0", default-features = false, features = ["v1_21"] }
 ```
 
 This will pull in `rustls` and `hyper-rustls`.

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -14,13 +14,14 @@ license = "Apache-2.0"
 disable-release = true
 
 [features]
-default = ["native-tls", "schema", "kubederive", "ws", "deprecated"]
+default = ["native-tls", "schema", "kubederive", "ws", "latest"]
 kubederive = ["kube/derive"] # by default import kube-derive with its default features
 schema = ["kube-derive/schema"] # crd_derive_no_schema shows how to opt out
 native-tls = ["kube/client", "kube/native-tls"]
 rustls-tls = ["kube/client", "kube/rustls-tls"]
 ws = ["kube/ws"]
-deprecated = ["kube/deprecated-crd-v1beta1"]
+latest = ["k8s-openapi/v1_22"]
+deprecated = ["kube/deprecated-crd-v1beta1", "k8s-openapi/v1_21"]
 
 [dependencies]
 tokio-util = "0.6.0"
@@ -34,7 +35,7 @@ kube = { path = "../kube", version = "^0.59.0", default-features = false, featur
 kube-derive = { path = "../kube-derive", version = "^0.59.0", default-features = false } # only needed to opt out of schema
 kube-runtime = { path = "../kube-runtime", version = "^0.59.0"}
 kube-core = { path = "../kube-core", version = "^0.59.0", default-features = false }
-k8s-openapi = { version = "0.13.0", features = ["v1_21"], default-features = false }
+k8s-openapi = { version = "0.13.0", default-features = false }
 log = "0.4.11"
 serde = { version = "1.0.118", features = ["derive"] }
 serde_json = "1.0.61"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -14,12 +14,13 @@ license = "Apache-2.0"
 disable-release = true
 
 [features]
-default = ["native-tls", "schema", "kubederive", "ws"]
+default = ["native-tls", "schema", "kubederive", "ws", "deprecated"]
 kubederive = ["kube/derive"] # by default import kube-derive with its default features
 schema = ["kube-derive/schema"] # crd_derive_no_schema shows how to opt out
 native-tls = ["kube/client", "kube/native-tls"]
 rustls-tls = ["kube/client", "kube/rustls-tls"]
 ws = ["kube/ws"]
+deprecated = ["kube/deprecated-crd-v1beta1"]
 
 [dependencies]
 tokio-util = "0.6.0"
@@ -33,7 +34,7 @@ kube = { path = "../kube", version = "^0.59.0", default-features = false, featur
 kube-derive = { path = "../kube-derive", version = "^0.59.0", default-features = false } # only needed to opt out of schema
 kube-runtime = { path = "../kube-runtime", version = "^0.59.0"}
 kube-core = { path = "../kube-core", version = "^0.59.0", default-features = false }
-k8s-openapi = { version = "0.13.0", features = ["v1_20"], default-features = false }
+k8s-openapi = { version = "0.13.0", features = ["v1_21"], default-features = false }
 log = "0.4.11"
 serde = { version = "1.0.118", features = ["derive"] }
 serde_json = "1.0.61"

--- a/examples/crd_api.rs
+++ b/examples/crd_api.rs
@@ -11,7 +11,7 @@ use tokio::time::sleep;
 use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1beta1 as apiexts;
 #[cfg(feature = "deprecated")] use kube::core::crd::v1beta1::CustomResourceExt;
 
-// Recommended: not deprecated features (defaults with latest v1 crd)
+// Recommended: no deprecated features (v1 crd)
 #[cfg(not(feature = "deprecated"))]
 use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1 as apiexts;
 #[cfg(not(feature = "deprecated"))] use kube::core::crd::v1::CustomResourceExt;

--- a/kube-core/Cargo.toml
+++ b/kube-core/Cargo.toml
@@ -34,7 +34,7 @@ features = []
 [dev-dependencies.k8s-openapi]
 version = "0.13.0"
 default-features = false
-features = ["v1_21"]
+features = ["v1_22"]
 
 [dev-dependencies]
 kube = { path = "../kube", version = "<1.0.0, >=0.53.0" }

--- a/kube-core/Cargo.toml
+++ b/kube-core/Cargo.toml
@@ -15,6 +15,7 @@ readme = "../README.md"
 ws = []
 admission = ["json-patch"]
 jsonpatch = ["json-patch"]
+deprecated-crd-v1beta1 = []
 
 [dependencies]
 serde = { version = "1.0.118", features = ["derive"] }
@@ -33,7 +34,7 @@ features = []
 [dev-dependencies.k8s-openapi]
 version = "0.13.0"
 default-features = false
-features = ["v1_20"]
+features = ["v1_21"]
 
 [dev-dependencies]
 kube = { path = "../kube", version = "<1.0.0, >=0.53.0" }

--- a/kube-core/src/crd.rs
+++ b/kube-core/src/crd.rs
@@ -22,6 +22,7 @@ pub mod v1 {
 }
 
 /// Types for legacy v1beta1 CustomResourceDefinitions
+#[cfg(feature = "deprecated-crd-v1beta1")]
 pub mod v1beta1 {
     /// Extension trait that will be implemented by kube-derive for legacy v1beta1::CustomResourceDefinitions
     ///

--- a/kube-core/src/request.rs
+++ b/kube-core/src/request.rs
@@ -226,16 +226,9 @@ impl Request {
 mod test {
     use crate::{params::PostParams, request::Request, resource::Resource};
     use k8s::{
-        admissionregistration::v1beta1 as adregv1beta1,
-        apps::v1 as appsv1,
-        authorization::v1 as authv1,
-        autoscaling::v1 as autoscalingv1,
-        batch::v1beta1 as batchv1beta1,
-        core::v1 as corev1,
-        extensions::v1beta1 as extsv1beta1,
-        networking::{v1 as networkingv1, v1beta1 as networkingv1beta1},
-        rbac::v1 as rbacv1,
-        storage::v1 as storagev1,
+        admissionregistration::v1 as adregv1, apps::v1 as appsv1, authorization::v1 as authv1,
+        autoscaling::v1 as autoscalingv1, batch::v1beta1 as batchv1beta1, core::v1 as corev1,
+        networking::v1 as networkingv1, rbac::v1 as rbacv1, storage::v1 as storagev1,
     };
     use k8s_openapi::api as k8s;
     // use k8s::batch::v1 as batchv1;
@@ -294,9 +287,9 @@ mod test {
     }
     #[test]
     fn api_url_ingress() {
-        let url = extsv1beta1::Ingress::url_path(&(), Some("ns"));
+        let url = networkingv1::Ingress::url_path(&(), Some("ns"));
         let req = Request::new(url).create(&PostParams::default(), vec![]).unwrap();
-        assert_eq!(req.uri(), "/apis/extensions/v1beta1/namespaces/ns/ingresses?");
+        assert_eq!(req.uri(), "/apis/networking.k8s.io/v1/namespaces/ns/ingresses?");
     }
 
     #[test]
@@ -308,11 +301,11 @@ mod test {
 
     #[test]
     fn api_url_admission() {
-        let url = adregv1beta1::ValidatingWebhookConfiguration::url_path(&(), None);
+        let url = adregv1::ValidatingWebhookConfiguration::url_path(&(), None);
         let req = Request::new(url).create(&PostParams::default(), vec![]).unwrap();
         assert_eq!(
             req.uri(),
-            "/apis/admissionregistration.k8s.io/v1beta1/validatingwebhookconfigurations?"
+            "/apis/admissionregistration.k8s.io/v1/validatingwebhookconfigurations?"
         );
     }
 
@@ -341,7 +334,6 @@ mod test {
     /// -----------------------------------------------------------------
     /// Tests that the misc mappings are also sensible
     use crate::params::{DeleteParams, ListParams, Patch, PatchParams};
-    use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1beta1 as apiextsv1beta1;
 
     #[test]
     fn list_path() {
@@ -430,35 +422,32 @@ mod test {
     #[test]
     fn create_ingress() {
         // NB: Ingress exists in extensions AND networking
-        let url = networkingv1beta1::Ingress::url_path(&(), Some("ns"));
+        let url = networkingv1::Ingress::url_path(&(), Some("ns"));
         let pp = PostParams::default();
         let req = Request::new(&url).create(&pp, vec![]).unwrap();
 
-        assert_eq!(
-            req.uri(),
-            "/apis/networking.k8s.io/v1beta1/namespaces/ns/ingresses?"
-        );
+        assert_eq!(req.uri(), "/apis/networking.k8s.io/v1/namespaces/ns/ingresses?");
         let patch_params = PatchParams::default();
         let req = Request::new(url)
             .patch("baz", &patch_params, &Patch::Merge(()))
             .unwrap();
         assert_eq!(
             req.uri(),
-            "/apis/networking.k8s.io/v1beta1/namespaces/ns/ingresses/baz?"
+            "/apis/networking.k8s.io/v1/namespaces/ns/ingresses/baz?"
         );
         assert_eq!(req.method(), "PATCH");
     }
 
     #[test]
     fn replace_status() {
-        let url = apiextsv1beta1::CustomResourceDefinition::url_path(&(), None);
+        let url = apiextsv1::CustomResourceDefinition::url_path(&(), None);
         let pp = PostParams::default();
         let req = Request::new(url)
             .replace_subresource("status", "mycrd.domain.io", &pp, vec![])
             .unwrap();
         assert_eq!(
             req.uri(),
-            "/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/mycrd.domain.io/status?"
+            "/apis/apiextensions.k8s.io/v1/customresourcedefinitions/mycrd.domain.io/status?"
         );
     }
     #[test]

--- a/kube-derive/Cargo.toml
+++ b/kube-derive/Cargo.toml
@@ -29,7 +29,7 @@ schema = []
 serde = { version = "1.0.118", features = ["derive"] }
 serde_yaml = "0.8.17"
 kube = { path = "../kube", default-features = false }
-k8s-openapi = { version = "0.13.0", default-features = false, features = ["v1_20"] }
+k8s-openapi = { version = "0.13.0", default-features = false, features = ["v1_21"] }
 schemars = { version = "0.8.0", features = ["chrono"] }
 chrono = "0.4.19"
 trybuild = "1.0"

--- a/kube-derive/Cargo.toml
+++ b/kube-derive/Cargo.toml
@@ -29,7 +29,7 @@ schema = []
 serde = { version = "1.0.118", features = ["derive"] }
 serde_yaml = "0.8.17"
 kube = { path = "../kube", default-features = false }
-k8s-openapi = { version = "0.13.0", default-features = false, features = ["v1_21"] }
+k8s-openapi = { version = "0.13.0", default-features = false, features = ["v1_22"] }
 schemars = { version = "0.8.0", features = ["chrono"] }
 chrono = "0.4.19"
 trybuild = "1.0"

--- a/kube-runtime/Cargo.toml
+++ b/kube-runtime/Cargo.toml
@@ -42,4 +42,4 @@ schemars = "0.8.0"
 [dev-dependencies.k8s-openapi]
 version = "0.13.0"
 default-features = false
-features = ["v1_20"]
+features = ["v1_21"]

--- a/kube-runtime/Cargo.toml
+++ b/kube-runtime/Cargo.toml
@@ -42,4 +42,4 @@ schemars = "0.8.0"
 [dev-dependencies.k8s-openapi]
 version = "0.13.0"
 default-features = false
-features = ["v1_21"]
+features = ["v1_22"]

--- a/kube/Cargo.toml
+++ b/kube/Cargo.toml
@@ -27,6 +27,7 @@ jsonpatch = ["kube-core/jsonpatch"]
 admission = ["kube-core/admission"]
 derive = ["kube-derive"]
 config = ["__non_core", "pem", "dirs"]
+deprecated-crd-v1beta1 = ["kube-core/deprecated-crd-v1beta1"]
 
 # private feature sets; do not use
 __non_core = ["tracing", "serde_yaml", "base64"]
@@ -87,4 +88,4 @@ tower-test = "0.4.0"
 [dev-dependencies.k8s-openapi]
 version = "0.13.0"
 default-features = false
-features = ["v1_20"]
+features = ["v1_21"]

--- a/kube/Cargo.toml
+++ b/kube/Cargo.toml
@@ -88,4 +88,4 @@ tower-test = "0.4.0"
 [dev-dependencies.k8s-openapi]
 version = "0.13.0"
 default-features = false
-features = ["v1_21"]
+features = ["v1_22"]

--- a/kube/src/api/core_methods.rs
+++ b/kube/src/api/core_methods.rs
@@ -90,7 +90,7 @@ where
     ///
     /// ```no_run
     /// use kube::{api::{Api, DeleteParams}, Client};
-    /// use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1beta1 as apiexts;
+    /// use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1 as apiexts;
     /// use apiexts::CustomResourceDefinition;
     /// #[tokio::main]
     /// async fn main() -> Result<(), kube::Error> {

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -18,7 +18,7 @@ anyhow = "1.0.37"
 env_logger = "0.8.2"
 futures = "0.3.8"
 kube = { path = "../kube", version = "^0.59.0", default-features = false, features = ["client", "rustls-tls"] }
-k8s-openapi = { version = "0.13.0", features = ["v1_20"], default-features = false }
+k8s-openapi = { version = "0.13.0", features = ["v1_21"], default-features = false }
 log = "0.4.11"
 serde_json = "1.0.61"
 tokio = { version = "1.0.1", features = ["full"] }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -18,7 +18,7 @@ anyhow = "1.0.37"
 env_logger = "0.8.2"
 futures = "0.3.8"
 kube = { path = "../kube", version = "^0.59.0", default-features = false, features = ["client", "rustls-tls"] }
-k8s-openapi = { version = "0.13.0", features = ["v1_21"], default-features = false }
+k8s-openapi = { version = "0.13.0", features = ["v1_22"], default-features = false }
 log = "0.4.11"
 serde_json = "1.0.61"
 tokio = { version = "1.0.1", features = ["full"] }


### PR DESCRIPTION
slightly dodgy because we need to do one of:

- pin k8s-openapi to v1_22 to test legacy features (tested in crd_api)
- pin k8s-openapi to v1_21 and hope the legacy paths work (cant test)
- build multiple k8s-openapi versions in CI

maybe the latter is the best. can pin latest everywhere, and have
examples lag behind as the only place to test legacy?