### PR TITLE
cargo deny mutliple-fields ban

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -60,8 +60,5 @@ unknown-git = "warn"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 allow-git = []
 
-[sources.allow-org]
-github = ["kube-rs"]
-
 [bans]
 multiple-versions = "deny"

--- a/deny.toml
+++ b/deny.toml
@@ -62,3 +62,6 @@ allow-git = []
 
 [sources.allow-org]
 github = ["kube-rs"]
+
+[bans]
+multiple-versions = "deny"

--- a/kube-runtime/Cargo.toml
+++ b/kube-runtime/Cargo.toml
@@ -33,7 +33,6 @@ tracing = "0.1.29"
 json-patch = "0.2.6"
 serde_json = "1.0.68"
 thiserror = "1.0.29"
-tokio-tungstenite = "0.14.*"
 
 [dependencies.k8s-openapi]
 version = "0.13.1"

--- a/kube-runtime/Cargo.toml
+++ b/kube-runtime/Cargo.toml
@@ -33,6 +33,7 @@ tracing = "0.1.29"
 json-patch = "0.2.6"
 serde_json = "1.0.68"
 thiserror = "1.0.29"
+tokio-tungstenite = "0.14.*"
 
 [dependencies.k8s-openapi]
 version = "0.13.1"


### PR DESCRIPTION
using https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html#the-multiple-versions-field-optional
to try to prevent issues like https://github.com/kube-rs/kube-rs/issues/709 in the future

i had issues originally, but deleted my local `Cargo.lock` and on a rebuild all the duplicates had gone away.

will add and remove a duplicate dependency here to ensure that this setup works.

(there are ways to temporarily whitelist from the duplicate ban list, so this shouldn't be a big inconvenience)