### PR TITLE
Work around Security Framework failing to import PKCS12 from OpenSSL 3

### DIFF
--- a/kube-client/src/client/tls.rs
+++ b/kube-client/src/client/tls.rs
@@ -56,7 +56,7 @@ pub mod native_tls {
             let mut builder = Pkcs12::builder();
             builder
                 .key_algorithm(Nid::PBE_WITHSHA1AND3_KEY_TRIPLEDES_CBC)
-                .cert_algorithm(Nid::PBE_WITHSHA1AND40BITRC2_CBC);
+                .cert_algorithm(Nid::PBE_WITHSHA1AND3_KEY_TRIPLEDES_CBC);
             builder
         };
         let p12 = p12_builder


### PR DESCRIPTION
Should be a workaround for #691.

OpenSSL 3 made the following breaking changes for PKCS#12:

> **PKCS#12 API updates**
>
> The default algorithms for pkcs12 creation with the PKCS12_create() function were changed to more modern PBKDF2 and AES based algorithms. The default MAC iteration count was changed to PKCS12_DEFAULT_ITER to make it equal with the password-based encryption iteration count. The default digest algorithm for the MAC computation was changed to SHA-256. The pkcs12 application now supports -legacy option that restores the previous default algorithms to support interoperability with legacy systems.
> https://www.openssl.org/docs/man3.0/man7/migration_guide.html#PKCS-12-API-updates

Security Framework used by `native_tls` on macOS and iOS [fails to import PKCS#12 with modern cyphers](https://openradar.appspot.com/FB8988319).

Work around this by using the legacy algorithms on macOS.

I don't know if Windows is affected, we can just change the `#[cfg]` if it is.

---

@danni-m

Can you try this branch?

```toml
kube = { git = "https://github.com/kazk/kube-rs", branch = "fix-macos-openssl3", features = ["derive", "native-tls"] }
```