### PR TITLE
Allow opting out of schema derivation per kind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ UNRELEASED
    - Replaced `kube::Error::RequestValidation(String)` variant with `kube::Error::BuildRequest(kube::core::request::Error)`. This variant includes possible errors when building an HTTP request as described above, and contains errors that was previously grouped under `kube::Error::SerdeError` and `kube::Error::HttpError`.
    - Removed `impl From<T> for kube::Error` for the following types: `std::io::Error`, `hyper::Error`, `tower::BoxError`, `std::string::FromUtf8Error`, `http::Error`, `http::uri::InvalidUri`, `serde_json::Error`, `openssl::error::ErrorStack`, `kube::core::Error`, `kube::error::ConfigError`, `kube::error::DisoveryError`, `kube::error::OAuthError`.
    - Changed variants of error enums in `kube::runtime`. Replaced `snafu` with `thiserror`.
+ * BREAKING: Replaced feature `kube-runtime/schema` with attribute `#[kube(derive_schema)]` - #690
+   - If you currently disable default `kube-runtime` default features to avoid this issue, add `#[kube(derive_schema = false)]` to your spec struct instead
 
 0.63.2 / 2021-10-28
 ===================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,10 @@ UNRELEASED
    - Replaced `kube::Error::RequestValidation(String)` variant with `kube::Error::BuildRequest(kube::core::request::Error)`. This variant includes possible errors when building an HTTP request as described above, and contains errors that was previously grouped under `kube::Error::SerdeError` and `kube::Error::HttpError`.
    - Removed `impl From<T> for kube::Error` for the following types: `std::io::Error`, `hyper::Error`, `tower::BoxError`, `std::string::FromUtf8Error`, `http::Error`, `http::uri::InvalidUri`, `serde_json::Error`, `openssl::error::ErrorStack`, `kube::core::Error`, `kube::error::ConfigError`, `kube::error::DisoveryError`, `kube::error::OAuthError`.
    - Changed variants of error enums in `kube::runtime`. Replaced `snafu` with `thiserror`.
- * BREAKING: Replaced feature `kube-derive/schema` with attribute `#[kube(schema_mode)]` - #690
-   - If you currently disable default `kube-derive` default features to avoid automatic schema generation, add `#[kube(schema_mode = "disabled")]` to your spec struct instead
+ * BREAKING: Replaced feature `kube-derive/schema` with attribute `#[kube(schema)]` - #690
+   - If you currently disable default `kube-derive` default features to avoid automatic schema generation, add `#[kube(schema = "disabled")]` to your spec struct instead
+ * BREAKING: Moved `CustomResource` derive crate overrides into subattribute `#[kube(crates(...))]` - #690
+   - Replace `#[kube(kube_core = .., k8s_openapi = .., schema = .., serde = .., serde_json = ..)]` with `#[kube(crates(kube_core = .., k8s_openapi = .., schema = .., serde = .., serde_json = ..))]`
 
 0.63.2 / 2021-10-28
 ===================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ UNRELEASED
    - Replaced `kube::Error::RequestValidation(String)` variant with `kube::Error::BuildRequest(kube::core::request::Error)`. This variant includes possible errors when building an HTTP request as described above, and contains errors that was previously grouped under `kube::Error::SerdeError` and `kube::Error::HttpError`.
    - Removed `impl From<T> for kube::Error` for the following types: `std::io::Error`, `hyper::Error`, `tower::BoxError`, `std::string::FromUtf8Error`, `http::Error`, `http::uri::InvalidUri`, `serde_json::Error`, `openssl::error::ErrorStack`, `kube::core::Error`, `kube::error::ConfigError`, `kube::error::DisoveryError`, `kube::error::OAuthError`.
    - Changed variants of error enums in `kube::runtime`. Replaced `snafu` with `thiserror`.
- * BREAKING: Replaced feature `kube-runtime/schema` with attribute `#[kube(derive_schema)]` - #690
-   - If you currently disable default `kube-runtime` default features to avoid this issue, add `#[kube(derive_schema = false)]` to your spec struct instead
+ * BREAKING: Replaced feature `kube-runtime/schema` with attribute `#[kube(schema_mode)]` - #690
+   - If you currently disable default `kube-runtime` default features to avoid automatic schema generation, add `#[kube(schema_mode = "disabled")]` to your spec struct instead
 
 0.63.2 / 2021-10-28
 ===================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ UNRELEASED
    - Removed `impl From<T> for kube::Error` for the following types: `std::io::Error`, `hyper::Error`, `tower::BoxError`, `std::string::FromUtf8Error`, `http::Error`, `http::uri::InvalidUri`, `serde_json::Error`, `openssl::error::ErrorStack`, `kube::core::Error`, `kube::error::ConfigError`, `kube::error::DisoveryError`, `kube::error::OAuthError`.
    - Changed variants of error enums in `kube::runtime`. Replaced `snafu` with `thiserror`.
  * BREAKING: Replaced feature `kube-derive/schema` with attribute `#[kube(schema_mode)]` - #690
-   - If you currently disable default `kube-runtime` default features to avoid automatic schema generation, add `#[kube(schema_mode = "disabled")]` to your spec struct instead
+   - If you currently disable default `kube-derive` default features to avoid automatic schema generation, add `#[kube(schema_mode = "disabled")]` to your spec struct instead
 
 0.63.2 / 2021-10-28
 ===================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ UNRELEASED
    - Replaced `kube::Error::RequestValidation(String)` variant with `kube::Error::BuildRequest(kube::core::request::Error)`. This variant includes possible errors when building an HTTP request as described above, and contains errors that was previously grouped under `kube::Error::SerdeError` and `kube::Error::HttpError`.
    - Removed `impl From<T> for kube::Error` for the following types: `std::io::Error`, `hyper::Error`, `tower::BoxError`, `std::string::FromUtf8Error`, `http::Error`, `http::uri::InvalidUri`, `serde_json::Error`, `openssl::error::ErrorStack`, `kube::core::Error`, `kube::error::ConfigError`, `kube::error::DisoveryError`, `kube::error::OAuthError`.
    - Changed variants of error enums in `kube::runtime`. Replaced `snafu` with `thiserror`.
- * BREAKING: Replaced feature `kube-runtime/schema` with attribute `#[kube(schema_mode)]` - #690
+ * BREAKING: Replaced feature `kube-derive/schema` with attribute `#[kube(schema_mode)]` - #690
    - If you currently disable default `kube-runtime` default features to avoid automatic schema generation, add `#[kube(schema_mode = "disabled")]` to your spec struct instead
 
 0.63.2 / 2021-10-28

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -82,7 +82,11 @@ path = "crd_derive.rs"
 name = "crd_derive_schema"
 path = "crd_derive_schema.rs"
 
-[[example]] # run this without --no-default-features --features="native-tls"
+[[example]]
+name = "crd_derive_custom_schema"
+path = "crd_derive_custom_schema.rs"
+
+[[example]]
 name = "crd_derive_no_schema"
 path = "crd_derive_no_schema.rs"
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -14,9 +14,8 @@ license = "Apache-2.0"
 release = false
 
 [features]
-default = ["native-tls", "schema", "kubederive", "ws", "latest", "runtime"]
-kubederive = ["kube/derive"] # by default import kube-derive with its default features
-schema = ["kube-derive/schema"] # crd_derive_no_schema shows how to opt out
+default = ["native-tls", "kubederive", "ws", "latest", "runtime"]
+kubederive = ["kube/derive"]
 native-tls = ["kube/client", "kube/native-tls"]
 rustls-tls = ["kube/client", "kube/rustls-tls"]
 runtime = ["kube/runtime"]

--- a/examples/crd_derive_custom_schema.rs
+++ b/examples/crd_derive_custom_schema.rs
@@ -64,7 +64,6 @@ fn main() {
 #[test]
 fn verify_bar_is_a_custom_resource() {
     use kube::Resource;
-    use schemars::JsonSchema; // only for ensuring it's not implemented
     use static_assertions::assert_impl_all;
 
     println!("Kind {}", Bar::kind(&()));
@@ -72,7 +71,7 @@ fn verify_bar_is_a_custom_resource() {
     println!("Spec: {:?}", bar.spec);
     assert_impl_all!(Bar: kube::Resource, JsonSchema);
 
-    let crd = Bar::crd_with_manual_schema();
+    let crd = Bar::crd();
     for v in crd.spec.versions {
         assert!(v.schema.unwrap().open_api_v3_schema.is_some());
     }

--- a/examples/crd_derive_custom_schema.rs
+++ b/examples/crd_derive_custom_schema.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
     version = "v1",
     kind = "Bar",
     namespaced,
-    schema_mode = "custom"
+    schema = "custom"
 )]
 pub struct MyBar {
     bars: u32,

--- a/examples/crd_derive_custom_schema.rs
+++ b/examples/crd_derive_custom_schema.rs
@@ -1,0 +1,79 @@
+use kube::CustomResourceExt;
+use kube_derive::CustomResource;
+use schemars::{
+    schema::{InstanceType, ObjectValidation, Schema, SchemaObject},
+    JsonSchema,
+};
+use serde::{Deserialize, Serialize};
+
+/// CustomResource with manually implemented `JsonSchema`
+#[derive(CustomResource, Serialize, Deserialize, Debug, Clone)]
+#[kube(
+    group = "clux.dev",
+    version = "v1",
+    kind = "Bar",
+    namespaced,
+    schema_mode = "custom"
+)]
+pub struct MyBar {
+    bars: u32,
+}
+
+impl JsonSchema for Bar {
+    fn schema_name() -> String {
+        "Bar".to_string()
+    }
+
+    fn json_schema(__gen: &mut schemars::gen::SchemaGenerator) -> Schema {
+        Schema::Object(SchemaObject {
+            object: Some(Box::new(ObjectValidation {
+                required: ["spec".to_string()].into(),
+                properties: [(
+                    "spec".to_string(),
+                    Schema::Object(SchemaObject {
+                        instance_type: Some(InstanceType::Object.into()),
+                        object: Some(Box::new(ObjectValidation {
+                            required: ["bars".to_string()].into(),
+                            properties: [(
+                                "bars".to_string(),
+                                Schema::Object(SchemaObject {
+                                    instance_type: Some(InstanceType::Integer.into()),
+                                    ..SchemaObject::default()
+                                }),
+                            )]
+                            .into(),
+                            ..ObjectValidation::default()
+                        })),
+                        ..SchemaObject::default()
+                    }),
+                )]
+                .into(),
+                ..ObjectValidation::default()
+            })),
+            ..SchemaObject::default()
+        })
+    }
+}
+
+fn main() {
+    let crd = Bar::crd();
+    println!("{}", serde_yaml::to_string(&crd).unwrap());
+}
+
+// Verify CustomResource derivable still
+#[test]
+fn verify_bar_is_a_custom_resource() {
+    use kube::Resource;
+    use schemars::JsonSchema; // only for ensuring it's not implemented
+    use static_assertions::assert_impl_all;
+
+    println!("Kind {}", Bar::kind(&()));
+    let bar = Bar::new("five", MyBar { bars: 5 });
+    println!("Spec: {:?}", bar.spec);
+    assert_impl_all!(Bar: kube::Resource, JsonSchema);
+
+    let crd = Bar::crd_with_manual_schema();
+    for v in crd.spec.versions {
+        assert!(v.schema.unwrap().open_api_v3_schema.is_some());
+    }
+}

--- a/examples/crd_derive_custom_schema.rs
+++ b/examples/crd_derive_custom_schema.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
     version = "v1",
     kind = "Bar",
     namespaced,
-    schema = "custom"
+    schema = "manual"
 )]
 pub struct MyBar {
     bars: u32,

--- a/examples/crd_derive_no_schema.rs
+++ b/examples/crd_derive_no_schema.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
     version = "v1",
     kind = "Bar",
     namespaced,
-    schema_mode = "disabled"
+    schema = "disabled"
 )]
 pub struct MyBar {
     bars: u32,

--- a/examples/crd_derive_no_schema.rs
+++ b/examples/crd_derive_no_schema.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
     version = "v1",
     kind = "Bar",
     namespaced,
-    derive_schema = false
+    schema_mode = "disabled"
 )]
 pub struct MyBar {
     bars: u32,

--- a/examples/crd_derive_no_schema.rs
+++ b/examples/crd_derive_no_schema.rs
@@ -1,25 +1,26 @@
-#[cfg(not(feature = "schema"))]
 use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::{
     CustomResourceDefinition, CustomResourceValidation, JSONSchemaProps,
 };
-#[cfg(not(feature = "schema"))] use kube_derive::CustomResource;
-#[cfg(not(feature = "schema"))] use serde::{Deserialize, Serialize};
+use kube_derive::CustomResource;
+use serde::{Deserialize, Serialize};
 
 /// CustomResource with manually implemented schema
 ///
-/// NB: Everything here is gated on the example's `schema` feature not being set
-///
 /// Normally you would do this by deriving JsonSchema or manually implementing it / parts of it.
 /// But here, we simply drop in a valid schema from a string and avoid schemars from the dependency tree entirely.
-#[cfg(not(feature = "schema"))]
 #[derive(CustomResource, Serialize, Deserialize, Debug, Clone)]
-#[kube(group = "clux.dev", version = "v1", kind = "Bar", namespaced)]
+#[kube(
+    group = "clux.dev",
+    version = "v1",
+    kind = "Bar",
+    namespaced,
+    derive_schema = false
+)]
 pub struct MyBar {
     bars: u32,
 }
 
-#[cfg(not(feature = "schema"))]
-const MANUAL_SCHEMA: &'static str = r#"
+const MANUAL_SCHEMA: &str = r#"
 type: object
 properties:
   spec:
@@ -31,7 +32,6 @@ properties:
     - bars
 "#;
 
-#[cfg(not(feature = "schema"))]
 impl Bar {
     fn crd_with_manual_schema() -> CustomResourceDefinition {
         use kube::CustomResourceExt;
@@ -47,18 +47,12 @@ impl Bar {
     }
 }
 
-#[cfg(not(feature = "schema"))]
 fn main() {
     let crd = Bar::crd_with_manual_schema();
     println!("{}", serde_yaml::to_string(&crd).unwrap());
 }
-#[cfg(feature = "schema")]
-fn main() {
-    eprintln!("This example it disabled when using the schema feature");
-}
 
 // Verify CustomResource derivable still
-#[cfg(not(feature = "schema"))]
 #[test]
 fn verify_bar_is_a_custom_resource() {
     use kube::Resource;

--- a/kube-derive/Cargo.toml
+++ b/kube-derive/Cargo.toml
@@ -22,10 +22,6 @@ darling = "0.13.0"
 [lib]
 proc-macro = true
 
-[features]
-default = ["schema"]
-schema = []
-
 [dev-dependencies]
 serde = { version = "1.0.130", features = ["derive"] }
 serde_yaml = "0.8.21"

--- a/kube-derive/src/custom_resource.rs
+++ b/kube-derive/src/custom_resource.rs
@@ -90,7 +90,7 @@ fn default_apiext() -> String {
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 enum SchemaMode {
     Disabled,
-    Custom,
+    Manual,
     Derived,
 }
 
@@ -98,7 +98,7 @@ impl SchemaMode {
     fn derive(self) -> bool {
         match self {
             SchemaMode::Disabled => false,
-            SchemaMode::Custom => false,
+            SchemaMode::Manual => false,
             SchemaMode::Derived => true,
         }
     }
@@ -106,7 +106,7 @@ impl SchemaMode {
     fn use_in_crd(self) -> bool {
         match self {
             SchemaMode::Disabled => false,
-            SchemaMode::Custom => true,
+            SchemaMode::Manual => true,
             SchemaMode::Derived => true,
         }
     }
@@ -116,7 +116,7 @@ impl FromMeta for SchemaMode {
     fn from_string(value: &str) -> darling::Result<Self> {
         match value {
             "disabled" => Ok(SchemaMode::Disabled),
-            "custom" => Ok(SchemaMode::Custom),
+            "manual" => Ok(SchemaMode::Manual),
             "derived" => Ok(SchemaMode::Derived),
             x => Err(darling::Error::unknown_value(x)),
         }

--- a/kube-derive/src/custom_resource.rs
+++ b/kube-derive/src/custom_resource.rs
@@ -24,6 +24,8 @@ struct KubeAttrs {
     #[darling(multiple, rename = "derive")]
     derives: Vec<String>,
     #[darling(default)]
+    derive_schema: Option<bool>,
+    #[darling(default)]
     status: Option<String>,
     #[darling(multiple, rename = "category")]
     categories: Vec<String>,
@@ -92,6 +94,7 @@ pub(crate) fn derive(input: proc_macro2::TokenStream) -> proc_macro2::TokenStrea
         version,
         namespaced,
         derives,
+        derive_schema,
         status,
         plural,
         singular,
@@ -152,9 +155,8 @@ pub(crate) fn derive(input: proc_macro2::TokenStream) -> proc_macro2::TokenStrea
         }
     }
 
-    // Schema generation is always enabled for v1 because it's mandatory.
-    // TODO Enable schema generation for v1beta1 if the spec derives `JsonSchema`.
-    let schema_gen_enabled = apiextensions == "v1" && cfg!(feature = "schema");
+    // Enable schema generation by default for v1 because it's mandatory.
+    let schema_gen_enabled = derive_schema.unwrap_or(apiextensions == "v1");
     // We exclude fields `apiVersion`, `kind`, and `metadata` from our schema because
     // these are validated by the API server implicitly. Also, we can't generate the
     // schema for `metadata` (`ObjectMeta`) because it doesn't implement `JsonSchema`.

--- a/kube-derive/src/lib.rs
+++ b/kube-derive/src/lib.rs
@@ -206,7 +206,7 @@ mod custom_resource;
 ///
 /// See [kubernetes openapi validation](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#validation) for the format of the OpenAPI v3 schemas.
 ///
-/// If you have to override a lot, [you can opt-out of schema-generation entirely](#kubederive_schema--false)
+/// If you have to override a lot, [you can opt-out of schema-generation entirely](#kubeschema_mode--mode)
 ///
 /// ## Advanced Features
 /// - **embedding k8s-openapi types** can be done by enabling the `schemars` feature of `k8s-openapi` from [`0.13.0`](https://github.com/Arnavion/k8s-openapi/blob/master/CHANGELOG.md#v0130-2021-08-09)

--- a/kube-derive/src/lib.rs
+++ b/kube-derive/src/lib.rs
@@ -87,20 +87,20 @@ mod custom_resource;
 /// ### `#[kube(struct = "StructName")]`
 /// Customize the name of the generated root struct (defaults to `kind`).
 ///
-/// ### `#[kube(kube_core = "::kube::core")]`
+/// ### `#[kube(crates(kube_core = "::kube::core"))]`
 /// Customize the crate name the generated code will reach into (defaults to `::kube::core`).
 /// Should be one of `kube::core`, `kube_client::core` or `kube_core`.
 ///
-/// ### `#[kube(k8s_openapi = "::k8s_openapi")]`
+/// ### `#[kube(crates(k8s_openapi = "::k8s_openapi"))]`
 /// Customize the crate name the generated code will use for [`k8s_openapi`](https://docs.rs/k8s-openapi/) (defaults to `::k8s_openapi`).
 ///
-/// ### `#[kube(schemars = "::schemars")]`
+/// ### `#[kube(crates(schemars = "::schemars"))]`
 /// Customize the crate name the generated code will use for [`schemars`](https://docs.rs/schemars/) (defaults to `::schemars`).
 ///
-/// ### `#[kube(serde = "::serde")]`
+/// ### `#[kube(crates(serde = "::serde"))]`
 /// Customize the crate name the generated code will use for [`serde`](https://docs.rs/serde/) (defaults to `::serde`).
 ///
-/// ### `#[kube(serde_json = "::serde_json")]`
+/// ### `#[kube(crates(serde_json = "::serde_json"))]`
 /// Customize the crate name the generated code will use for [`serde_json`](https://docs.rs/serde_json/) (defaults to `::serde_json`).
 ///
 /// ### `#[kube(status = "StatusStructName")]`
@@ -111,7 +111,7 @@ mod custom_resource;
 /// Adding `#[kube(derive = "PartialEq")]` is required if you want your generated
 /// top level type to be able to `#[derive(PartialEq)]`
 ///
-/// ### `#[kube(schema_mode = "mode")]`
+/// ### `#[kube(schema = "mode")]`
 /// Defines whether the `JsonSchema` of the top level generated type should be used when generating a `CustomResourceDefinition`.
 ///
 /// Legal values:
@@ -124,7 +124,7 @@ mod custom_resource;
 ///
 /// Defaults to `"disabled"` when `apiextensions = "v1beta1"`, otherwise `"derived"`.
 ///
-/// NOTE: `apiextensions = "v1"` `CustomResourceDefinition`s require a schema. If `schema_mode = "disabled"` then
+/// NOTE: `apiextensions = "v1"` `CustomResourceDefinition`s require a schema. If `schema = "disabled"` then
 /// `Self::crd()` will not be installable into the cluster as-is.
 ///
 /// ### `#[kube(scale = r#"json"#)]`
@@ -206,7 +206,7 @@ mod custom_resource;
 ///
 /// See [kubernetes openapi validation](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#validation) for the format of the OpenAPI v3 schemas.
 ///
-/// If you have to override a lot, [you can opt-out of schema-generation entirely](#kubeschema_mode--mode)
+/// If you have to override a lot, [you can opt-out of schema-generation entirely](#kubeschema--mode)
 ///
 /// ## Advanced Features
 /// - **embedding k8s-openapi types** can be done by enabling the `schemars` feature of `k8s-openapi` from [`0.13.0`](https://github.com/Arnavion/k8s-openapi/blob/master/CHANGELOG.md#v0130-2021-08-09)

--- a/kube-derive/src/lib.rs
+++ b/kube-derive/src/lib.rs
@@ -116,7 +116,7 @@ mod custom_resource;
 ///
 /// Legal values:
 /// - `"derived"`: A `JsonSchema` implementation is automatically derived
-/// - `"custom"`: `JsonSchema` is not derived, but used when creating the `CustomResourceDefinition` object
+/// - `"manual"`: `JsonSchema` is not derived, but used when creating the `CustomResourceDefinition` object
 /// - `"disabled"`: No `JsonSchema` is used
 ///
 /// This can be used to provide a completely custom schema, or to interact with third-party custom resources

--- a/kube-derive/src/lib.rs
+++ b/kube-derive/src/lib.rs
@@ -111,11 +111,21 @@ mod custom_resource;
 /// Adding `#[kube(derive = "PartialEq")]` is required if you want your generated
 /// top level type to be able to `#[derive(PartialEq)]`
 ///
-/// ### `#[kube(derive_schema = false)]`
-/// Disables the automatic `#[derive(JsonSchema)]` on the top level generated type.
+/// ### `#[kube(schema_mode = "mode")]`
+/// Defines whether the `JsonSchema` of the top level generated type should be used when generating a `CustomResourceDefinition`.
 ///
-/// This can be used to provide a completely custom schema, or to interact with third-party custom resources,
+/// Legal values:
+/// - `"derived"`: A `JsonSchema` implementation is automatically derived
+/// - `"custom"`: `JsonSchema` is not derived, but used when creating the `CustomResource` object
+/// - `"disabled"`: No `JsonSchema` is used
+///
+/// This can be used to provide a completely custom schema, or to interact with third-party custom resources
 /// where you are not responsible for installing the `CustomResourceDefinition`.
+///
+/// Defaults to `"disabled"` when `apiextensions = "v1beta1"`, otherwise `"derived"`.
+///
+/// NOTE: `apiextensions = "v1"` `CustomResourceDefinition`s require a schema. If `schema_mode = "disabled"` then
+/// `Self::crd()` will not be installable into the cluster as-is.
 ///
 /// ### `#[kube(scale = r#"json"#)]`
 /// Allow customizing the scale struct for the [scale subresource](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#subresources).

--- a/kube-derive/src/lib.rs
+++ b/kube-derive/src/lib.rs
@@ -116,7 +116,7 @@ mod custom_resource;
 ///
 /// Legal values:
 /// - `"derived"`: A `JsonSchema` implementation is automatically derived
-/// - `"custom"`: `JsonSchema` is not derived, but used when creating the `CustomResource` object
+/// - `"custom"`: `JsonSchema` is not derived, but used when creating the `CustomResourceDefinition` object
 /// - `"disabled"`: No `JsonSchema` is used
 ///
 /// This can be used to provide a completely custom schema, or to interact with third-party custom resources

--- a/kube-derive/src/lib.rs
+++ b/kube-derive/src/lib.rs
@@ -111,6 +111,12 @@ mod custom_resource;
 /// Adding `#[kube(derive = "PartialEq")]` is required if you want your generated
 /// top level type to be able to `#[derive(PartialEq)]`
 ///
+/// ### `#[kube(derive_schema = false)]`
+/// Disables the automatic `#[derive(JsonSchema)]` on the top level generated type.
+///
+/// This can be used to provide a completely custom schema, or to interact with third-party custom resources,
+/// where you are not responsible for installing the `CustomResourceDefinition`.
+///
 /// ### `#[kube(scale = r#"json"#)]`
 /// Allow customizing the scale struct for the [scale subresource](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#subresources).
 ///
@@ -190,7 +196,7 @@ mod custom_resource;
 ///
 /// See [kubernetes openapi validation](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#validation) for the format of the OpenAPI v3 schemas.
 ///
-/// If you have to override a lot, [you can opt-out of schema-generation entirely](https://github.com/kube-rs/kube-rs/issues/355#issuecomment-751253657)
+/// If you have to override a lot, [you can opt-out of schema-generation entirely](#kubederive_schema--false)
 ///
 /// ## Advanced Features
 /// - **embedding k8s-openapi types** can be done by enabling the `schemars` feature of `k8s-openapi` from [`0.13.0`](https://github.com/Arnavion/k8s-openapi/blob/master/CHANGELOG.md#v0130-2021-08-09)


### PR DESCRIPTION
The feature-flag approach was problematic since it applies to the whole dependency tree: as long as *any* crate depends on `kube_derive` without disabling default features then the derived schema becomes mandatory.

This PR adds a new `#[kube(derive_schema = false)]` attribute that allows you to specify this per kind.