### PR TITLE
Add helper for fully deleting an object

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -189,3 +189,7 @@ path = "custom_client_trace.rs"
 [[example]]
 name = "secret_syncer"
 path = "secret_syncer.rs"
+
+[[example]]
+name = "secret_deleter"
+path = "secret_deleter.rs"

--- a/examples/pod_watcher.rs
+++ b/examples/pod_watcher.rs
@@ -31,7 +31,7 @@ fn pod_unready(p: &Pod) -> Option<String> {
     let status = p.status.as_ref().unwrap();
     if let Some(conds) = &status.conditions {
         let failed = conds
-            .into_iter()
+            .iter()
             .filter(|c| c.type_ == "Ready" && c.status == "False")
             .map(|c| c.message.clone().unwrap_or_default())
             .collect::<Vec<_>>()

--- a/examples/secret_deleter.rs
+++ b/examples/secret_deleter.rs
@@ -1,0 +1,14 @@
+// Demonstrates deleting a resource and waiting for it to be finalized
+
+use k8s_openapi::api::core::v1::Secret;
+use kube::api::DeleteParams;
+use kube_runtime::finalizer::finalize_and_delete;
+
+#[tokio::main]
+async fn main() -> color_eyre::Result<()> {
+    env_logger::init();
+    let kube = kube::Client::try_default().await?;
+    let cms = kube::Api::<Secret>::default_namespaced(kube.clone());
+    finalize_and_delete(&cms, "kubers-deleter-example-secret", &DeleteParams::default()).await?;
+    Ok(())
+}

--- a/examples/secret_syncer.rs
+++ b/examples/secret_syncer.rs
@@ -1,4 +1,4 @@
-// Demonstrates a controller some outside resource that it needs to clean up when the owner is deleted
+// Demonstrates a controller managing some outside resource that it needs to clean up when the owner is deleted
 
 // NOTE: This is designed to demonstrate how to use finalizers, but is not in itself a good use case for them.
 // If you actually want to clean up other Kubernetes objects then you should use `ownerReferences` instead and let

--- a/kube-core/src/subresource.rs
+++ b/kube-core/src/subresource.rs
@@ -279,7 +279,7 @@ impl AttachParams {
             qp.append_pair("tty", "true");
         }
         if let Some(container) = &self.container {
-            qp.append_pair("container", &container);
+            qp.append_pair("container", container);
         }
     }
 }

--- a/kube-runtime/src/lib.rs
+++ b/kube-runtime/src/lib.rs
@@ -11,11 +11,11 @@
 #![deny(unsafe_code)]
 #![deny(clippy::all)]
 #![deny(clippy::pedantic)]
-// Makes for confusing SNAFU context selectors
-#![allow(clippy::pub_enum_variant_names)]
 // Triggered by many derive macros (kube-derive, derivative)
 #![allow(clippy::default_trait_access)]
 #![allow(clippy::type_repetition_in_bounds)]
+// Triggered by Tokio macros
+#![allow(clippy::semicolon_if_nothing_returned)]
 
 pub mod controller;
 pub mod finalizer;

--- a/kube-runtime/src/reflector/store.rs
+++ b/kube-runtime/src/reflector/store.rs
@@ -50,11 +50,11 @@ where
         match event {
             watcher::Event::Applied(obj) => {
                 self.store
-                    .insert(ObjectRef::from_obj_with(&obj, self.dyntype.clone()), obj.clone());
+                    .insert(ObjectRef::from_obj_with(obj, self.dyntype.clone()), obj.clone());
             }
             watcher::Event::Deleted(obj) => {
                 self.store
-                    .remove(&ObjectRef::from_obj_with(&obj, self.dyntype.clone()));
+                    .remove(&ObjectRef::from_obj_with(obj, self.dyntype.clone()));
             }
             watcher::Event::Restarted(new_objs) => {
                 let new_objs = new_objs


### PR DESCRIPTION
`Api::delete` returns immediately, even if finalizers are blocking the deletion. This fills that gap.

Open questions:

- Should this be documented on `Api::delete`?
- Should we also support deleting collections?
- Does this really belong in `kube_runtime::finalizer`? It feels weird to have two `Error` enums in the same module, but I couldn't come up with a better name for it... Maybe the existing finalizer stuff should be moved into `kube_runtime::controller::finalizer`?
- Needs to be documented in the changelog
- Is this missing anything before it could replace operator-rs' `ensure_deleted`? (https://github.com/stackabletech/operator-rs/blob/0b5de6fe88b507dbaf62e7b6d931c545daefcac5/src/client.rs#L335, cc @soenkeliebau)