### PR TITLE
Add `restart` utility function.

### DIFF
--- a/kube-core/Cargo.toml
+++ b/kube-core/Cargo.toml
@@ -25,6 +25,7 @@ form_urlencoded = "1.0.1"
 http = "0.2.2"
 json-patch = { version = "0.2.6", optional = true }
 once_cell = "1.8.0"
+chrono = "0.4.19"
 
 [dependencies.k8s-openapi]
 version = "0.13.0"

--- a/kube-core/src/lib.rs
+++ b/kube-core/src/lib.rs
@@ -41,6 +41,8 @@ pub mod response;
 
 pub mod subresource;
 
+pub mod util;
+
 pub mod watch;
 pub use watch::WatchEvent;
 

--- a/kube-core/src/util.rs
+++ b/kube-core/src/util.rs
@@ -1,0 +1,36 @@
+//! Utils and helpers
+
+use crate::{
+    params::{Patch, PatchParams},
+    Request, Result,
+};
+use chrono::Utc;
+use k8s_openapi::api::apps::v1::{DaemonSet, Deployment, ReplicaSet, StatefulSet};
+
+/// Restartable Resource marker trait
+pub trait Restart {}
+
+impl Restart for Deployment {}
+impl Restart for DaemonSet {}
+impl Restart for StatefulSet {}
+impl Restart for ReplicaSet {}
+
+impl Request {
+    /// Restart a resource
+    pub fn restart(&self, name: &str) -> Result<http::Request<Vec<u8>>> {
+        let patch = serde_json::json!({
+          "spec": {
+            "template": {
+              "metadata": {
+                "annotations": {
+                  "kube.kubernetes.io/restartedAt": Utc::now().to_rfc3339()
+                }
+              }
+            }
+          }
+        });
+
+        let pparams = PatchParams::default();
+        self.patch(name, &pparams, &Patch::Merge(patch))
+    }
+}

--- a/kube/src/api/mod.rs
+++ b/kube/src/api/mod.rs
@@ -11,6 +11,8 @@ mod subresource;
 pub use subresource::{Attach, AttachParams, Execute};
 pub use subresource::{Evict, EvictParams, Log, LogParams, ScaleSpec, ScaleStatus};
 
+mod util;
+
 // Re-exports from kube-core
 #[cfg(feature = "admission")]
 #[cfg_attr(docsrs, doc(cfg(feature = "admission")))]

--- a/kube/src/api/util.rs
+++ b/kube/src/api/util.rs
@@ -1,0 +1,18 @@
+use crate::{
+    api::{Api, Resource},
+    Result,
+};
+use kube_core::util::Restart;
+use serde::de::DeserializeOwned;
+
+impl<K> Api<K>
+where
+    K: Restart + Resource + DeserializeOwned,
+{
+    /// Trigger a restart of a Resource.
+    pub async fn restart(&self, name: &str) -> Result<K> {
+        let mut req = self.request.restart(name)?;
+        req.extensions_mut().insert("restart");
+        self.client.request::<K>(req).await
+    }
+}


### PR DESCRIPTION
This PR adds the `restart(name)` function on `Api<K>` where `K` is one of `Deployment`, `DaemonSet`, `StatefulSet` or `ReplicaSet`.
It also adds the complementary method to the `kube` crate.

To implement this functionality, I chose to add `chrono` to the `kube-core` crate, as the alternatives involved lots of code and it's already used in the bigger crate.

This fixes #630 by implementing the necessary functionality.

I hope this PR is acceptable.
Thank you.