### PR TITLE
Start Refining Errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@ UNRELEASED
 ===================
  * see https://github.com/kube-rs/kube-rs/compare/0.63.2...master
 
+ * BREAKING: The following breaking changes were made as a part of an effort to refine errors (#688).
+   - Removed `kube::core::Error` and `kube::core::Result`. `kube::core::Error` was replaced by more specific errors as described below.
+   - Replaced `kube::core::Error::InvalidGroupVersion` with `kube::core::gvk::ParseGroupVersionError`.
+   - Changed the error returned from `kube::core::admission::AdmissionRequest::with_patch` to `kube::core::admission::SerializePatchError` (was `kube::core::Error::SerdeError`).
+   - Changed the error associated with `TryInto<AdmissionRequest<T>` to `kube::core::admission::ConvertAdmissionReviewError` (was `kube::core::Error::RequestValidation`).
+   - Changed the error returned from methods of `kube::core::Request` to `kube::core::request::Error` (was `kube::core::Error`). `kube::core::request::Error` represents possible errors when building an HTTP request. The removed `kube::core::Error` had `RequestValidation(String)`, `SerdeError(serde_json::Error)`, and `HttpError(http::Error)` variants. They are now `Validation(String)`, `SerializeBody(serde_json::Error)`, and  `BuildRequest(http::Error)` respectively in `kube::core::request::Error`.
+   - Replaced `kube::Error::RequestValidation(String)` variant with `kube::Error::BuildRequest(kube::core::request::Error)`. This variant includes possible errors when building an HTTP request as described above, and contains errors that was previously grouped under `kube::Error::SerdeError` and `kube::Error::HttpError`.
+   - Removed `impl From<T> for kube::Error` for the following types: `std::io::Error`, `hyper::Error`, `tower::BoxError`, `std::string::FromUtf8Error`, `http::Error`, `http::uri::InvalidUri`, `serde_json::Error`, `openssl::error::ErrorStack`, `kube::core::Error`, `kube::error::ConfigError`, `kube::error::DisoveryError`, `kube::error::OAuthError`.
+   - Changed variants of error enums in `kube::runtime`. Replaced `snafu` with `thiserror`.
+
 0.63.2 / 2021-10-28
 ===================
 * `kube::runtime::events`: fix build and hide module on kubernetes < 1.19 (events/v1 missing there) - [#685](https://github.com/kube-rs/kube-rs/issues/685)

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -40,7 +40,6 @@ serde_json = "1.0.68"
 serde_yaml = "0.8.21"
 tokio = { version = "1.12.0", features = ["full"] }
 color-eyre = "0.5.10"
-snafu = { version = "0.6.10", features = ["futures"] }
 # Some Api::delete methods use Either
 either = "1.6.1"
 schemars = "0.8.6"
@@ -54,6 +53,7 @@ json-patch = "0.2.6"
 tower = { version = "0.4.6" }
 tower-http = { version = "0.1.0", features = ["trace", "decompression-gzip"] }
 hyper = { version = "0.14.13", features = ["client", "http1", "stream", "tcp"] }
+thiserror = "1.0.29"
 
 [[example]]
 name = "configmapgen_controller"

--- a/examples/configmapgen_controller.rs
+++ b/examples/configmapgen_controller.rs
@@ -12,21 +12,16 @@ use kube::{
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use snafu::{Backtrace, OptionExt, ResultExt, Snafu};
 use std::{collections::BTreeMap, io::BufRead};
+use thiserror::Error;
 use tokio::time::Duration;
 
-#[derive(Debug, Snafu)]
+#[derive(Debug, Error)]
 enum Error {
-    #[snafu(display("Failed to create ConfigMap: {}", source))]
-    ConfigMapCreationFailed {
-        source: kube::Error,
-        backtrace: Backtrace,
-    },
-    MissingObjectKey {
-        name: &'static str,
-        backtrace: Backtrace,
-    },
+    #[error("Failed to create ConfigMap: {0}")]
+    ConfigMapCreationFailed(#[source] kube::Error),
+    #[error("MissingObjectKey: {name}")]
+    MissingObjectKey { name: &'static str },
 }
 
 #[derive(CustomResource, Debug, Clone, Deserialize, Serialize, JsonSchema)]
@@ -42,10 +37,10 @@ fn object_to_owner_reference<K: Resource<DynamicType = ()>>(
     Ok(OwnerReference {
         api_version: K::api_version(&()).to_string(),
         kind: K::kind(&()).to_string(),
-        name: meta.name.context(MissingObjectKey {
+        name: meta.name.ok_or(Error::MissingObjectKey {
             name: ".metadata.name",
         })?,
-        uid: meta.uid.context(MissingObjectKey {
+        uid: meta.uid.ok_or(Error::MissingObjectKey {
             name: ".metadata.uid",
         })?,
         ..OwnerReference::default()
@@ -76,20 +71,24 @@ async fn reconcile(generator: ConfigMapGenerator, ctx: Context<Data>) -> Result<
     };
     let cm_api = Api::<ConfigMap>::namespaced(
         client.clone(),
-        generator.metadata.namespace.as_ref().context(MissingObjectKey {
-            name: ".metadata.namespace",
-        })?,
+        generator
+            .metadata
+            .namespace
+            .as_ref()
+            .ok_or(Error::MissingObjectKey {
+                name: ".metadata.namespace",
+            })?,
     );
     cm_api
         .patch(
-            cm.metadata.name.as_ref().context(MissingObjectKey {
+            cm.metadata.name.as_ref().ok_or(Error::MissingObjectKey {
                 name: ".metadata.name",
             })?,
             &PatchParams::apply("configmapgenerator.kube-rt.nullable.se"),
             &Patch::Apply(&cm),
         )
         .await
-        .context(ConfigMapCreationFailed)?;
+        .map_err(Error::ConfigMapCreationFailed)?;
     Ok(ReconcilerAction {
         requeue_after: Some(Duration::from_secs(300)),
     })

--- a/kube-client/src/api/core_methods.rs
+++ b/kube-client/src/api/core_methods.rs
@@ -25,7 +25,7 @@ where
     /// }
     /// ```
     pub async fn get(&self, name: &str) -> Result<K> {
-        let mut req = self.request.get(name)?;
+        let mut req = self.request.get(name).map_err(Error::BuildRequest)?;
         req.extensions_mut().insert("get");
         self.client.request::<K>(req).await
     }
@@ -49,7 +49,7 @@ where
     /// }
     /// ```
     pub async fn list(&self, lp: &ListParams) -> Result<ObjectList<K>> {
-        let mut req = self.request.list(lp)?;
+        let mut req = self.request.list(lp).map_err(Error::BuildRequest)?;
         req.extensions_mut().insert("list");
         self.client.request::<ObjectList<K>>(req).await
     }
@@ -75,7 +75,7 @@ where
         K: Serialize,
     {
         let bytes = serde_json::to_vec(&data).map_err(Error::SerdeError)?;
-        let mut req = self.request.create(pp, bytes)?;
+        let mut req = self.request.create(pp, bytes).map_err(Error::BuildRequest)?;
         req.extensions_mut().insert("create");
         self.client.request::<K>(req).await
     }
@@ -103,7 +103,7 @@ where
     /// }
     /// ```
     pub async fn delete(&self, name: &str, dp: &DeleteParams) -> Result<Either<K, Status>> {
-        let mut req = self.request.delete(name, dp)?;
+        let mut req = self.request.delete(name, dp).map_err(Error::BuildRequest)?;
         req.extensions_mut().insert("delete");
         self.client.request_status::<K>(req).await
     }
@@ -140,7 +140,10 @@ where
         dp: &DeleteParams,
         lp: &ListParams,
     ) -> Result<Either<ObjectList<K>, Status>> {
-        let mut req = self.request.delete_collection(dp, lp)?;
+        let mut req = self
+            .request
+            .delete_collection(dp, lp)
+            .map_err(Error::BuildRequest)?;
         req.extensions_mut().insert("delete_collection");
         self.client.request_status::<ObjectList<K>>(req).await
     }
@@ -180,7 +183,7 @@ where
         pp: &PatchParams,
         patch: &Patch<P>,
     ) -> Result<K> {
-        let mut req = self.request.patch(name, pp, patch)?;
+        let mut req = self.request.patch(name, pp, patch).map_err(Error::BuildRequest)?;
         req.extensions_mut().insert("patch");
         self.client.request::<K>(req).await
     }
@@ -234,7 +237,10 @@ where
         K: Serialize,
     {
         let bytes = serde_json::to_vec(&data).map_err(Error::SerdeError)?;
-        let mut req = self.request.replace(name, pp, bytes)?;
+        let mut req = self
+            .request
+            .replace(name, pp, bytes)
+            .map_err(Error::BuildRequest)?;
         req.extensions_mut().insert("replace");
         self.client.request::<K>(req).await
     }
@@ -281,7 +287,7 @@ where
         lp: &ListParams,
         version: &str,
     ) -> Result<impl Stream<Item = Result<WatchEvent<K>>>> {
-        let mut req = self.request.watch(lp, version)?;
+        let mut req = self.request.watch(lp, version).map_err(Error::BuildRequest)?;
         req.extensions_mut().insert("watch");
         self.client.request_events::<K>(req).await
     }

--- a/kube-client/src/api/core_methods.rs
+++ b/kube-client/src/api/core_methods.rs
@@ -3,7 +3,7 @@ use futures::Stream;
 use serde::{de::DeserializeOwned, Serialize};
 use std::fmt::Debug;
 
-use crate::{api::Api, Result};
+use crate::{api::Api, Error, Result};
 use kube_core::{object::ObjectList, params::*, response::Status, WatchEvent};
 
 /// PUSH/PUT/POST/GET abstractions
@@ -74,7 +74,7 @@ where
     where
         K: Serialize,
     {
-        let bytes = serde_json::to_vec(&data)?;
+        let bytes = serde_json::to_vec(&data).map_err(Error::SerdeError)?;
         let mut req = self.request.create(pp, bytes)?;
         req.extensions_mut().insert("create");
         self.client.request::<K>(req).await
@@ -233,7 +233,7 @@ where
     where
         K: Serialize,
     {
-        let bytes = serde_json::to_vec(&data)?;
+        let bytes = serde_json::to_vec(&data).map_err(Error::SerdeError)?;
         let mut req = self.request.replace(name, pp, bytes)?;
         req.extensions_mut().insert("replace");
         self.client.request::<K>(req).await

--- a/kube-client/src/api/core_methods.rs
+++ b/kube-client/src/api/core_methods.rs
@@ -17,7 +17,7 @@ where
     /// use kube::{Api, Client};
     /// use k8s_openapi::api::core::v1::Pod;
     /// #[tokio::main]
-    /// async fn main() -> Result<(), kube::Error> {
+    /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
     ///     let client = Client::try_default().await?;
     ///     let pods: Api<Pod> = Api::namespaced(client, "apps");
     ///     let p: Pod = pods.get("blog").await?;
@@ -38,7 +38,7 @@ where
     /// use kube::{api::{Api, ListParams, ResourceExt}, Client};
     /// use k8s_openapi::api::core::v1::Pod;
     /// #[tokio::main]
-    /// async fn main() -> Result<(), kube::Error> {
+    /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
     ///     let client = Client::try_default().await?;
     ///     let pods: Api<Pod> = Api::namespaced(client, "apps");
     ///     let lp = ListParams::default().labels("app=blog"); // for this app only
@@ -93,7 +93,7 @@ where
     /// use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1 as apiexts;
     /// use apiexts::CustomResourceDefinition;
     /// #[tokio::main]
-    /// async fn main() -> Result<(), kube::Error> {
+    /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
     ///     let client = Client::try_default().await?;
     ///     let crds: Api<CustomResourceDefinition> = Api::all(client);
     ///     crds.delete("foos.clux.dev", &DeleteParams::default()).await?
@@ -120,7 +120,7 @@ where
     /// use kube::{api::{Api, DeleteParams, ListParams, ResourceExt}, Client};
     /// use k8s_openapi::api::core::v1::Pod;
     /// #[tokio::main]
-    /// async fn main() -> Result<(), kube::Error> {
+    /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
     ///     let client = Client::try_default().await?;
     ///     let pods: Api<Pod> = Api::namespaced(client, "apps");
     ///     match pods.delete_collection(&DeleteParams::default(), &ListParams::default()).await? {
@@ -156,7 +156,7 @@ where
     /// use kube::{api::{Api, PatchParams, Patch, Resource}, Client};
     /// use k8s_openapi::api::core::v1::Pod;
     /// #[tokio::main]
-    /// async fn main() -> Result<(), kube::Error> {
+    /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
     ///     let client = Client::try_default().await?;
     ///     let pods: Api<Pod> = Api::namespaced(client, "apps");
     ///     let patch = serde_json::json!({
@@ -200,7 +200,7 @@ where
     /// use kube::{api::{Api, PostParams, ResourceExt}, Client};
     /// use k8s_openapi::api::batch::v1::Job;
     /// #[tokio::main]
-    /// async fn main() -> Result<(), kube::Error> {
+    /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
     ///     let client = Client::try_default().await?;
     ///     let jobs: Api<Job> = Api::namespaced(client, "apps");
     ///     let j = jobs.get("baz").await?;
@@ -261,7 +261,7 @@ where
     /// use k8s_openapi::api::batch::v1::Job;
     /// use futures::{StreamExt, TryStreamExt};
     /// #[tokio::main]
-    /// async fn main() -> Result<(), kube::Error> {
+    /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
     ///     let client = Client::try_default().await?;
     ///     let jobs: Api<Job> = Api::namespaced(client, "apps");
     ///     let lp = ListParams::default()

--- a/kube-client/src/api/subresource.rs
+++ b/kube-client/src/api/subresource.rs
@@ -5,7 +5,7 @@ use std::fmt::Debug;
 
 use crate::{
     api::{Api, Patch, PatchParams, PostParams},
-    Result,
+    Error, Result,
 };
 
 use kube_core::response::Status;
@@ -26,7 +26,10 @@ where
 {
     /// Fetch the scale subresource
     pub async fn get_scale(&self, name: &str) -> Result<Scale> {
-        let mut req = self.request.get_subresource("scale", name)?;
+        let mut req = self
+            .request
+            .get_subresource("scale", name)
+            .map_err(Error::BuildRequest)?;
         req.extensions_mut().insert("get_scale");
         self.client.request::<Scale>(req).await
     }
@@ -38,14 +41,20 @@ where
         pp: &PatchParams,
         patch: &Patch<P>,
     ) -> Result<Scale> {
-        let mut req = self.request.patch_subresource("scale", name, pp, patch)?;
+        let mut req = self
+            .request
+            .patch_subresource("scale", name, pp, patch)
+            .map_err(Error::BuildRequest)?;
         req.extensions_mut().insert("patch_scale");
         self.client.request::<Scale>(req).await
     }
 
     /// Replace the scale subresource
     pub async fn replace_scale(&self, name: &str, pp: &PostParams, data: Vec<u8>) -> Result<Scale> {
-        let mut req = self.request.replace_subresource("scale", name, pp, data)?;
+        let mut req = self
+            .request
+            .replace_subresource("scale", name, pp, data)
+            .map_err(Error::BuildRequest)?;
         req.extensions_mut().insert("replace_scale");
         self.client.request::<Scale>(req).await
     }
@@ -64,7 +73,10 @@ where
     ///
     /// This actually returns the whole K, with metadata, and spec.
     pub async fn get_status(&self, name: &str) -> Result<K> {
-        let mut req = self.request.get_subresource("status", name)?;
+        let mut req = self
+            .request
+            .get_subresource("status", name)
+            .map_err(Error::BuildRequest)?;
         req.extensions_mut().insert("get_status");
         self.client.request::<K>(req).await
     }
@@ -98,7 +110,10 @@ where
         pp: &PatchParams,
         patch: &Patch<P>,
     ) -> Result<K> {
-        let mut req = self.request.patch_subresource("status", name, pp, patch)?;
+        let mut req = self
+            .request
+            .patch_subresource("status", name, pp, patch)
+            .map_err(Error::BuildRequest)?;
         req.extensions_mut().insert("patch_status");
         self.client.request::<K>(req).await
     }
@@ -123,7 +138,10 @@ where
     /// }
     /// ```
     pub async fn replace_status(&self, name: &str, pp: &PostParams, data: Vec<u8>) -> Result<K> {
-        let mut req = self.request.replace_subresource("status", name, pp, data)?;
+        let mut req = self
+            .request
+            .replace_subresource("status", name, pp, data)
+            .map_err(Error::BuildRequest)?;
         req.extensions_mut().insert("replace_status");
         self.client.request::<K>(req).await
     }
@@ -157,14 +175,14 @@ where
 {
     /// Fetch logs as a string
     pub async fn logs(&self, name: &str, lp: &LogParams) -> Result<String> {
-        let mut req = self.request.logs(name, lp)?;
+        let mut req = self.request.logs(name, lp).map_err(Error::BuildRequest)?;
         req.extensions_mut().insert("logs");
         self.client.request_text(req).await
     }
 
     /// Fetch logs as a stream of bytes
     pub async fn log_stream(&self, name: &str, lp: &LogParams) -> Result<impl Stream<Item = Result<Bytes>>> {
-        let mut req = self.request.logs(name, lp)?;
+        let mut req = self.request.logs(name, lp).map_err(Error::BuildRequest)?;
         req.extensions_mut().insert("log_stream");
         self.client.request_text_stream(req).await
     }
@@ -195,7 +213,7 @@ where
 {
     /// Create an eviction
     pub async fn evict(&self, name: &str, ep: &EvictParams) -> Result<Status> {
-        let mut req = self.request.evict(name, ep)?;
+        let mut req = self.request.evict(name, ep).map_err(Error::BuildRequest)?;
         req.extensions_mut().insert("evict");
         self.client.request::<Status>(req).await
     }
@@ -239,7 +257,7 @@ where
 {
     /// Attach to pod
     pub async fn attach(&self, name: &str, ap: &AttachParams) -> Result<AttachedProcess> {
-        let mut req = self.request.attach(name, ap)?;
+        let mut req = self.request.attach(name, ap).map_err(Error::BuildRequest)?;
         req.extensions_mut().insert("attach");
         let stream = self.client.connect(req).await?;
         Ok(AttachedProcess::new(stream, ap))
@@ -294,7 +312,10 @@ where
         I: IntoIterator<Item = T>,
         T: Into<String>,
     {
-        let mut req = self.request.exec(name, command, ap)?;
+        let mut req = self
+            .request
+            .exec(name, command, ap)
+            .map_err(Error::BuildRequest)?;
         req.extensions_mut().insert("exec");
         let stream = self.client.connect(req).await?;
         Ok(AttachedProcess::new(stream, ap))

--- a/kube-client/src/api/subresource.rs
+++ b/kube-client/src/api/subresource.rs
@@ -89,7 +89,7 @@ where
     /// use kube::{api::{Api, PatchParams, Patch}, Client};
     /// use k8s_openapi::api::batch::v1::Job;
     /// #[tokio::main]
-    /// async fn main() -> Result<(), kube::Error> {
+    /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
     ///     let client = Client::try_default().await?;
     ///     let jobs: Api<Job> = Api::namespaced(client, "apps");
     ///     let mut j = jobs.get("baz").await?;
@@ -127,7 +127,7 @@ where
     /// use kube::{api::{Api, PostParams}, Client};
     /// use k8s_openapi::api::batch::v1::{Job, JobStatus};
     /// #[tokio::main]
-    /// async fn main() -> Result<(), kube::Error> {
+    /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
     ///     let client = Client::try_default().await?;
     ///     let jobs: Api<Job> = Api::namespaced(client, "apps");
     ///     let mut o = jobs.get_status("baz").await?; // retrieve partial object

--- a/kube-client/src/api/util.rs
+++ b/kube-client/src/api/util.rs
@@ -1,6 +1,6 @@
 use crate::{
     api::{Api, Resource},
-    Result,
+    Error, Result,
 };
 use kube_core::util::Restart;
 use serde::de::DeserializeOwned;
@@ -11,7 +11,7 @@ where
 {
     /// Trigger a restart of a Resource.
     pub async fn restart(&self, name: &str) -> Result<K> {
-        let mut req = self.request.restart(name)?;
+        let mut req = self.request.restart(name).map_err(Error::BuildRequest)?;
         req.extensions_mut().insert("restart");
         self.client.request::<K>(req).await
     }

--- a/kube-client/src/client/middleware/refresh_token.rs
+++ b/kube-client/src/client/middleware/refresh_token.rs
@@ -8,7 +8,7 @@ use http::{header::AUTHORIZATION, Request, Response};
 use pin_project::pin_project;
 use tower::{layer::Layer, BoxError, Service};
 
-use crate::{client::auth::RefreshableToken, Result};
+use crate::client::auth::RefreshableToken;
 
 /// `Layer` to decorate the request with `Authorization` header with refreshable token.
 /// Token is refreshed automatically when necessary.

--- a/kube-client/src/client/tls.rs
+++ b/kube-client/src/client/tls.rs
@@ -40,10 +40,13 @@ pub mod native_tls {
     // TODO Replace this with pure Rust implementation to avoid depending on openssl on macOS and Win
     fn pkcs12_from_pem(pem: &[u8], password: &str) -> Result<Vec<u8>> {
         use openssl::{pkcs12::Pkcs12, pkey::PKey, x509::X509};
-        let x509 = X509::from_pem(pem)?;
-        let pkey = PKey::private_key_from_pem(pem)?;
-        let p12 = Pkcs12::builder().build(password, "kubeconfig", &pkey, &x509)?;
-        let der = p12.to_der()?;
+        // TODO These are all treated as the same error. Add specific errors.
+        let x509 = X509::from_pem(pem).map_err(Error::OpensslError)?;
+        let pkey = PKey::private_key_from_pem(pem).map_err(Error::OpensslError)?;
+        let p12 = Pkcs12::builder()
+            .build(password, "kubeconfig", &pkey, &x509)
+            .map_err(Error::OpensslError)?;
+        let der = p12.to_der().map_err(Error::OpensslError)?;
         Ok(der)
     }
 }

--- a/kube-client/src/config/utils.rs
+++ b/kube-client/src/config/utils.rs
@@ -17,7 +17,7 @@ pub fn data_or_file_with_base64<P: AsRef<Path>>(data: &Option<String>, file: &Op
             .map_err(ConfigError::Base64Decode)
             .map_err(Error::Kubeconfig),
         (_, Some(f)) => read_file(f),
-        _ => Err(ConfigError::NoBase64FileOrData.into()),
+        _ => Err(Error::Kubeconfig(ConfigError::NoBase64FileOrData)),
     }?;
     //Ensure there is a trailing newline in the blob
     //Don't bother if the blob is empty
@@ -29,21 +29,19 @@ pub fn data_or_file_with_base64<P: AsRef<Path>>(data: &Option<String>, file: &Op
 
 pub fn read_file<P: AsRef<Path>>(file: P) -> Result<Vec<u8>> {
     fs::read(&file).map_err(|source| {
-        ConfigError::ReadFile {
+        Error::Kubeconfig(ConfigError::ReadFile {
             path: file.as_ref().into(),
             source,
-        }
-        .into()
+        })
     })
 }
 
 pub fn read_file_to_string<P: AsRef<Path>>(file: P) -> Result<String> {
     fs::read_to_string(&file).map_err(|source| {
-        ConfigError::ReadFile {
+        Error::Kubeconfig(ConfigError::ReadFile {
             path: file.as_ref().into(),
             source,
-        }
-        .into()
+        })
     })
 }
 

--- a/kube-client/src/discovery/apigroup.rs
+++ b/kube-client/src/discovery/apigroup.rs
@@ -18,7 +18,7 @@ use kube_core::gvk::{GroupVersion, GroupVersionKind, ParseGroupVersionError};
 /// ```no_run
 /// use kube::{Client, api::{Api, DynamicObject}, discovery, ResourceExt};
 /// #[tokio::main]
-/// async fn main() -> Result<(), kube::Error> {
+/// async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///     let client = Client::try_default().await?;
 ///     let apigroup = discovery::group(&client, "apiregistration.k8s.io").await?;
 ///      for (apiresource, caps) in apigroup.versioned_resources("v1") {
@@ -42,7 +42,7 @@ use kube_core::gvk::{GroupVersion, GroupVersionKind, ParseGroupVersionError};
 /// ```no_run
 /// use kube::{Client, api::{Api, DynamicObject}, discovery, ResourceExt};
 /// #[tokio::main]
-/// async fn main() -> Result<(), kube::Error> {
+/// async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///     let client = Client::try_default().await?;
 ///     let apigroup = discovery::group(&client, "apiregistration.k8s.io").await?;
 ///     let (ar, caps) = apigroup.recommended_kind("APIService").unwrap();
@@ -222,7 +222,7 @@ impl ApiGroup {
     /// ```no_run
     /// use kube::{Client, api::{Api, DynamicObject}, discovery::{self, verbs}, ResourceExt};
     /// #[tokio::main]
-    /// async fn main() -> Result<(), kube::Error> {
+    /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
     ///     let client = Client::try_default().await?;
     ///     let apigroup = discovery::group(&client, "apiregistration.k8s.io").await?;
     ///     for (ar, caps) in apigroup.recommended_resources() {
@@ -249,7 +249,7 @@ impl ApiGroup {
     /// ```no_run
     /// use kube::{Client, api::{Api, DynamicObject}, discovery, ResourceExt};
     /// #[tokio::main]
-    /// async fn main() -> Result<(), kube::Error> {
+    /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
     ///     let client = Client::try_default().await?;
     ///     let apigroup = discovery::group(&client, "apiregistration.k8s.io").await?;
     ///     let (ar, caps) = apigroup.recommended_kind("APIService").unwrap();

--- a/kube-client/src/discovery/mod.rs
+++ b/kube-client/src/discovery/mod.rs
@@ -89,7 +89,7 @@ impl Discovery {
     /// ```no_run
     /// use kube::{Client, api::{Api, DynamicObject}, discovery::{Discovery, verbs, Scope}, ResourceExt};
     /// #[tokio::main]
-    /// async fn main() -> Result<(), kube::Error> {
+    /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
     ///     let client = Client::try_default().await?;
     ///     let discovery = Discovery::new(client.clone()).run().await?;
     ///     for group in discovery.groups() {

--- a/kube-client/src/discovery/oneshot.rs
+++ b/kube-client/src/discovery/oneshot.rs
@@ -26,7 +26,7 @@ use kube_core::{
 /// ```no_run
 /// use kube::{Client, api::{Api, DynamicObject}, discovery, ResourceExt};
 /// #[tokio::main]
-/// async fn main() -> Result<(), kube::Error> {
+/// async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///     let client = Client::try_default().await?;
 ///     let apigroup = discovery::group(&client, "apiregistration.k8s.io").await?;
 ///     let (ar, caps) = apigroup.recommended_kind("APIService").unwrap();
@@ -62,7 +62,7 @@ pub async fn group(client: &Client, apigroup: &str) -> Result<ApiGroup> {
 /// ```no_run
 /// use kube::{Client, api::{Api, DynamicObject}, discovery, ResourceExt};
 /// #[tokio::main]
-/// async fn main() -> Result<(), kube::Error> {
+/// async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///     let client = Client::try_default().await?;
 ///     let gv = "apiregistration.k8s.io/v1".parse()?;
 ///     let apigroup = discovery::pinned_group(&client, &gv).await?;
@@ -90,7 +90,7 @@ pub async fn pinned_group(client: &Client, gv: &GroupVersion) -> Result<ApiGroup
 /// ```no_run
 /// use kube::{Client, api::{Api, DynamicObject, GroupVersionKind}, discovery, ResourceExt};
 /// #[tokio::main]
-/// async fn main() -> Result<(), kube::Error> {
+/// async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///     let client = Client::try_default().await?;
 ///     let gvk = GroupVersionKind::gvk("apiregistration.k8s.io", "v1", "APIService");
 ///     let (ar, caps) = discovery::pinned_kind(&client, &gvk).await?;

--- a/kube-client/src/discovery/oneshot.rs
+++ b/kube-client/src/discovery/oneshot.rs
@@ -12,7 +12,7 @@
 //! [`oneshot::pinned_kind`]: crate::discovery::pinned_kind
 
 use super::ApiGroup;
-use crate::{error::DiscoveryError, Client, Result};
+use crate::{error::DiscoveryError, Client, Error, Result};
 use kube_core::{
     discovery::{ApiCapabilities, ApiResource},
     gvk::{GroupVersion, GroupVersionKind},
@@ -50,7 +50,9 @@ pub async fn group(client: &Client, apigroup: &str) -> Result<ApiGroup> {
             return ApiGroup::query_apis(client, g).await;
         }
     }
-    Err(DiscoveryError::MissingApiGroup(apigroup.to_string()).into())
+    Err(Error::Discovery(DiscoveryError::MissingApiGroup(
+        apigroup.to_string(),
+    )))
 }
 
 /// Discovers all APIs available under a certain group at a pinned version

--- a/kube-client/src/discovery/parse.rs
+++ b/kube-client/src/discovery/parse.rs
@@ -1,5 +1,5 @@
 //! Abstractions on top of k8s_openapi::apimachinery::pkg::apis::meta::v1
-use crate::{error::DiscoveryError, Result};
+use crate::{error::DiscoveryError, Error, Result};
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::{APIResource, APIResourceList};
 use kube_core::{
     discovery::{ApiCapabilities, ApiResource, Scope},
@@ -29,7 +29,7 @@ pub(crate) fn parse_apicapabilities(list: &APIResourceList, name: &str) -> Resul
         .resources
         .iter()
         .find(|r| r.name == name)
-        .ok_or_else(|| DiscoveryError::MissingResource(name.into()))?;
+        .ok_or_else(|| Error::Discovery(DiscoveryError::MissingResource(name.into())))?;
     let scope = if ar.namespaced {
         Scope::Namespaced
     } else {

--- a/kube-client/src/error.rs
+++ b/kube-client/src/error.rs
@@ -1,8 +1,10 @@
 //! Error handling in [`kube`][crate]
-use http::header::InvalidHeaderValue;
-pub use kube_core::ErrorResponse;
 use std::path::PathBuf;
+
+use http::header::InvalidHeaderValue;
 use thiserror::Error;
+
+pub use kube_core::ErrorResponse;
 
 /// Possible errors when working with [`kube`][crate]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "config", feature = "client"))))]
@@ -68,9 +70,9 @@ pub enum Error {
     #[error("Error parsing response")]
     RequestParse,
 
-    /// A request validation failed
-    #[error("Request validation failed with {0}")]
-    RequestValidation(String),
+    /// Failed to build request
+    #[error("Failed to build request: {0}")]
+    BuildRequest(#[source] kube_core::request::Error),
 
     /// Configuration error
     #[error("Error loading kubeconfig: {0}")]
@@ -271,15 +273,4 @@ pub enum DiscoveryError {
     MissingResource(String),
     #[error("Empty Api Group: {0}")]
     EmptyApiGroup(String),
-}
-
-// TODO Remove this
-impl From<kube_core::Error> for Error {
-    fn from(error: kube_core::Error) -> Self {
-        match error {
-            kube_core::Error::RequestValidation(s) => Error::RequestValidation(s),
-            kube_core::Error::SerdeError(e) => Error::SerdeError(e),
-            kube_core::Error::HttpError(e) => Error::HttpError(e),
-        }
-    }
 }

--- a/kube-client/src/error.rs
+++ b/kube-client/src/error.rs
@@ -280,9 +280,6 @@ impl From<kube_core::Error> for Error {
             kube_core::Error::RequestValidation(s) => Error::RequestValidation(s),
             kube_core::Error::SerdeError(e) => Error::SerdeError(e),
             kube_core::Error::HttpError(e) => Error::HttpError(e),
-            kube_core::Error::InvalidGroupVersion(s) => {
-                Error::Discovery(DiscoveryError::InvalidGroupVersion(s))
-            }
         }
     }
 }

--- a/kube-client/src/error.rs
+++ b/kube-client/src/error.rs
@@ -19,20 +19,20 @@ pub enum Error {
 
     /// ConnectionError for when TcpStream fails to connect.
     #[error("ConnectionError: {0}")]
-    Connection(std::io::Error),
+    Connection(#[source] std::io::Error),
 
     /// Hyper error
     #[cfg(feature = "client")]
     #[error("HyperError: {0}")]
-    HyperError(#[from] hyper::Error),
+    HyperError(#[source] hyper::Error),
     /// Service error
     #[cfg(feature = "client")]
     #[error("ServiceError: {0}")]
-    Service(tower::BoxError),
+    Service(#[source] tower::BoxError),
 
     /// UTF-8 Error
     #[error("UTF-8 Error: {0}")]
-    FromUtf8(#[from] std::string::FromUtf8Error),
+    FromUtf8(#[source] std::string::FromUtf8Error),
 
     /// Returned when failed to find a newline character within max length.
     /// Only returned by `Client::request_events` and this should never happen as
@@ -42,19 +42,19 @@ pub enum Error {
 
     /// Returned on `std::io::Error` when reading event stream.
     #[error("Error reading events stream: {0}")]
-    ReadEvents(std::io::Error),
+    ReadEvents(#[source] std::io::Error),
 
     /// Http based error
     #[error("HttpError: {0}")]
-    HttpError(#[from] http::Error),
+    HttpError(#[source] http::Error),
 
     /// Failed to construct a URI.
-    #[error(transparent)]
-    InvalidUri(#[from] http::uri::InvalidUri),
+    #[error("InvalidUri: {0}")]
+    InvalidUri(#[source] http::uri::InvalidUri),
 
     /// Common error case when requesting parsing into own structs
     #[error("Error deserializing response")]
-    SerdeError(#[from] serde_json::Error),
+    SerdeError(#[source] serde_json::Error),
 
     /// Error building a request
     #[error("Error building request")]
@@ -74,11 +74,11 @@ pub enum Error {
 
     /// Configuration error
     #[error("Error loading kubeconfig: {0}")]
-    Kubeconfig(#[from] ConfigError),
+    Kubeconfig(#[source] ConfigError),
 
     /// Discovery errors
     #[error("Error from discovery: {0}")]
-    Discovery(#[from] DiscoveryError),
+    Discovery(#[source] DiscoveryError),
 
     /// An error with configuring SSL occured
     #[error("SslError: {0}")]
@@ -88,7 +88,7 @@ pub enum Error {
     #[cfg(feature = "native-tls")]
     #[cfg_attr(docsrs, doc(cfg(feature = "native-tls")))]
     #[error("OpensslError: {0}")]
-    OpensslError(#[from] openssl::error::ErrorStack),
+    OpensslError(#[source] openssl::error::ErrorStack),
 
     /// The server did not respond with [`SWITCHING_PROTOCOLS`] status when upgrading the
     /// connection.
@@ -179,7 +179,7 @@ pub enum ConfigError {
     #[cfg(feature = "oauth")]
     #[cfg_attr(docsrs, doc(cfg(feature = "oauth")))]
     #[error("OAuth Error: {0}")]
-    OAuth(#[from] OAuthError),
+    OAuth(#[source] OAuthError),
 
     #[error("Unable to load config file: {0}")]
     LoadConfigFile(#[source] Box<Error>),
@@ -256,14 +256,6 @@ pub enum OAuthError {
     Unknown(String),
 }
 
-#[cfg(feature = "oauth")]
-#[cfg_attr(docsrs, doc(cfg(feature = "oauth")))]
-impl From<OAuthError> for Error {
-    fn from(e: OAuthError) -> Self {
-        ConfigError::OAuth(e).into()
-    }
-}
-
 #[derive(Error, Debug)]
 // Redundant with the error messages and machine names
 #[allow(missing_docs)]
@@ -281,6 +273,7 @@ pub enum DiscoveryError {
     EmptyApiGroup(String),
 }
 
+// TODO Remove this
 impl From<kube_core::Error> for Error {
     fn from(error: kube_core::Error) -> Self {
         match error {

--- a/kube-client/src/lib.rs
+++ b/kube-client/src/lib.rs
@@ -15,7 +15,7 @@
 //! use k8s_openapi::api::core::v1::Pod;
 //!
 //! #[tokio::main]
-//! async fn main() -> Result<(), kube_client::Error> {
+//! async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //!     // Read the environment to find config for kube client.
 //!     // Note that this tries an in-cluster configuration first,
 //!     // then falls back on a kubeconfig file.

--- a/kube-core/src/dynamic.rs
+++ b/kube-core/src/dynamic.rs
@@ -92,7 +92,6 @@ mod test {
         params::{Patch, PatchParams, PostParams},
         request::Request,
         resource::Resource,
-        Result,
     };
     #[test]
     fn raw_custom_resource() {
@@ -112,14 +111,13 @@ mod test {
     }
 
     #[test]
-    fn raw_resource_in_default_group() -> Result<()> {
+    fn raw_resource_in_default_group() {
         let gvk = GroupVersionKind::gvk("", "v1", "Service");
         let api_resource = ApiResource::from_gvk(&gvk);
         let url = DynamicObject::url_path(&api_resource, None);
         let pp = PostParams::default();
-        let req = Request::new(url).create(&pp, vec![])?;
+        let req = Request::new(url).create(&pp, vec![]).unwrap();
         assert_eq!(req.uri(), "/api/v1/services?");
-        Ok(())
     }
 
     #[cfg(feature = "derive")]

--- a/kube-core/src/error.rs
+++ b/kube-core/src/error.rs
@@ -1,22 +1,6 @@
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-/// Core error types.
-#[derive(Error, Debug)]
-pub enum Error {
-    /// A request validation failed
-    #[error("Request validation failed with {0}")]
-    RequestValidation(String),
-
-    /// Common error case when requesting parsing into own structs
-    #[error("Error deserializing response")]
-    SerdeError(#[source] serde_json::Error),
-
-    /// Http based error
-    #[error("HttpError: {0}")]
-    HttpError(#[source] http::Error),
-}
-
 /// An error response from the API.
 #[derive(Error, Deserialize, Serialize, Debug, Clone, Eq, PartialEq)]
 #[error("{message}: {reason}")]

--- a/kube-core/src/error.rs
+++ b/kube-core/src/error.rs
@@ -10,11 +10,11 @@ pub enum Error {
 
     /// Common error case when requesting parsing into own structs
     #[error("Error deserializing response")]
-    SerdeError(#[from] serde_json::Error),
+    SerdeError(#[source] serde_json::Error),
 
     /// Http based error
     #[error("HttpError: {0}")]
-    HttpError(#[from] http::Error),
+    HttpError(#[source] http::Error),
 
     /// Invalid GroupVersion
     #[error("Invalid GroupVersion: {0}")]

--- a/kube-core/src/error.rs
+++ b/kube-core/src/error.rs
@@ -15,10 +15,6 @@ pub enum Error {
     /// Http based error
     #[error("HttpError: {0}")]
     HttpError(#[source] http::Error),
-
-    /// Invalid GroupVersion
-    #[error("Invalid GroupVersion: {0}")]
-    InvalidGroupVersion(String),
 }
 
 /// An error response from the API.

--- a/kube-core/src/gvk.rs
+++ b/kube-core/src/gvk.rs
@@ -1,7 +1,13 @@
 //! Type information structs for dynamic resources.
-use crate::Error;
-use serde::{Deserialize, Serialize};
 use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+#[error("failed to parse group version: {0}")]
+/// Failed to parse group version.
+pub struct ParseGroupVersionError(pub String);
 
 /// Core information about an API Resource.
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq, Hash)]
@@ -44,14 +50,14 @@ impl GroupVersion {
 }
 
 impl FromStr for GroupVersion {
-    type Err = Error;
+    type Err = ParseGroupVersionError;
 
     fn from_str(gv: &str) -> Result<Self, Self::Err> {
         let gvsplit = gv.splitn(2, '/').collect::<Vec<_>>();
         let (group, version) = match *gvsplit.as_slice() {
             [g, v] => (g.to_string(), v.to_string()), // standard case
             [v] => ("".to_string(), v.to_string()),   // core v1 case
-            _ => return Err(Error::InvalidGroupVersion(gv.into())),
+            _ => return Err(ParseGroupVersionError(gv.into())),
         };
         Ok(Self { group, version })
     }

--- a/kube-core/src/lib.rs
+++ b/kube-core/src/lib.rs
@@ -50,7 +50,4 @@ pub mod watch;
 pub use watch::WatchEvent;
 
 mod error;
-pub use error::{Error, ErrorResponse};
-
-/// Convient alias for `Result<T, Error>`
-pub type Result<T, E = Error> = std::result::Result<T, E>;
+pub use error::ErrorResponse;

--- a/kube-core/src/params.rs
+++ b/kube-core/src/params.rs
@@ -253,7 +253,7 @@ impl<T: Serialize> Patch<T> {
             Self::Strategic(p) => serde_json::to_vec(p),
             Self::Merge(p) => serde_json::to_vec(p),
         }
-        .map_err(Into::into)
+        .map_err(Error::SerdeError)
     }
 }
 

--- a/kube-core/src/params.rs
+++ b/kube-core/src/params.rs
@@ -1,5 +1,5 @@
 //! A port of request parameter *Optionals from apimachinery/types.go
-use crate::{Error, Result};
+use crate::request::Error;
 use serde::Serialize;
 
 /// Common query parameters used in watch/list/delete calls on collections
@@ -63,13 +63,11 @@ impl Default for ListParams {
 }
 
 impl ListParams {
-    pub(crate) fn validate(&self) -> Result<()> {
+    pub(crate) fn validate(&self) -> Result<(), Error> {
         if let Some(to) = &self.timeout {
             // https://github.com/kubernetes/kubernetes/issues/6513
             if *to >= 295 {
-                return Err(Error::RequestValidation(
-                    "ListParams::timeout must be < 295s".into(),
-                ));
+                return Err(Error::Validation("ListParams::timeout must be < 295s".into()));
             }
         }
         Ok(())
@@ -146,12 +144,12 @@ pub struct PostParams {
 }
 
 impl PostParams {
-    pub(crate) fn validate(&self) -> Result<()> {
+    pub(crate) fn validate(&self) -> Result<(), Error> {
         if let Some(field_manager) = &self.field_manager {
             // Implement the easy part of validation, in future this may be extended to provide validation as in go code
             // For now it's fine, because k8s API server will return an error
             if field_manager.len() > 128 {
-                return Err(Error::RequestValidation(
+                return Err(Error::Validation(
                     "Failed to validate PostParams::field_manager!".into(),
                 ));
             }
@@ -244,7 +242,7 @@ impl<T: Serialize> Patch<T> {
 }
 
 impl<T: Serialize> Patch<T> {
-    pub(crate) fn serialize(&self) -> Result<Vec<u8>> {
+    pub(crate) fn serialize(&self) -> Result<Vec<u8>, serde_json::Error> {
         match self {
             Self::Apply(p) => serde_json::to_vec(p),
             #[cfg(feature = "jsonpatch")]
@@ -253,7 +251,6 @@ impl<T: Serialize> Patch<T> {
             Self::Strategic(p) => serde_json::to_vec(p),
             Self::Merge(p) => serde_json::to_vec(p),
         }
-        .map_err(Error::SerdeError)
     }
 }
 
@@ -270,18 +267,18 @@ pub struct PatchParams {
 }
 
 impl PatchParams {
-    pub(crate) fn validate<P: Serialize>(&self, patch: &Patch<P>) -> Result<()> {
+    pub(crate) fn validate<P: Serialize>(&self, patch: &Patch<P>) -> Result<(), Error> {
         if let Some(field_manager) = &self.field_manager {
             // Implement the easy part of validation, in future this may be extended to provide validation as in go code
             // For now it's fine, because k8s API server will return an error
             if field_manager.len() > 128 {
-                return Err(Error::RequestValidation(
+                return Err(Error::Validation(
                     "Failed to validate PatchParams::field_manager!".into(),
                 ));
             }
         }
         if self.force && !patch.is_apply() {
-            return Err(Error::RequestValidation(
+            return Err(Error::Validation(
                 "PatchParams::force only works with Patch::Apply".into(),
             ));
         }

--- a/kube-core/src/request.rs
+++ b/kube-core/src/request.rs
@@ -113,7 +113,7 @@ impl Request {
         let target = format!("{}/{}?", self.url_path, name);
         let mut qp = form_urlencoded::Serializer::new(target);
         let urlstr = qp.finish();
-        let body = serde_json::to_vec(&dp)?;
+        let body = serde_json::to_vec(&dp).map_err(Error::SerdeError)?;
         let req = http::Request::delete(urlstr).header(http::header::CONTENT_TYPE, JSON_MIME);
         req.body(body).map_err(Error::HttpError)
     }
@@ -129,7 +129,7 @@ impl Request {
             qp.append_pair("labelSelector", labels);
         }
         let urlstr = qp.finish();
-        let body = serde_json::to_vec(&dp)?;
+        let body = serde_json::to_vec(&dp).map_err(Error::SerdeError)?;
         let req = http::Request::delete(urlstr).header(http::header::CONTENT_TYPE, JSON_MIME);
         req.body(body).map_err(Error::HttpError)
     }

--- a/kube-core/src/request.rs
+++ b/kube-core/src/request.rs
@@ -1,8 +1,23 @@
 //! Request builder type for arbitrary api types
+use thiserror::Error;
+
 use super::params::{DeleteParams, ListParams, Patch, PatchParams, PostParams};
-use crate::{Error, Result};
 
 pub(crate) const JSON_MIME: &str = "application/json";
+
+/// Possible errors when building a request.
+#[derive(Debug, Error)]
+pub enum Error {
+    /// Failed to build a request.
+    #[error("failed to build request: {0}")]
+    BuildRequest(#[source] http::Error),
+    /// Failed to serialize body.
+    #[error("failed to serialize body: {0}")]
+    SerializeBody(#[source] serde_json::Error),
+    /// Failed to validate request.
+    #[error("failed to validate request")]
+    Validation(String),
+}
 
 /// A Kubernetes request builder
 ///
@@ -28,7 +43,7 @@ impl Request {
 /// Convenience methods found from API conventions
 impl Request {
     /// List a collection of a resource
-    pub fn list(&self, lp: &ListParams) -> Result<http::Request<Vec<u8>>> {
+    pub fn list(&self, lp: &ListParams) -> Result<http::Request<Vec<u8>>, Error> {
         let target = format!("{}?", self.url_path);
         let mut qp = form_urlencoded::Serializer::new(target);
 
@@ -47,21 +62,21 @@ impl Request {
 
         let urlstr = qp.finish();
         let req = http::Request::get(urlstr);
-        req.body(vec![]).map_err(Error::HttpError)
+        req.body(vec![]).map_err(Error::BuildRequest)
     }
 
     /// Watch a resource at a given version
-    pub fn watch(&self, lp: &ListParams, ver: &str) -> Result<http::Request<Vec<u8>>> {
+    pub fn watch(&self, lp: &ListParams, ver: &str) -> Result<http::Request<Vec<u8>>, Error> {
         let target = format!("{}?", self.url_path);
         let mut qp = form_urlencoded::Serializer::new(target);
         lp.validate()?;
         if lp.limit.is_some() {
-            return Err(Error::RequestValidation(
+            return Err(Error::Validation(
                 "ListParams::limit cannot be used with a watch.".into(),
             ));
         }
         if lp.continue_token.is_some() {
-            return Err(Error::RequestValidation(
+            return Err(Error::Validation(
                 "ListParams::continue_token cannot be used with a watch.".into(),
             ));
         }
@@ -83,20 +98,20 @@ impl Request {
 
         let urlstr = qp.finish();
         let req = http::Request::get(urlstr);
-        req.body(vec![]).map_err(Error::HttpError)
+        req.body(vec![]).map_err(Error::BuildRequest)
     }
 
     /// Get a single instance
-    pub fn get(&self, name: &str) -> Result<http::Request<Vec<u8>>> {
+    pub fn get(&self, name: &str) -> Result<http::Request<Vec<u8>>, Error> {
         let target = format!("{}/{}", self.url_path, name);
         let mut qp = form_urlencoded::Serializer::new(target);
         let urlstr = qp.finish();
         let req = http::Request::get(urlstr);
-        req.body(vec![]).map_err(Error::HttpError)
+        req.body(vec![]).map_err(Error::BuildRequest)
     }
 
     /// Create an instance of a resource
-    pub fn create(&self, pp: &PostParams, data: Vec<u8>) -> Result<http::Request<Vec<u8>>> {
+    pub fn create(&self, pp: &PostParams, data: Vec<u8>) -> Result<http::Request<Vec<u8>>, Error> {
         pp.validate()?;
         let target = format!("{}?", self.url_path);
         let mut qp = form_urlencoded::Serializer::new(target);
@@ -105,21 +120,25 @@ impl Request {
         }
         let urlstr = qp.finish();
         let req = http::Request::post(urlstr).header(http::header::CONTENT_TYPE, JSON_MIME);
-        req.body(data).map_err(Error::HttpError)
+        req.body(data).map_err(Error::BuildRequest)
     }
 
     /// Delete an instance of a resource
-    pub fn delete(&self, name: &str, dp: &DeleteParams) -> Result<http::Request<Vec<u8>>> {
+    pub fn delete(&self, name: &str, dp: &DeleteParams) -> Result<http::Request<Vec<u8>>, Error> {
         let target = format!("{}/{}?", self.url_path, name);
         let mut qp = form_urlencoded::Serializer::new(target);
         let urlstr = qp.finish();
-        let body = serde_json::to_vec(&dp).map_err(Error::SerdeError)?;
+        let body = serde_json::to_vec(&dp).map_err(Error::SerializeBody)?;
         let req = http::Request::delete(urlstr).header(http::header::CONTENT_TYPE, JSON_MIME);
-        req.body(body).map_err(Error::HttpError)
+        req.body(body).map_err(Error::BuildRequest)
     }
 
     /// Delete a collection of a resource
-    pub fn delete_collection(&self, dp: &DeleteParams, lp: &ListParams) -> Result<http::Request<Vec<u8>>> {
+    pub fn delete_collection(
+        &self,
+        dp: &DeleteParams,
+        lp: &ListParams,
+    ) -> Result<http::Request<Vec<u8>>, Error> {
         let target = format!("{}?", self.url_path);
         let mut qp = form_urlencoded::Serializer::new(target);
         if let Some(fields) = &lp.field_selector {
@@ -129,9 +148,9 @@ impl Request {
             qp.append_pair("labelSelector", labels);
         }
         let urlstr = qp.finish();
-        let body = serde_json::to_vec(&dp).map_err(Error::SerdeError)?;
+        let body = serde_json::to_vec(&dp).map_err(Error::SerializeBody)?;
         let req = http::Request::delete(urlstr).header(http::header::CONTENT_TYPE, JSON_MIME);
-        req.body(body).map_err(Error::HttpError)
+        req.body(body).map_err(Error::BuildRequest)
     }
 
     /// Patch an instance of a resource
@@ -142,7 +161,7 @@ impl Request {
         name: &str,
         pp: &PatchParams,
         patch: &Patch<P>,
-    ) -> Result<http::Request<Vec<u8>>> {
+    ) -> Result<http::Request<Vec<u8>>, Error> {
         pp.validate(patch)?;
         let target = format!("{}/{}?", self.url_path, name);
         let mut qp = form_urlencoded::Serializer::new(target);
@@ -152,14 +171,19 @@ impl Request {
         http::Request::patch(urlstr)
             .header(http::header::ACCEPT, JSON_MIME)
             .header(http::header::CONTENT_TYPE, patch.content_type())
-            .body(patch.serialize()?)
-            .map_err(Error::HttpError)
+            .body(patch.serialize().map_err(Error::SerializeBody)?)
+            .map_err(Error::BuildRequest)
     }
 
     /// Replace an instance of a resource
     ///
     /// Requires `metadata.resourceVersion` set in data
-    pub fn replace(&self, name: &str, pp: &PostParams, data: Vec<u8>) -> Result<http::Request<Vec<u8>>> {
+    pub fn replace(
+        &self,
+        name: &str,
+        pp: &PostParams,
+        data: Vec<u8>,
+    ) -> Result<http::Request<Vec<u8>>, Error> {
         let target = format!("{}/{}?", self.url_path, name);
         let mut qp = form_urlencoded::Serializer::new(target);
         if pp.dry_run {
@@ -167,19 +191,23 @@ impl Request {
         }
         let urlstr = qp.finish();
         let req = http::Request::put(urlstr).header(http::header::CONTENT_TYPE, JSON_MIME);
-        req.body(data).map_err(Error::HttpError)
+        req.body(data).map_err(Error::BuildRequest)
     }
 }
 
 /// Subresources
 impl Request {
     /// Get an instance of the subresource
-    pub fn get_subresource(&self, subresource_name: &str, name: &str) -> Result<http::Request<Vec<u8>>> {
+    pub fn get_subresource(
+        &self,
+        subresource_name: &str,
+        name: &str,
+    ) -> Result<http::Request<Vec<u8>>, Error> {
         let target = format!("{}/{}/{}", self.url_path, name, subresource_name);
         let mut qp = form_urlencoded::Serializer::new(target);
         let urlstr = qp.finish();
         let req = http::Request::get(urlstr);
-        req.body(vec![]).map_err(Error::HttpError)
+        req.body(vec![]).map_err(Error::BuildRequest)
     }
 
     /// Patch an instance of the subresource
@@ -189,7 +217,7 @@ impl Request {
         name: &str,
         pp: &PatchParams,
         patch: &Patch<P>,
-    ) -> Result<http::Request<Vec<u8>>> {
+    ) -> Result<http::Request<Vec<u8>>, Error> {
         pp.validate(patch)?;
         let target = format!("{}/{}/{}?", self.url_path, name, subresource_name);
         let mut qp = form_urlencoded::Serializer::new(target);
@@ -199,8 +227,8 @@ impl Request {
         http::Request::patch(urlstr)
             .header(http::header::ACCEPT, JSON_MIME)
             .header(http::header::CONTENT_TYPE, patch.content_type())
-            .body(patch.serialize()?)
-            .map_err(Error::HttpError)
+            .body(patch.serialize().map_err(Error::SerializeBody)?)
+            .map_err(Error::BuildRequest)
     }
 
     /// Replace an instance of the subresource
@@ -210,7 +238,7 @@ impl Request {
         name: &str,
         pp: &PostParams,
         data: Vec<u8>,
-    ) -> Result<http::Request<Vec<u8>>> {
+    ) -> Result<http::Request<Vec<u8>>, Error> {
         let target = format!("{}/{}/{}?", self.url_path, name, subresource_name);
         let mut qp = form_urlencoded::Serializer::new(target);
         if pp.dry_run {
@@ -218,7 +246,7 @@ impl Request {
         }
         let urlstr = qp.finish();
         let req = http::Request::put(urlstr).header(http::header::CONTENT_TYPE, JSON_MIME);
-        req.body(data).map_err(Error::HttpError)
+        req.body(data).map_err(Error::BuildRequest)
     }
 }
 

--- a/kube-core/src/subresource.rs
+++ b/kube-core/src/subresource.rs
@@ -111,7 +111,8 @@ impl Request {
         let data = serde_json::to_vec(&serde_json::json!({
             "delete_options": ep.delete_options,
             "metadata": { "name": name }
-        }))?;
+        }))
+        .map_err(Error::SerdeError)?;
         let req = http::Request::post(urlstr).header(http::header::CONTENT_TYPE, JSON_MIME);
         req.body(data).map_err(Error::HttpError)
     }

--- a/kube-core/src/subresource.rs
+++ b/kube-core/src/subresource.rs
@@ -3,8 +3,7 @@ use std::fmt::Debug;
 
 use crate::{
     params::{DeleteParams, PostParams},
-    request::{Request, JSON_MIME},
-    Error, Result,
+    request::{Error, Request, JSON_MIME},
 };
 
 pub use k8s_openapi::api::autoscaling::v1::{Scale, ScaleSpec, ScaleStatus};
@@ -40,7 +39,7 @@ pub struct LogParams {
 
 impl Request {
     /// Get a pod logs
-    pub fn logs(&self, name: &str, lp: &LogParams) -> Result<http::Request<Vec<u8>>> {
+    pub fn logs(&self, name: &str, lp: &LogParams) -> Result<http::Request<Vec<u8>>, Error> {
         let target = format!("{}/{}/log?", self.url_path, name);
         let mut qp = form_urlencoded::Serializer::new(target);
 
@@ -78,7 +77,7 @@ impl Request {
 
         let urlstr = qp.finish();
         let req = http::Request::get(urlstr);
-        req.body(vec![]).map_err(Error::HttpError)
+        req.body(vec![]).map_err(Error::BuildRequest)
     }
 }
 
@@ -97,7 +96,7 @@ pub struct EvictParams {
 
 impl Request {
     /// Create an eviction
-    pub fn evict(&self, name: &str, ep: &EvictParams) -> Result<http::Request<Vec<u8>>> {
+    pub fn evict(&self, name: &str, ep: &EvictParams) -> Result<http::Request<Vec<u8>>, Error> {
         let target = format!("{}/{}/eviction?", self.url_path, name);
         // This is technically identical to Request::create, but different url
         let pp = &ep.post_options;
@@ -112,9 +111,9 @@ impl Request {
             "delete_options": ep.delete_options,
             "metadata": { "name": name }
         }))
-        .map_err(Error::SerdeError)?;
+        .map_err(Error::SerializeBody)?;
         let req = http::Request::post(urlstr).header(http::header::CONTENT_TYPE, JSON_MIME);
-        req.body(data).map_err(Error::HttpError)
+        req.body(data).map_err(Error::BuildRequest)
     }
 }
 
@@ -249,16 +248,16 @@ impl AttachParams {
         self
     }
 
-    fn validate(&self) -> Result<()> {
+    fn validate(&self) -> Result<(), Error> {
         if !self.stdin && !self.stdout && !self.stderr {
-            return Err(Error::RequestValidation(
+            return Err(Error::Validation(
                 "AttachParams: one of stdin, stdout, or stderr must be true".into(),
             ));
         }
 
         if self.stderr && self.tty {
             // Multiplexing is not supported with TTY
-            return Err(Error::RequestValidation(
+            return Err(Error::Validation(
                 "AttachParams: tty and stderr cannot both be true".into(),
             ));
         }
@@ -289,7 +288,7 @@ impl AttachParams {
 #[cfg_attr(docsrs, doc(cfg(feature = "ws")))]
 impl Request {
     /// Attach to a pod
-    pub fn attach(&self, name: &str, ap: &AttachParams) -> Result<http::Request<Vec<u8>>> {
+    pub fn attach(&self, name: &str, ap: &AttachParams) -> Result<http::Request<Vec<u8>>, Error> {
         ap.validate()?;
 
         let target = format!("{}/{}/attach?", self.url_path, name);
@@ -297,7 +296,7 @@ impl Request {
         ap.append_to_url_serializer(&mut qp);
 
         let req = http::Request::get(qp.finish());
-        req.body(vec![]).map_err(Error::HttpError)
+        req.body(vec![]).map_err(Error::BuildRequest)
     }
 }
 
@@ -308,7 +307,12 @@ impl Request {
 #[cfg_attr(docsrs, doc(cfg(feature = "ws")))]
 impl Request {
     /// Execute command in a pod
-    pub fn exec<I, T>(&self, name: &str, command: I, ap: &AttachParams) -> Result<http::Request<Vec<u8>>>
+    pub fn exec<I, T>(
+        &self,
+        name: &str,
+        command: I,
+        ap: &AttachParams,
+    ) -> Result<http::Request<Vec<u8>>, Error>
     where
         I: IntoIterator<Item = T>,
         T: Into<String>,
@@ -324,6 +328,6 @@ impl Request {
         }
 
         let req = http::Request::get(qp.finish());
-        req.body(vec![]).map_err(Error::HttpError)
+        req.body(vec![]).map_err(Error::BuildRequest)
     }
 }

--- a/kube-core/src/util.rs
+++ b/kube-core/src/util.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     params::{Patch, PatchParams},
-    Request, Result,
+    request, Request,
 };
 use chrono::Utc;
 use k8s_openapi::api::apps::v1::{DaemonSet, Deployment, ReplicaSet, StatefulSet};
@@ -17,7 +17,7 @@ impl Restart for ReplicaSet {}
 
 impl Request {
     /// Restart a resource
-    pub fn restart(&self, name: &str) -> Result<http::Request<Vec<u8>>> {
+    pub fn restart(&self, name: &str) -> Result<http::Request<Vec<u8>>, request::Error> {
         let patch = serde_json::json!({
           "spec": {
             "template": {

--- a/kube-runtime/Cargo.toml
+++ b/kube-runtime/Cargo.toml
@@ -27,12 +27,12 @@ serde = "1.0.130"
 smallvec = "1.7.0"
 pin-project = "1.0.2"
 tokio = { version = "1.12.0", features = ["time"] }
-snafu = { version = "0.6.10", features = ["futures"] }
 dashmap = "4.0.1"
 tokio-util = { version = "0.6.8", features = ["time"] }
 tracing = "0.1.29"
 json-patch = "0.2.6"
 serde_json = "1.0.68"
+thiserror = "1.0.29"
 
 [dependencies.k8s-openapi]
 version = "0.13.1"

--- a/kube-runtime/src/controller/mod.rs
+++ b/kube-runtime/src/controller/mod.rs
@@ -22,7 +22,6 @@ use futures::{
 };
 use kube_client::api::{Api, DynamicObject, ListParams, Resource};
 use serde::de::DeserializeOwned;
-use snafu::{futures::TryStreamExt as SnafuTryStreamExt, Backtrace, ResultExt, Snafu};
 use std::{
     fmt::{Debug, Display},
     hash::Hash,
@@ -30,30 +29,23 @@ use std::{
     time::Duration,
 };
 use stream::BoxStream;
+use thiserror::Error;
 use tokio::{runtime::Handle, time::Instant};
 use tracing::{info_span, Instrument};
 
 mod future_hash_map;
 mod runner;
 
-#[derive(Snafu, Debug)]
+#[derive(Debug, Error)]
 pub enum Error<ReconcilerErr: std::error::Error + 'static, QueueErr: std::error::Error + 'static> {
-    ObjectNotFound {
-        obj_ref: ObjectRef<DynamicObject>,
-        backtrace: Backtrace,
-    },
-    ReconcilerFailed {
-        source: ReconcilerErr,
-        backtrace: Backtrace,
-    },
-    SchedulerDequeueFailed {
-        #[snafu(backtrace)]
-        source: scheduler::Error,
-    },
-    QueueError {
-        source: QueueErr,
-        backtrace: Backtrace,
-    },
+    #[error("ObjectNotFound")]
+    ObjectNotFound(ObjectRef<DynamicObject>),
+    #[error("ReconcilerFailed: {0}")]
+    ReconcilerFailed(#[source] ReconcilerErr),
+    #[error("SchedulerDequeueFailed: {0}")]
+    SchedulerDequeueFailed(#[source] scheduler::Error),
+    #[error("QueueError: {0}")]
+    QueueError(#[source] QueueErr),
 }
 
 /// Results of the reconciliation attempt
@@ -250,7 +242,7 @@ where
         // input: stream combining scheduled tasks and user specified inputs event
         Box::pin(stream::select(
             // 1. inputs from users queue stream
-            queue.context(QueueError).map_ok(|request| ScheduleRequest {
+            queue.map_err(Error::QueueError).map_ok(|request| ScheduleRequest {
                 message: request.into(),
                 run_at: Instant::now() + Duration::from_millis(1),
             })
@@ -281,15 +273,12 @@ where
                         .left_future()
                     },
                     None => future::err(
-                        ObjectNotFound {
-                            obj_ref: request.obj_ref.erase(),
-                        }
-                        .build(),
+                        Error::ObjectNotFound(request.obj_ref.erase())
                     )
                     .right_future(),
                 }
             })
-            .context(SchedulerDequeueFailed)
+            .map_err(Error::SchedulerDequeueFailed)
             .map(|res| res.and_then(|x| x))
             .on_complete(async { tracing::debug!("applier runner terminated") })
         },
@@ -319,7 +308,7 @@ where
             }
             reconciler_result
                 .map(|action| (obj_ref, action))
-                .context(ReconcilerFailed)
+                .map_err(Error::ReconcilerFailed)
         }
     })
     .on_complete(async { tracing::debug!("applier terminated") })
@@ -347,10 +336,11 @@ where
 /// use futures::StreamExt;
 /// use k8s_openapi::api::core::v1::ConfigMap;
 /// use schemars::JsonSchema;
+/// use thiserror::Error;
 ///
-/// use snafu::{Backtrace, OptionExt, ResultExt, Snafu};
-/// #[derive(Debug, Snafu)]
+/// #[derive(Debug, Error)]
 /// enum Error {}
+///
 /// /// A custom resource
 /// #[derive(CustomResource, Debug, Clone, Deserialize, Serialize, JsonSchema)]
 /// #[kube(group = "nullable.se", version = "v1", kind = "ConfigMapGenerator", namespaced)]

--- a/kube-runtime/src/controller/mod.rs
+++ b/kube-runtime/src/controller/mod.rs
@@ -375,7 +375,7 @@ where
 ///
 /// /// something to drive the controller
 /// #[tokio::main]
-/// async fn main() -> Result<(), kube::Error> {
+/// async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///     let client = Client::try_default().await?;
 ///     let context = Context::new(()); // bad empty context - put client in here
 ///     let cmgs = Api::<ConfigMapGenerator>::all(client.clone());

--- a/kube/src/lib.rs
+++ b/kube/src/lib.rs
@@ -23,7 +23,7 @@
 //! use k8s_openapi::api::core::v1::Pod;
 //!
 //! #[tokio::main]
-//! async fn main() -> Result<(), kube::Error> {
+//! async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //!     // Infer the runtime environment and try to create a Kubernetes Client
 //!     let client = Client::try_default().await?;
 //!


### PR DESCRIPTION
I wanted to add "Refine Errors" (opened #688) to our roadmap, so I tried a bit to see how we can tackle this. Any feedback is appreciated.

### Remove `impl From<T> for kube::Error`

Require explicitly mapping errors.
[This commit](https://github.com/kube-rs/kube-rs/commit/f595f9bd960abf959206055e378a418ea49dd86b) shows how much we need to mentally process while reading the code (maintenance cost), and how badly grouped they are (usability issue).
Removing `impl From` forces us to attach context, and this is a good thing. It's verbose right now, but that's because we need to break them down.

As an example, I got rid of `kube_core::Error`. Parsing group version no longer has an error variant `HttpError`.

### `thiserror` vs `snafu`

As I mentioned in [`thiserror` vs `snafu`](https://github.com/kube-rs/kube-rs/discussions/453#discussioncomment-451968) discussion, the huge `kube::Error` is a problem I'd like us to start fixing. I've been using both `thiserror` and `snafu`, and I think using `thiserror` without `#[from]`, and gradually breaking errors down is probably the best approach for `kube`. While I think `snafu` help us _initially to think_ of errors in a more scalable way, it's not necessary to implement the pattern. Also, we probably can't do SNAFU way until we finish breaking them down cleanly anyway, and the features to prevent misuse will get in the way (e.g., private context selectors by default). So, I don't think it's worth some downsides.

#### Stability

`thiserror` is stable (v1). `snafu` is still evolving. 0.7 will add `Snafu` suffix to generated context selectors. Tuple variants are [not well-supported](https://github.com/shepmaster/snafu/issues/61)? (I haven't used tuple variants with `snafu`, so I don't know the details).

#### Popularity

`thiserror` v1 is used by [9,491](https://lib.rs/crates/thiserror/rev) public crates. `snafu` 0.6 is used by [270](https://lib.rs/crates/snafu/rev). `snafu` is _extra_ dependency for many.

#### Features

`snafu` provides some syntactic sugars, but I don't think it adds that much value. Avoiding `#[from]` and using the usual `Result::map_err` feels similar enough, especially as we break the errors down.

```rust
let mut file = File::open(path).context(OpenFileSnafu { path })?;
let mut file = File::open(path).map_err(|e| Error::OpenFile(e, path.to_owned()))?;
let mut file = File::open(path).map_err(|source| Error::OpenFile { source, path: path.into() })?;

action().context(ActionSnafu)?;
action().map_err(Error::Action)?;
```

One feature `snafu` optionally provides that `thiserror` doesn't, is backtrace in stable, but this requires the end users to depend on `snafu` and enable the `backtrace` feature. There are error reporter crates to do this until backtrace become stable.

Unless I missed something significant, I think we should go with `thiserror` without `#[from]`.