### PR TITLE
Possibly fix "the binary target name `examples` is forbidden" error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,11 +34,11 @@ jobs:
       - name: Run workspace doc tests
         run: cargo test --doc --all -j6
       - name: Test examples
-        run: cargo test -p examples --examples -j6
+        run: cargo test -p kube-examples --examples -j6
       - name: Compile check remaining examples
         # No OS specific code in examples, run this on fastest executor
         if: matrix.os == 'ubuntu-latest'
-        run: cargo build -j4 -p examples
+        run: cargo build -j4 -p kube-examples
 
       # Feature tests
       - name: Test kube with features native-tls,ws,oauth
@@ -52,10 +52,10 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
       # Feature tests in examples
       - name: Test crd_derive_no_schema example
-        run: cargo test -p examples --example crd_derive_no_schema --no-default-features --features=native-tls,latest
+        run: cargo test -p kube-examples --example crd_derive_no_schema --no-default-features --features=native-tls,latest
         if: matrix.os == 'ubuntu-latest'
       - name: Test crd_api example with deprecated crd
-        run: cargo test -p examples --example crd_api --no-default-features --features=deprecated,kubederive,native-tls
+        run: cargo test -p kube-examples --example crd_api --no-default-features --features=deprecated,kubederive,native-tls
         if: matrix.os == 'ubuntu-latest'
 
   check-msrv:

--- a/Makefile
+++ b/Makefile
@@ -17,17 +17,17 @@ doc:
 test:
 	cargo test --lib --all
 	cargo test --doc --all
-	cargo test -p examples --examples
+	cargo test -p kube-examples --examples
 	cargo test -p kube --lib --no-default-features --features=rustls-tls,ws,oauth
 	cargo test -p kube --lib --no-default-features --features=native-tls,ws,oauth
 	cargo test -p kube --lib --no-default-features
-	cargo test -p examples --example crd_api --no-default-features --features=deprecated,kubederive,native-tls
+	cargo test -p kube-examples --example crd_api --no-default-features --features=deprecated,kubederive,native-tls
 
 test-kubernetes:
 	cargo test --lib --all -- --ignored # also run tests that fail on github actions
 	cargo test -p kube --features=derive -- --ignored
-	cargo run -p examples --example crd_derive
-	cargo run -p examples --example crd_api
+	cargo run -p kube-examples --example crd_derive
+	cargo run -p kube-examples --example crd_api
 
 readme:
 	rustdoc README.md --test --edition=2021

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "examples"
+name = "kube-examples"
 version = "0.1.0"
 authors = [
   "clux <sszynrae@gmail.com>",


### PR DESCRIPTION
Depdendabot has been failing with the following error:

```text
Dependabot can't resolve your Rust dependency files

Dependabot failed to update your dependencies because there was an error resolving your Rust dependency files.

Dependabot encountered the following error:

error: failed to parse manifest at `/home/dependabot/dependabot-updater/dependabot_tmp_dir/examples/Cargo.toml`

Caused by:
  the binary target name `examples` is forbidden, it conflicts with with cargo's build directory names
```

Try changing the name of the target to `kube-examples`.