### PR TITLE
Include the object that failed in controller::Error::ReconcilerFailed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ UNRELEASED
  * BREAKING: Added `kube::Error::NativeTls(kube::client::NativeTlsError)` for errors from Native TLS - #716
  * BREAKING: Added `kube::Error::RustlsTls(kube::client::RustlsTlsError)` for errors from Rustls TLS - #704
  * Updated `rustls` to 0.20.1 - #704
+ * BREAKING: Added `ObjectRef` to the object that failed to be reconciled to `kube_runtime::controller::Error::ReconcileFailed`
 
 0.64.0 / 2021-11-16
 ===================

--- a/kube-runtime/src/controller/mod.rs
+++ b/kube-runtime/src/controller/mod.rs
@@ -38,13 +38,13 @@ mod runner;
 
 #[derive(Debug, Error)]
 pub enum Error<ReconcilerErr: std::error::Error + 'static, QueueErr: std::error::Error + 'static> {
-    #[error("ObjectNotFound")]
+    #[error("tried to reconcile object {0} that was not found in local store")]
     ObjectNotFound(ObjectRef<DynamicObject>),
-    #[error("ReconcilerFailed: {0}")]
-    ReconcilerFailed(#[source] ReconcilerErr),
-    #[error("SchedulerDequeueFailed: {0}")]
+    #[error("reconciler for object {1} failed")]
+    ReconcilerFailed(#[source] ReconcilerErr, ObjectRef<DynamicObject>),
+    #[error("scheduler dequeue failed")]
     SchedulerDequeueFailed(#[source] scheduler::Error),
-    #[error("QueueError: {0}")]
+    #[error("event queue error")]
     QueueError(#[source] QueueErr),
 }
 
@@ -306,9 +306,10 @@ where
                     })
                     .await;
             }
-            reconciler_result
-                .map(|action| (obj_ref, action))
-                .map_err(Error::ReconcilerFailed)
+            match reconciler_result {
+                Ok(action) => Ok((obj_ref, action)),
+                Err(err) => Err(Error::ReconcilerFailed(err, obj_ref.erase()))
+            }
         }
     })
     .on_complete(async { tracing::debug!("applier terminated") })

--- a/kube/src/lib.rs
+++ b/kube/src/lib.rs
@@ -204,7 +204,7 @@ mod test {
         let gvk = GroupVersionKind::gvk("clux.dev", "v1", "Foo");
         let api_resource = ApiResource::from_gvk(&gvk);
         let a1: Api<DynamicObject> = Api::namespaced_with(client.clone(), "myns", &api_resource);
-        let a2: Api<Foo> = Api::namespaced(client.clone(), "myns");
+        let a2: Api<Foo> = Api::namespaced(client, "myns");
 
         // make sure they return the same url_path through their impls
         assert_eq!(a1.resource_url(), a2.resource_url());


### PR DESCRIPTION
## Motivation

Most errors are influenced by the object being reconciled, so including it is useful to diagnose the problem. Typically I end up including this myself in the concrete error type, but that's a lot of repetitive typing for something that kube-runtime already knows about.

## Solution

Add it to the global `ReconcilerFailed` variant instead.