### PR TITLE
Add `openssl-tls` feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Test kube with features rustls-tls,ws,oauth
         run: cargo test -p kube --lib --no-default-features --features=rustls-tls,ws,oauth
         if: matrix.os == 'ubuntu-latest'
+      - name: Test kube with features openssl-tls,ws,oauth
+        run: cargo test -p kube --lib --no-default-features --features=openssl-tls,ws,oauth
+        if: matrix.os == 'ubuntu-latest'
       # Feature tests in examples
       - name: Test crd_derive_no_schema example
         run: cargo test -p examples --example crd_derive_no_schema --no-default-features --features=native-tls,latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ UNRELEASED
    - If you currently disable default `kube-derive` default features to avoid automatic schema generation, add `#[kube(schema = "disabled")]` to your spec struct instead
  * BREAKING: Moved `CustomResource` derive crate overrides into subattribute `#[kube(crates(...))]` - #690
    - Replace `#[kube(kube_core = .., k8s_openapi = .., schema = .., serde = .., serde_json = ..)]` with `#[kube(crates(kube_core = .., k8s_openapi = .., schema = .., serde = .., serde_json = ..))]`
+ * Added `openssl-tls` feature to use `openssl` for TLS on all platforms. Note that, even though `native-tls` uses a platform specific TLS, `kube` requires `openssl` on all platforms because `native-tls` only allows PKCS12 input to load certificates and private key at the moment, and creating PKCS12 requires `openssl`. - #700
+
 ### Refining Errors
 
 We started working on improving error ergonomics (tracking issue: #688).

--- a/kube-client/Cargo.toml
+++ b/kube-client/Cargo.toml
@@ -19,6 +19,7 @@ edition = "2021"
 default = ["client", "native-tls"]
 native-tls = ["openssl", "hyper-tls", "tokio-native-tls"]
 rustls-tls = ["rustls", "rustls-pemfile", "hyper-rustls", "webpki"]
+openssl-tls = ["openssl", "hyper-openssl"]
 ws = ["client", "tokio-tungstenite", "rand", "kube-core/ws"]
 oauth = ["client", "tame-oauth"]
 gzip = ["client", "tower-http/decompression-gzip"]
@@ -32,7 +33,7 @@ deprecated-crd-v1beta1 = ["kube-core/deprecated-crd-v1beta1"]
 __non_core = ["tracing", "serde_yaml", "base64"]
 
 [package.metadata.docs.rs]
-features = ["client", "native-tls", "rustls-tls", "ws", "oauth", "jsonpatch", "admission", "k8s-openapi/v1_22"]
+features = ["client", "native-tls", "rustls-tls", "openssl-tls", "ws", "oauth", "jsonpatch", "admission", "k8s-openapi/v1_22"]
 # Define the configuration attribute `docsrs`. Used to enable `doc_cfg` feature.
 rustdoc-args = ["--cfg", "docsrs"]
 
@@ -70,6 +71,7 @@ tame-oauth = { version = "0.4.7", features = ["gcp"], optional = true }
 pin-project = { version = "1.0.4", optional = true }
 rand = { version = "0.8.3", optional = true }
 tracing = { version = "0.1.29", features = ["log"], optional = true }
+hyper-openssl = { version = "0.9.1", optional = true }
 
 [dependencies.k8s-openapi]
 version = "0.13.1"

--- a/kube-client/src/error.rs
+++ b/kube-client/src/error.rs
@@ -69,6 +69,12 @@ pub enum Error {
     #[error("OpensslError: {0}")]
     OpensslError(#[source] openssl::error::ErrorStack),
 
+    /// Errors from OpenSSL TLS
+    #[cfg(feature = "openssl-tls")]
+    #[cfg_attr(docsrs, doc(feature = "openssl-tls"))]
+    #[error("openssl tls error: {0}")]
+    OpensslTls(#[source] crate::client::OpensslTlsError),
+
     /// Failed to upgrade to a WebSocket connection
     #[cfg(feature = "ws")]
     #[cfg_attr(docsrs, doc(cfg(feature = "ws")))]

--- a/kube/Cargo.toml
+++ b/kube/Cargo.toml
@@ -19,6 +19,7 @@ edition = "2021"
 default = ["client", "native-tls"]
 native-tls = ["kube-client/native-tls"]
 rustls-tls = ["kube-client/rustls-tls"]
+openssl-tls = ["kube-client/openssl-tls"]
 ws = ["kube-client/ws", "kube-core/ws"]
 oauth = ["kube-client/oauth"]
 gzip = ["kube-client/gzip"]
@@ -31,7 +32,7 @@ runtime = ["kube-runtime"]
 deprecated-crd-v1beta1 = ["kube-core/deprecated-crd-v1beta1"]
 
 [package.metadata.docs.rs]
-features = ["client", "native-tls", "rustls-tls", "derive", "ws", "oauth", "jsonpatch", "admission", "runtime", "k8s-openapi/v1_22"]
+features = ["client", "native-tls", "rustls-tls", "openssl-tls", "derive", "ws", "oauth", "jsonpatch", "admission", "runtime", "k8s-openapi/v1_22"]
 # Define the configuration attribute `docsrs`. Used to enable `doc_cfg` feature.
 rustdoc-args = ["--cfg", "docsrs"]
 


### PR DESCRIPTION
Looked into this after discussing the possibility of "OpenSSL everywhere" in #693, and decided to implement since it looked straightforward. As far as I can tell, `kube` ended up with `native-tls` + `openssl` because:

- `reqwest` is either `native-tls` (default) or `rustls-tls`
- `rustls-tls` has limitations
- `native-tls` requires PKCS#12 to support client certificates-based authentication, and `openssl` is required to create PKCS#12

`native-tls` is still nice to keep for macOS and Windows once PKCS#8 is supported.