### PR TITLE
showcase rate limiting strategies on custom clients in example

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -49,7 +49,7 @@ tracing-subscriber = "0.2.25"
 warp = { version = "0.3", features = ["tls"] }
 http = "0.2.5"
 json-patch = "0.2.6"
-tower = { version = "0.4.6" }
+tower = { version = "0.4.6", features = ["limit"] }
 tower-http = { version = "0.1.0", features = ["trace", "decompression-gzip"] }
 hyper = { version = "0.14.13", features = ["client", "http1", "stream", "tcp"] }
 thiserror = "1.0.29"

--- a/examples/custom_client_trace.rs
+++ b/examples/custom_client_trace.rs
@@ -20,7 +20,7 @@ async fn main() -> anyhow::Result<()> {
     let service = ServiceBuilder::new()
         .layer(config.base_uri_layer())
         // showcase rate limiting; max 10rps, and 4 concurrent
-        .layer(tower::limit::RateLimitLayer::new(10, std::time::Duration::from_secs(1)))
+        .layer(tower::limit::RateLimitLayer::new(10, Duration::from_secs(1)))
         .layer(tower::limit::ConcurrencyLimitLayer::new(4))
         // Add `DecompressionLayer` to make request headers interesting.
         .layer(DecompressionLayer::new())

--- a/examples/custom_client_trace.rs
+++ b/examples/custom_client_trace.rs
@@ -19,6 +19,9 @@ async fn main() -> anyhow::Result<()> {
     let https = config.native_tls_https_connector()?;
     let service = ServiceBuilder::new()
         .layer(config.base_uri_layer())
+        // showcase rate limiting; max 10rps, and 4 concurrent
+        .layer(tower::limit::RateLimitLayer::new(10, std::time::Duration::from_secs(1)))
+        .layer(tower::limit::ConcurrencyLimitLayer::new(4))
         // Add `DecompressionLayer` to make request headers interesting.
         .layer(DecompressionLayer::new())
         .layer(


### PR DESCRIPTION
minor thing to close an old issue.

using custom_client_trace example for now.. could maybe make a separate example for it.