### PR TITLE
attempt upgrading rustls to 0.20.0 - for #644

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -108,5 +108,5 @@ The `crd_reflector` will just await changes. You can run `kubectl apply -f crd-b
 Disable default features and enable `rustls-tls`:
 
 ```sh
-cargo run --example pod_watcher --no-default-features --features=rustls-tls
+cargo run --example pod_watcher --no-default-features --features=rustls-tls,latest
 ```

--- a/examples/README.md
+++ b/examples/README.md
@@ -40,7 +40,7 @@ How deriving `CustomResource` works in practice, and how it interacts with the [
 cargo run --example crd_api
 cargo run --example crd_derive
 cargo run --example crd_derive_schema
-cargo run --example crd_derive_no_schema --no-default-features --features=native-tls
+cargo run --example crd_derive_no_schema --no-default-features --features=native-tls,latest
 ```
 
 The last one opts out from the default `schema` feature from `kube-derive` (and thus the need for you to derive/impl `JsonSchema`).
@@ -108,5 +108,5 @@ The `crd_reflector` will just await changes. You can run `kubectl apply -f crd-b
 Disable default features and enable `rustls-tls`:
 
 ```sh
-cargo run --example pod_watcher --no-default-features --features=rustls-tls,latest
+cargo run --example pod_watcher --no-default-features --features=rustls-tls,latest,runtime
 ```

--- a/examples/pod_watcher.rs
+++ b/examples/pod_watcher.rs
@@ -4,14 +4,16 @@ use k8s_openapi::api::core::v1::Pod;
 use kube::{
     api::{Api, ListParams, ResourceExt},
     runtime::{utils::try_flatten_applied, watcher},
-    Client,
+    Client, Config,
 };
 
 #[tokio::main]
 async fn main() -> Result<()> {
     std::env::set_var("RUST_LOG", "info,kube=debug");
     env_logger::init();
-    let client = Client::try_default().await?;
+    let config = Config::infer().await?;
+    tracing::info!("config is: {:?}", config);
+    let client = Client::try_from(config)?;
     let namespace = std::env::var("NAMESPACE").unwrap_or_else(|_| "default".into());
     let api = Api::<Pod>::namespaced(client, &namespace);
     let watcher = watcher(api, ListParams::default());

--- a/kube-client/Cargo.toml
+++ b/kube-client/Cargo.toml
@@ -51,7 +51,7 @@ futures = { version = "0.3.17", optional = true }
 pem = { version = "0.8.2", optional = true }
 openssl = { version = "0.10.36", optional = true }
 tokio-native-tls = { version = "0.3.0", optional = true }
-rustls = { version = "0.19.1", features = ["dangerous_configuration"], optional = true }
+rustls = { version = "0.20.0", optional = true }
 rustls-pemfile = { version = "0.2.1", optional = true }
 webpki = { version = "0.21.4", optional = true }
 bytes = { version = "1.1.0", optional = true }

--- a/kube-client/Cargo.toml
+++ b/kube-client/Cargo.toml
@@ -62,7 +62,7 @@ tokio-util = { version = "0.6.8", optional = true, features = ["io", "codec"] }
 hyper = { version = "0.14.13", optional = true, features = ["client", "http1", "stream", "tcp"] }
 hyper-tls = { version = "0.5.0", optional = true }
 #hyper-rustls = { version = "0.22.1", optional = true }
-hyper-rustls = { git = "https://github.com/g2p/hyper-rustls.git", rev = "30c6f4756c7140e5f374fcfd7ea2f12b580d4679", optional = true }
+hyper-rustls = { git = "https://github.com/g2p/hyper-rustls.git", rev = "05f5a0bd384451f21dd72e7ca3e2467688b78c84", optional = true }
 tokio-tungstenite = { version = "0.15.0", optional = true }
 tower = { version = "0.4.6", optional = true, features = ["buffer", "util"] }
 tower-http = { version = "0.1.1", optional = true, features = ["auth", "map-response-body", "trace"] }

--- a/kube-client/Cargo.toml
+++ b/kube-client/Cargo.toml
@@ -51,7 +51,7 @@ futures = { version = "0.3.17", optional = true }
 pem = { version = "0.8.2", optional = true }
 openssl = { version = "0.10.36", optional = true }
 tokio-native-tls = { version = "0.3.0", optional = true }
-rustls = { version = "0.20.0", optional = true }
+rustls = { version = "0.20.0", features = ["dangerous_configuration"], optional = true }
 rustls-pemfile = { version = "0.2.1", optional = true }
 webpki = { version = "0.21.4", optional = true }
 bytes = { version = "1.1.0", optional = true }
@@ -61,7 +61,8 @@ jsonpath_lib = { version = "0.3.0", optional = true }
 tokio-util = { version = "0.6.8", optional = true, features = ["io", "codec"] }
 hyper = { version = "0.14.13", optional = true, features = ["client", "http1", "stream", "tcp"] }
 hyper-tls = { version = "0.5.0", optional = true }
-hyper-rustls = { version = "0.22.1", optional = true }
+#hyper-rustls = { version = "0.22.1", optional = true }
+hyper-rustls = { git = "https://github.com/g2p/hyper-rustls.git", rev = "30c6f4756c7140e5f374fcfd7ea2f12b580d4679", optional = true }
 tokio-tungstenite = { version = "0.15.0", optional = true }
 tower = { version = "0.4.6", optional = true, features = ["buffer", "util"] }
 tower-http = { version = "0.1.1", optional = true, features = ["auth", "map-response-body", "trace"] }

--- a/kube-client/src/client/tls.rs
+++ b/kube-client/src/client/tls.rs
@@ -79,6 +79,7 @@ pub mod rustls_tls {
                     .map_err(|e| Error::SslError(format!("{}", e)))?;
             }
         }
+        let has_roots = !roots.is_empty();
 
         // rustls client config require a complicated series of steps through an ordered builder
         // See https://docs.rs/rustls/0.20.0/rustls/struct.ConfigBuilder.html
@@ -143,7 +144,7 @@ pub mod rustls_tls {
             cfgbld
                 .with_single_cert(certs, key)
                 .map_err(|e| Error::SslError(format!("{}", e)))?
-        } else if accept_invalid || true {
+        } else if accept_invalid || !has_roots {
             let mut cfgbld = cfgbld.with_no_client_auth();
             cfgbld
                 .dangerous()


### PR DESCRIPTION
a bit of major change based on the massive release history in https://github.com/rustls/rustls#release-history

it has some helpful changes:
- allowing an empty [root cert store struct](https://docs.rs/rustls/0.20.0/rustls/struct.RootCertStore.html)
- ~~not having to implement the no client verification strategy ourselves~~ seems to not work
- ~~and we can do this without enabling dangerous configuration features~~ no, still need it for token auth

but it also:
- changes the [ClientConfig::builder to enforce a particular order](https://docs.rs/rustls/0.20.0/rustls/struct.ConfigBuilder.html#)
- ~~somehow breaks the magic [`From` implementation for `hyper_rustls::HttpsConnector`](https://docs.rs/hyper-rustls/0.22.1/hyper_rustls/struct.HttpsConnector.html#impl-From%3C(H%2C%20C)%3E)~~

not sure i got it all correct, or if i have changed behaviour subly, but it compiles now and can run **on some clusters**.

<details><summary>edited out confusion about rustls</summary>
<p>

however, have currently not gotten the last `From` impl to work... It currently fails with:

```
error[E0277]: the trait bound `Arc<rustls::client::ClientConfig>: From<Arc<ClientConfig>>` is not satisfied
   --> kube-client/src/client/config_ext.rs:155:12
    |
155 |         Ok(hyper_rustls::HttpsConnector::from((http, rustls_config)))
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `From<Arc<ClientConfig>>` is not implemented for `Arc<rustls::client::ClientConfig>`
    |
    = help: the following implementations were found:
              <Arc<B> as From<Cow<'a, B>>>
              <Arc<CStr> as From<&CStr>>
              <Arc<CStr> as From<CString>>
              <Arc<OsStr> as From<&OsStr>>
            and 9 others
    = note: required because of the requirements on the impl of `Into<Arc<rustls::client::ClientConfig>>` for `Arc<ClientConfig>`
    = note: required because of the requirements on the impl of `From<(HttpConnector, Arc<ClientConfig>)>` for `HttpsConnector<HttpConnector>`
```
</p>
</details>

relies on the [hyper-rustls](https://github.com/rustls/hyper-rustls) rustls 0.20 branch 
