### PR TITLE
dedicate a root file to adopters

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -4,7 +4,7 @@
 
 - [linkerd-policy-controller](https://github.com/linkerd/linkerd2/tree/main/policy-controller) - the policy controllers for the Linkerd service mesh
 - [krustlet](https://github.com/krustlet/krustlet) - a complete `WASM` running `kubelet`
-- [stackabletech operators](https://github.com/stackabletech) - ([kafka](https://github.com/stackabletech/kafka-operator), [zookeeper](https://github.com/stackabletech/zookeeper-operator), and more)
+- [stackable operators](https://github.com/stackabletech) - ([kafka](https://github.com/stackabletech/kafka-operator), [zookeeper](https://github.com/stackabletech/zookeeper-operator), and more)
 - [kdash tui](https://github.com/kdash-rs/kdash) - terminal dashboard for kubernetes
 - [logdna agent](https://github.com/logdna/logdna-agent-v2)
 - [kubeapps pinniped](https://github.com/kubeapps/kubeapps/tree/master/cmd/pinniped-proxy)

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,0 +1,26 @@
+# kube-rs adopters
+
+## Open Source
+
+- [linkerd-policy-controller](https://github.com/linkerd/linkerd2/tree/main/policy-controller) - the policy controllers for the Linkerd service mesh
+- [krustlet](https://github.com/krustlet/krustlet) - a complete `WASM` running `kubelet`
+- [stackabletech operators](https://github.com/stackabletech) - ([kafka](https://github.com/stackabletech/kafka-operator), [zookeeper](https://github.com/stackabletech/zookeeper-operator), and more)
+- [kdash tui](https://github.com/kdash-rs/kdash) - terminal dashboard for kubernetes
+- [logdna agent](https://github.com/logdna/logdna-agent-v2)
+- [kubeapps pinniped](https://github.com/kubeapps/kubeapps/tree/master/cmd/pinniped-proxy)
+- [kubectl-view-allocations](https://github.com/davidB/kubectl-view-allocations) - kubectl plugin to list resource allocations
+- [krator](https://github.com/krator-rs/krator) - kubernetes operators using state machines
+
+## Companies
+
+- [Buoyant](https://buoyant.io)
+- [Deis Labs](https://deislabs.io)
+- [Stackable](https://www.stackable.de)
+- [logdna](https://www.logdna.com)
+- [Bitnami](https://bitnami.com)
+- [Materialize](http://materialize.com)
+- [Qualified](https://www.qualified.io)
+- [TrueLayer](https://truelayer.com)
+
+If you're using kube-rs and aren't on this list, please [submit a pull
+request](https://github.com/kube-rs/kube-rs/edit/master/ADOPTERS.md)!

--- a/README.md
+++ b/README.md
@@ -38,18 +38,10 @@ See the **[examples directory](https://github.com/kube-rs/kube-rs/blob/master/ex
 
 Official examples:
 
-- [version-rs](https://github.com/kube-rs/version-rs): super lightweight reflector deployment with actix 2 and prometheus metrics
-- [controller-rs](https://github.com/kube-rs/controller-rs): `Controller` owned by a `Manager` inside actix
+- [version-rs](https://github.com/kube-rs/version-rs): lightweight deployment `reflector` using axum
+- [controller-rs](https://github.com/kube-rs/controller-rs): `Controller` of a crd inside actix
 
-Real world users:
-
-- [linkerd-policy-controller](https://github.com/linkerd/linkerd2/tree/main/policy-controller) - the policy controllers for the Linkerd service mesh
-- [krustlet](https://github.com/krustlet/krustlet) - a complete `WASM` running `kubelet`
-- [stackabletech operators](https://github.com/stackabletech) - ([kafka](https://github.com/stackabletech/kafka-operator), [zookeeper](https://github.com/stackabletech/zookeeper-operator), and more)
-- [kdash tui](https://github.com/kdash-rs/kdash) - terminal dashboard for kubernetes
-- [logdna agent](https://github.com/logdna/logdna-agent-v2)
-- [kubeapps pinniped](https://github.com/kubeapps/kubeapps/tree/master/cmd/pinniped-proxy)
-- [kubectl-view-allocations](https://github.com/davidB/kubectl-view-allocations) - kubectl plugin to list resource allocations
+For real world projects see [ADOPTERS](https://github.com/kube-rs/kube-rs/blob/master/ADOPTERS.md).
 
 ## Api
 


### PR DESCRIPTION
left an extra space for companies to submit similar to what [linkerd does](https://github.com/linkerd/linkerd2/blob/main/ADOPTERS.md). Seeded it with companies that can provably be shown to use it in public:

- Bouyant (linkerd policy controller)
- Deis Labs (krustlet)
- Stackable (linked github)
- logdna (v2 log agent)
- bitnami (kubeapps pinniped)
- Materialize ([nice little controller on top of aws eips](https://github.com/MaterializeInc/k8s-eip-operator))
- Qualified (e.g. [ephemeron](https://github.com/qualified))
- TrueLayer (private use - [honeycomb sli controller](https://twitter.com/algo_luca/status/1451845921780682764))

pretty certain aws is using it as well, but can't find it online.