### PR TITLE
Update `rustls` to 0.20.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,11 @@ UNRELEASED
 ===================
  * see https://github.com/kube-rs/kube-rs/compare/0.64.0...master
 
- * BREAKING: Removed `kube::Error::OpenSslError`
- * BREAKING: Added `kube::Error::NativeTls(kube::client::NativeTlsError)` for errors from native TLS
+ * BREAKING: Removed `kube::Error::OpenSslError` - #716
+ * BREAKING: Removed `kube::Error::SslError` - #704 and #716
+ * BREAKING: Added `kube::Error::NativeTls(kube::client::NativeTlsError)` for errors from Native TLS - #716
+ * BREAKING: Added `kube::Error::RustlsTls(kube::client::RustlsTlsError)` for errors from Rustls TLS - #704
+ * Updated `rustls` to 0.20.1 - #704
 
 0.64.0 / 2021-11-16
 ===================

--- a/deny.toml
+++ b/deny.toml
@@ -62,3 +62,10 @@ allow-git = []
 
 [bans]
 multiple-versions = "deny"
+skip = [
+    # warp uses an older version of rustls (warp is only used in the examples)
+    { name = "rustls", version = "=0.19.1" },
+    { name = "webpki", version = "=0.21.4" },
+    { name = "tokio-rustls", version = "=0.22.0" },
+    { name = "sct", version = "=0.6.1" },
+]

--- a/examples/README.md
+++ b/examples/README.md
@@ -40,7 +40,7 @@ How deriving `CustomResource` works in practice, and how it interacts with the [
 cargo run --example crd_api
 cargo run --example crd_derive
 cargo run --example crd_derive_schema
-cargo run --example crd_derive_no_schema --no-default-features --features=native-tls
+cargo run --example crd_derive_no_schema --no-default-features --features=native-tls,latest
 ```
 
 The last one opts out from the default `schema` feature from `kube-derive` (and thus the need for you to derive/impl `JsonSchema`).
@@ -108,5 +108,5 @@ The `crd_reflector` will just await changes. You can run `kubectl apply -f crd-b
 Disable default features and enable `rustls-tls`:
 
 ```sh
-cargo run --example pod_watcher --no-default-features --features=rustls-tls
+cargo run --example pod_watcher --no-default-features --features=rustls-tls,latest,runtime
 ```

--- a/kube-client/Cargo.toml
+++ b/kube-client/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2021"
 [features]
 default = ["client", "native-tls"]
 native-tls = ["openssl", "hyper-tls", "tokio-native-tls"]
-rustls-tls = ["rustls", "rustls-pemfile", "hyper-rustls", "webpki"]
+rustls-tls = ["rustls", "rustls-pemfile", "hyper-rustls"]
 openssl-tls = ["openssl", "hyper-openssl"]
 ws = ["client", "tokio-tungstenite", "rand", "kube-core/ws"]
 oauth = ["client", "tame-oauth"]
@@ -52,9 +52,8 @@ futures = { version = "0.3.17", optional = true }
 pem = { version = "1.0.1", optional = true }
 openssl = { version = "0.10.36", optional = true }
 tokio-native-tls = { version = "0.3.0", optional = true }
-rustls = { version = "0.19.1", features = ["dangerous_configuration"], optional = true }
+rustls = { version = "0.20.1", features = ["dangerous_configuration"], optional = true }
 rustls-pemfile = { version = "0.2.1", optional = true }
-webpki = { version = "0.21.4", optional = true }
 bytes = { version = "1.1.0", optional = true }
 tokio = { version = "1.14.0", features = ["time", "signal", "sync"], optional = true }
 kube-core = { path = "../kube-core", version = "^0.64.0"}
@@ -62,7 +61,7 @@ jsonpath_lib = { version = "0.3.0", optional = true }
 tokio-util = { version = "0.6.8", optional = true, features = ["io", "codec"] }
 hyper = { version = "0.14.13", optional = true, features = ["client", "http1", "stream", "tcp"] }
 hyper-tls = { version = "0.5.0", optional = true }
-hyper-rustls = { version = "0.22.1", optional = true }
+hyper-rustls = { version = "0.23.0", optional = true }
 tokio-tungstenite = { version = "0.15.0", optional = true }
 tower = { version = "0.4.6", optional = true, features = ["buffer", "util"] }
 tower-http = { version = "0.1.1", optional = true, features = ["auth", "map-response-body", "trace"] }

--- a/kube-client/src/client/auth/oauth.rs
+++ b/kube-client/src/client/auth/oauth.rs
@@ -120,7 +120,11 @@ impl Gcp {
                     not(any(feature = "openssl-tls", feature = "native-tls")),
                     feature = "rustls-tls"
                 ))]
-                let https = hyper_rustls::HttpsConnector::with_native_roots();
+                let https = hyper_rustls::HttpsConnectorBuilder::new()
+                    .with_native_roots()
+                    .https_only()
+                    .enable_http1()
+                    .build();
 
                 let client = hyper::Client::builder().build::<_, hyper::Body>(https);
 

--- a/kube-client/src/client/config_ext.rs
+++ b/kube-client/src/client/config_ext.rs
@@ -200,8 +200,8 @@ impl ConfigExt for Config {
     #[cfg(feature = "rustls-tls")]
     fn rustls_client_config(&self) -> Result<rustls::ClientConfig> {
         tls::rustls_tls::rustls_client_config(
-            self.identity_pem.as_ref(),
-            self.root_cert.as_ref(),
+            self.identity_pem.as_deref(),
+            self.root_cert.as_deref(),
             self.accept_invalid_certs,
         )
     }

--- a/kube-client/src/client/config_ext.rs
+++ b/kube-client/src/client/config_ext.rs
@@ -204,6 +204,7 @@ impl ConfigExt for Config {
             self.root_cert.as_deref(),
             self.accept_invalid_certs,
         )
+        .map_err(Error::RustlsTls)
     }
 
     #[cfg(feature = "rustls-tls")]

--- a/kube-client/src/client/mod.rs
+++ b/kube-client/src/client/mod.rs
@@ -43,6 +43,7 @@ mod tls;
 #[cfg(feature = "native-tls")] pub use tls::native_tls::Error as NativeTlsError;
 #[cfg(feature = "openssl-tls")]
 pub use tls::openssl_tls::Error as OpensslTlsError;
+#[cfg(feature = "rustls-tls")] pub use tls::rustls_tls::Error as RustlsTlsError;
 #[cfg(feature = "ws")] mod upgrade;
 
 #[cfg(feature = "oauth")]

--- a/kube-client/src/error.rs
+++ b/kube-client/src/error.rs
@@ -59,10 +59,6 @@ pub enum Error {
     #[error("Error from discovery: {0}")]
     Discovery(#[source] DiscoveryError),
 
-    /// An error with configuring SSL occured
-    #[error("SslError: {0}")]
-    SslError(String),
-
     /// Errors from Native TLS
     #[cfg(feature = "native-tls")]
     #[cfg_attr(docsrs, doc(cfg(feature = "native-tls")))]
@@ -74,6 +70,12 @@ pub enum Error {
     #[cfg_attr(docsrs, doc(feature = "openssl-tls"))]
     #[error("openssl tls error: {0}")]
     OpensslTls(#[source] crate::client::OpensslTlsError),
+
+    /// Errors from Rustls TLS
+    #[cfg(feature = "rustls-tls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "rustls-tls")))]
+    #[error("rustls tls error: {0}")]
+    RustlsTls(#[source] crate::client::RustlsTlsError),
 
     /// Failed to upgrade to a WebSocket connection
     #[cfg(feature = "ws")]


### PR DESCRIPTION
Continuing from #692 for #644 after rebasing. `webpki` is no longer necessary, so this is the last one.

#### TODO

- [x] Refine errors
- [x] Replace `hyper_rustls::HttpsConnector::with_native_roots` with `HttpsConnectorBuilder`
- [x] Use published `hyper-rustls` (https://github.com/rustls/hyper-rustls/pull/159)

---

Closes #644 