### PR TITLE
doc = include_str! readme

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,26 +150,6 @@ jobs:
         with:
           command: check ${{ matrix.checks }}
 
-  docs:
-    name: Run rustfmt
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          override: true
-          toolchain: nightly
-          profile: minimal
-      # Smart caching for Rust projects.
-      # Includes workaround for macos cache corruption.
-      # - https://github.com/rust-lang/cargo/issues/8603
-      # - https://github.com/actions/cache/issues/403
-      - uses: Swatinem/rust-cache@v1
-
-      - name: Ensure markdown targets are valid
-        run: RUSTDOCFLAGS="-Dwarnings" cargo +nightly doc -p integration --lib
-
-
   rustfmt:
     name: Run rustfmt
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,26 @@ jobs:
         with:
           command: check ${{ matrix.checks }}
 
+  docs:
+    name: Run rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          override: true
+          toolchain: nightly
+          profile: minimal
+      # Smart caching for Rust projects.
+      # Includes workaround for macos cache corruption.
+      # - https://github.com/rust-lang/cargo/issues/8603
+      # - https://github.com/actions/cache/issues/403
+      - uses: Swatinem/rust-cache@v1
+
+      - name: Ensure markdown targets are valid
+        run: RUSTDOCFLAGS="-Dwarnings" cargo +nightly doc -p integration --lib
+
+
   rustfmt:
     name: Run rustfmt
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ println!("Got blog pod with containers: {:?}", p.spec.unwrap().containers);
 let patch = json!({"spec": {
     "activeDeadlineSeconds": 5
 }});
-let pp = PatchParams::apply("my_controller");
+let pp = PatchParams::apply("kube");
 let patched = pods.patch("blog", &pp, &Patch::Apply(patch)).await?;
 assert_eq!(patched.spec.active_deadline_seconds, Some(5));
 

--- a/integration/Cargo.toml
+++ b/integration/Cargo.toml
@@ -13,11 +13,15 @@ release = false
 name = "dapp"
 path = "dapp.rs"
 
+[lib]
+name = "docs"
+path = "docs.rs"
+
 [dependencies]
 anyhow = "1.0.44"
 env_logger = "0.9.0"
 futures = "0.3.17"
-kube = { path = "../kube", version = "^0.64.0", default-features = false, features = ["client", "rustls-tls"] }
+kube = { path = "../kube", version = "^0.64.0", default-features = false, features = ["client", "runtime", "derive", "rustls-tls"] }
 k8s-openapi = { version = "0.13.1", features = ["v1_22"], default-features = false }
 log = "0.4.11"
 serde_json = "1.0.68"

--- a/integration/docs.rs
+++ b/integration/docs.rs
@@ -1,0 +1,7 @@
+/// Doctests for CI
+pub mod docs {
+    /// Root README.md
+    pub mod readme {
+        #![doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/../README.md"))]
+    }
+}


### PR DESCRIPTION
minimal tests for the readme trying to follow: https://blog.guillaume-gomez.fr/articles/2021-08-03+Improvements+for+%23%5Bdoc%5D+attributes+in+Rust

<details><summary>investigation thoughts irrelevant now</summary>
<p>

it gave me errors when i didn't have enough features on kube in the integration crate where i stashed it, but after that it doesn't complain about anything anymore :(

maybe it just doesn't parse the inline code blocks ...

maybe we need to use [doc_comment](https://github.com/GuillaumeGomez/doc-comment) instead like [tokio](https://github.com/tokio-rs/tokio/blob/b42f21ec3e212ace25331d0c13889a45769e6006/tests-integration/src/lib.rs). that is a heavily deprecated crate though..

EDIT: turns out it "works" with `cargo test --doc --all`...

</p>
</details>
