### PR TITLE
Set up code coverage properly

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -31,8 +31,7 @@ jobs:
           version: '0.18.5'
           out-type: Xml
           timeout: 600
-          # NB: feature selection do not work yet
-          args: '--workspace --lib --ignored --doc -e integration -- --test-threads 1'
+          args: '--config=tarpaulin.toml -- --test-threads 1'
       - uses: codecov/codecov-action@v2
         with:
           flags: unittests,rust

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,10 +11,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Install stable toolchain
+      - name: Install nightly toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: nightly
           override: true
       - uses: Swatinem/rust-cache@v1
       - uses: AbsaOSS/k3d-action@v2
@@ -31,7 +31,8 @@ jobs:
           version: '0.18.5'
           out-type: Xml
           timeout: 600
-          args: '--workspace --bins --lib --doc --ignored -e examples -e integration -- --test-threads 1'
+          # NB: feature selection do not work yet
+          args: '--workspace --lib --ignored --doc -e integration -- --test-threads 1'
       - uses: codecov/codecov-action@v2
         with:
           flags: unittests,rust

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -32,5 +32,3 @@ jobs:
           out-type: Xml
           args: ' -- --test-threads 1'
       - uses: codecov/codecov-action@v2
-        with:
-          flags: unittests,rust

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,44 @@
+name: Coverage
+
+on:
+  push:
+    #branches:
+    #  - master
+
+jobs:
+  rust:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - uses: Swatinem/rust-cache@v1
+      - uses: AbsaOSS/k3d-action@v1.4.0
+        name: "Create Single Cluster"
+        with:
+          cluster-name: "test-cluster-1"
+          args: >-
+            -p "8083:80@agent[0]"
+            -p "8443:443@agent[0]"
+            -p "5053:53/udp@agent[0]"
+            --agents 1
+            --no-lb
+            --image docker.io/rancher/k3s:v1.20.4-k3s1
+            --k3s-server-arg "--disable=traefik,servicelb,metrics-server,local-storage"
+            --k3s-server-arg "--disable-cloud-controller"
+      - name: Run cargo-tarpaulin
+        uses: actions-rs/tarpaulin@v0.1
+        with:
+          version: '0.18.5'
+          #out-type: Lcov
+          timeout: 600
+          args: '--all -e tests -- --test-threads 1'
+      - name: Coveralls Finished
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: ./lcov.info

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,19 +17,18 @@ jobs:
           toolchain: stable
           override: true
       - uses: Swatinem/rust-cache@v1
-      - uses: AbsaOSS/k3d-action@v1.4.0
+      - uses: AbsaOSS/k3d-action@v2
         name: "Create Single Cluster"
         with:
           cluster-name: "test-cluster-1"
           args: >-
-            -p "8083:80@agent[0]"
-            -p "8443:443@agent[0]"
-            -p "5053:53/udp@agent[0]"
+            -p "8083:80@agent:0:direct"
+            -p "8443:443@agent:0:direct"
+            -p "5053:53/udp@agent:0:direct"
             --agents 1
             --no-lb
             --image docker.io/rancher/k3s:v1.20.4-k3s1
-            --k3s-server-arg "--disable=traefik,servicelb,metrics-server,local-storage"
-            --k3s-server-arg "--disable-cloud-controller"
+            --k3s-arg "--no-deploy=traefik,servicelb,metrics-server@server:*"
       - name: Run cargo-tarpaulin
         uses: actions-rs/tarpaulin@v0.1
         with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -22,13 +22,11 @@ jobs:
         with:
           cluster-name: "test-cluster-1"
           args: >-
-            -p "8083:80@agent:0:direct"
-            -p "8443:443@agent:0:direct"
-            -p "5053:53/udp@agent:0:direct"
             --agents 1
-            --no-lb
-            --image docker.io/rancher/k3s:v1.20.4-k3s1
+            --image docker.io/rancher/k3s:v1.22.4-k3s1
             --k3s-arg "--no-deploy=traefik,servicelb,metrics-server@server:*"
+
+      #--no-lb
       - name: Run cargo-tarpaulin
         uses: actions-rs/tarpaulin@v0.1
         with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -34,11 +34,14 @@ jobs:
         uses: actions-rs/tarpaulin@v0.1
         with:
           version: '0.18.5'
-          #out-type: Lcov
+          out-type: Xml
           timeout: 600
           args: '--all -e tests -- --test-threads 1'
-      - name: Coveralls Finished
-        uses: coverallsapp/github-action@master
+      #- name: Coveralls Finished
+      #  uses: coverallsapp/github-action@master
+      #  with:
+      #    github-token: ${{ secrets.GITHUB_TOKEN }}
+      #    path-to-lcov: ./lcov.info
+      - uses: codecov/codecov-action@v2
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: ./lcov.info
+          flags: unittests,rust

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,10 +11,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Install nightly toolchain
+      - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: stable
           override: true
       - uses: Swatinem/rust-cache@v1
       - uses: AbsaOSS/k3d-action@v2
@@ -30,8 +30,7 @@ jobs:
         with:
           version: '0.18.5'
           out-type: Xml
-          timeout: 600
-          args: '--config=tarpaulin.toml -- --test-threads 1'
+          args: ' -- --test-threads 1'
       - uses: codecov/codecov-action@v2
         with:
           flags: unittests,rust

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -31,7 +31,7 @@ jobs:
           version: '0.18.5'
           out-type: Xml
           timeout: 600
-          args: '--workspace --ignored -e examples -e integration --features=runtime,derive,ws,oauth,jsonpatch,admission,k8s-openapi/v1_22 -o Stdout -t 600 -- --test-threads 1'
+          args: '--workspace --ignored -e examples -e integration --features=runtime,derive,ws,oauth,jsonpatch,admission,k8s-openapi/v1_22 -- --test-threads 1'
       - uses: codecov/codecov-action@v2
         with:
           flags: unittests,rust

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,20 +25,13 @@ jobs:
             --agents 1
             --image docker.io/rancher/k3s:v1.22.4-k3s1
             --k3s-arg "--no-deploy=traefik,servicelb,metrics-server@server:*"
-
-      #--no-lb
       - name: Run cargo-tarpaulin
         uses: actions-rs/tarpaulin@v0.1
         with:
           version: '0.18.5'
           out-type: Xml
           timeout: 600
-          args: '--all -e tests -- --test-threads 1'
-      #- name: Coveralls Finished
-      #  uses: coverallsapp/github-action@master
-      #  with:
-      #    github-token: ${{ secrets.GITHUB_TOKEN }}
-      #    path-to-lcov: ./lcov.info
+          args: '--workspace --ignored -e examples -e integration --features=runtime,derive,ws,oauth,jsonpatch,admission,k8s-openapi/v1_22 -o Stdout -t 600 -- --test-threads 1'
       - uses: codecov/codecov-action@v2
         with:
           flags: unittests,rust

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -31,7 +31,7 @@ jobs:
           version: '0.18.5'
           out-type: Xml
           timeout: 600
-          args: '--workspace --ignored -e examples -e integration -- --test-threads 1'
+          args: '--workspace --bins --lib --doc --ignored -e examples -e integration -- --test-threads 1'
       - uses: codecov/codecov-action@v2
         with:
           flags: unittests,rust

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -31,7 +31,7 @@ jobs:
           version: '0.18.5'
           out-type: Xml
           timeout: 600
-          args: '--workspace --ignored -e examples -e integration --features=runtime,derive,ws,oauth,jsonpatch,admission,k8s-openapi/v1_22 -- --test-threads 1'
+          args: '--workspace --ignored -e examples -e integration -- --test-threads 1'
       - uses: codecov/codecov-action@v2
         with:
           flags: unittests,rust

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,25 +19,3 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           body_path: release.txt
-  code-coverage:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-      - name: Run cargo-tarpaulin
-        uses: actions-rs/tarpaulin@v0.1
-        with:
-          version: '0.18.0'
-          out-type: Lcov
-          timeout: 600
-          args: '--all -e tests -- --test-threads 1'
-      - name: Coveralls Finished
-        uses: coverallsapp/github-action@master
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: ./lcov.info

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ test:
 
 test-kubernetes:
 	cargo test --lib --all -- --ignored # also run tests that fail on github actions
-	cargo test -p kube --features=derive -- --ignored
+	cargo test -p kube --lib --features=derive,runtime -- --ignored
 	cargo run -p kube-examples --example crd_derive
 	cargo run -p kube-examples --example crd_api
 

--- a/kube-client/src/api/core_methods.rs
+++ b/kube-client/src/api/core_methods.rs
@@ -266,7 +266,7 @@ where
     ///     let jobs: Api<Job> = Api::namespaced(client, "apps");
     ///     let lp = ListParams::default()
     ///         .fields("metadata.name=my_job")
-    ///         .timeout(5); // upper bound of how long we watch for
+    ///         .timeout(20); // upper bound of how long we watch for
     ///     let mut stream = jobs.watch(&lp, "0").await?.boxed();
     ///     while let Some(status) = stream.try_next().await? {
     ///         match status {

--- a/kube-client/src/api/core_methods.rs
+++ b/kube-client/src/api/core_methods.rs
@@ -266,7 +266,7 @@ where
     ///     let jobs: Api<Job> = Api::namespaced(client, "apps");
     ///     let lp = ListParams::default()
     ///         .fields("metadata.name=my_job")
-    ///         .timeout(20); // upper bound of how long we watch for
+    ///         .timeout(5); // upper bound of how long we watch for
     ///     let mut stream = jobs.watch(&lp, "0").await?.boxed();
     ///     while let Some(status) = stream.try_next().await? {
     ///         match status {

--- a/kube-core/src/admission.rs
+++ b/kube-core/src/admission.rs
@@ -31,7 +31,6 @@ pub struct SerializePatchError(#[source] serde_json::Error);
 /// Failed to convert `AdmissionReview` into `AdmissionRequest`.
 pub struct ConvertAdmissionReviewError;
 
-
 /// The `kind` field in [`TypeMeta`].
 pub const META_KIND: &str = "AdmissionReview";
 /// The `api_version` field in [`TypeMeta`] on the v1 version.

--- a/kube-derive/src/lib.rs
+++ b/kube-derive/src/lib.rs
@@ -209,8 +209,10 @@ mod custom_resource;
 /// If you have to override a lot, [you can opt-out of schema-generation entirely](#kubeschema--mode)
 ///
 /// ## Advanced Features
+///
 /// - **embedding k8s-openapi types** can be done by enabling the `schemars` feature of `k8s-openapi` from [`0.13.0`](https://github.com/Arnavion/k8s-openapi/blob/master/CHANGELOG.md#v0130-2021-08-09)
 /// - **adding validation** via [validator crate](https://github.com/Keats/validator) is supported from `schemars` >= [`0.8.5`](https://github.com/GREsau/schemars/blob/master/CHANGELOG.md#085---2021-09-20)
+/// - **generating rust code from schemas** can be done via [kopium](https://github.com/kube-rs/kopium) and is supported on stable crds (> 1.16 kubernetes)
 ///
 /// ### Validation Caveats
 /// The supported **`#[validate]` attrs also exist as `#[schemars]` attrs** so you can use those directly if you do not require the validation to run client-side (in your code).

--- a/kube/src/lib.rs
+++ b/kube/src/lib.rs
@@ -183,7 +183,6 @@ pub use kube_core as core;
 // Tests that require a cluster and the complete feature set
 // Can be run with `cargo test -p kube --lib --features=runtime,derive -- --ignored`
 #[cfg(test)]
-#[cfg(all(feature = "derive", feature = "runtime"))]
 mod test {
     use crate::{Api, Client, CustomResourceExt};
     use kube_derive::CustomResource;
@@ -209,6 +208,7 @@ mod test {
 
     #[tokio::test]
     #[ignore] // needs kubeconfig
+    #[cfg(feature = "derive")]
     async fn custom_resource_generates_correct_core_structs() {
         use crate::core::{ApiResource, DynamicObject, GroupVersionKind};
         let client = Client::try_default().await.unwrap();
@@ -225,6 +225,7 @@ mod test {
     use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::CustomResourceDefinition;
     #[tokio::test]
     #[ignore] // needs cluster (creates + patches foo crd)
+    #[cfg(all(feature = "derive", feature = "runtime"))]
     async fn derived_resource_queriable() -> Result<(), Box<dyn std::error::Error>> {
         use crate::{
             core::params::{Patch, PatchParams},

--- a/kube/src/lib.rs
+++ b/kube/src/lib.rs
@@ -183,6 +183,7 @@ pub use kube_core as core;
 // Tests that require a cluster and the complete feature set
 // Can be run with `cargo test -p kube --lib --features=runtime,derive -- --ignored`
 #[cfg(test)]
+#[cfg(all(feature = "derive", feature = "client"))]
 mod test {
     use crate::{Api, Client, CustomResourceExt};
     use kube_derive::CustomResource;
@@ -208,7 +209,6 @@ mod test {
 
     #[tokio::test]
     #[ignore] // needs kubeconfig
-    #[cfg(all(feature = "derive", feature = "client"))]
     async fn custom_resource_generates_correct_core_structs() {
         use crate::core::{ApiResource, DynamicObject, GroupVersionKind};
         let client = Client::try_default().await.unwrap();

--- a/kube/src/lib.rs
+++ b/kube/src/lib.rs
@@ -185,10 +185,10 @@ pub use kube_core as core;
 #[cfg(test)]
 #[cfg(all(feature = "derive", feature = "runtime"))]
 mod test {
-    use schemars::JsonSchema;
-    use serde::{Deserialize, Serialize};
     use crate::{Api, Client, CustomResourceExt};
     use kube_derive::CustomResource;
+    use schemars::JsonSchema;
+    use serde::{Deserialize, Serialize};
 
     #[derive(CustomResource, Deserialize, Serialize, Clone, Debug, JsonSchema)]
     #[kube(group = "clux.dev", version = "v1", kind = "Foo", namespaced)]
@@ -224,7 +224,7 @@ mod test {
 
     use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::CustomResourceDefinition;
     #[tokio::test]
-    #[ignore] // needs kubeconfig
+    #[ignore] // needs cluster (creates + patches foo crd)
     async fn derived_resource_queriable() -> Result<(), Box<dyn std::error::Error>> {
         use crate::{
             core::params::{Patch, PatchParams},

--- a/kube/src/lib.rs
+++ b/kube/src/lib.rs
@@ -208,7 +208,7 @@ mod test {
 
     #[tokio::test]
     #[ignore] // needs kubeconfig
-    #[cfg(feature = "derive")]
+    #[cfg(all(feature = "derive", feature = "client"))]
     async fn custom_resource_generates_correct_core_structs() {
         use crate::core::{ApiResource, DynamicObject, GroupVersionKind};
         let client = Client::try_default().await.unwrap();

--- a/kube/src/lib.rs
+++ b/kube/src/lib.rs
@@ -180,25 +180,37 @@ pub use crate::core::{CustomResourceExt, Resource, ResourceExt};
 pub use kube_core as core;
 
 
+// Tests that require a cluster and the complete feature set
+// Can be run with `cargo test -p kube --lib --features=runtime,derive -- --ignored`
 #[cfg(test)]
+#[cfg(all(feature = "derive", feature = "runtime"))]
 mod test {
-    #[cfg(all(feature = "derive", feature = "client"))]
+    use schemars::JsonSchema;
+    use serde::{Deserialize, Serialize};
+    use crate::{Api, Client, CustomResourceExt};
+    use kube_derive::CustomResource;
+
+    #[derive(CustomResource, Deserialize, Serialize, Clone, Debug, JsonSchema)]
+    #[kube(group = "clux.dev", version = "v1", kind = "Foo", namespaced)]
+    #[kube(status = "FooStatus")]
+    #[kube(scale = r#"{"specReplicasPath":".spec.replicas", "statusReplicasPath":".status.replicas"}"#)]
+    #[kube(crates(kube_core = "crate::core"))] // for dev-dep test structure
+    pub struct FooSpec {
+        name: String,
+        info: Option<String>,
+        replicas: isize,
+    }
+
+    #[derive(Deserialize, Serialize, Clone, Debug, Default, JsonSchema)]
+    pub struct FooStatus {
+        is_bad: bool,
+        replicas: isize,
+    }
+
     #[tokio::test]
     #[ignore] // needs kubeconfig
-    async fn convenient_custom_resource() {
-        use crate::{
-            core::{ApiResource, DynamicObject, GroupVersionKind},
-            Api, Client, CustomResource,
-        };
-        use schemars::JsonSchema;
-        use serde::{Deserialize, Serialize};
-
-        #[derive(Clone, Debug, CustomResource, Deserialize, Serialize, JsonSchema)]
-        #[kube(group = "clux.dev", version = "v1", kind = "Foo", namespaced)]
-        #[kube(crates(kube_core = "crate::core"))]
-        struct FooSpec {
-            foo: String,
-        }
+    async fn custom_resource_generates_correct_core_structs() {
+        use crate::core::{ApiResource, DynamicObject, GroupVersionKind};
         let client = Client::try_default().await.unwrap();
 
         let gvk = GroupVersionKind::gvk("clux.dev", "v1", "Foo");
@@ -208,5 +220,46 @@ mod test {
 
         // make sure they return the same url_path through their impls
         assert_eq!(a1.resource_url(), a2.resource_url());
+    }
+
+    use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::CustomResourceDefinition;
+    #[tokio::test]
+    #[ignore] // needs kubeconfig
+    async fn derived_resource_queriable() -> Result<(), Box<dyn std::error::Error>> {
+        use crate::{
+            core::params::{Patch, PatchParams},
+            runtime::wait::{await_condition, conditions},
+        };
+        let client = Client::try_default().await?;
+        let ssapply = PatchParams::apply("kube").force();
+        let crds: Api<CustomResourceDefinition> = Api::all(client.clone());
+        // Server-side apply CRD
+        crds.patch("foos.clux.dev", &ssapply, &Patch::Apply(Foo::crd()))
+            .await?;
+        // Wait for it to be ready:
+        let establish = await_condition(crds, "foos.clux.dev", conditions::is_crd_established());
+        let _ = tokio::time::timeout(std::time::Duration::from_secs(10), establish).await?;
+        // Use it
+        let foos: Api<Foo> = Api::default_namespaced(client.clone());
+        // Apply from generated struct
+        let foo = Foo::new("baz", FooSpec {
+            name: "baz".into(),
+            info: Some("old baz".into()),
+            replicas: 3,
+        });
+        let o = foos.patch("baz", &ssapply, &Patch::Apply(&foo)).await?;
+        assert_eq!(o.spec.name, "baz");
+        // Apply from partial json!
+        let patch = serde_json::json!({
+            "apiVersion": "clux.dev/v1",
+            "kind": "Foo",
+            "spec": {
+                "name": "foo",
+                "replicas": 2
+            }
+        });
+        let o2 = foos.patch("baz", &ssapply, &Patch::Apply(patch)).await?;
+        assert_eq!(o2.spec.replicas, 2);
+        Ok(())
     }
 }

--- a/kube/src/lib.rs
+++ b/kube/src/lib.rs
@@ -179,7 +179,6 @@ pub use crate::core::{CustomResourceExt, Resource, ResourceExt};
 #[doc(inline)]
 pub use kube_core as core;
 
-
 // Tests that require a cluster and the complete feature set
 // Can be run with `cargo test -p kube --lib --features=runtime,derive -- --ignored`
 #[cfg(test)]
@@ -228,7 +227,7 @@ mod test {
     #[cfg(all(feature = "derive", feature = "runtime"))]
     async fn derived_resource_queriable() -> Result<(), Box<dyn std::error::Error>> {
         use crate::{
-            core::params::{Patch, PatchParams},
+            core::params::{DeleteParams, Patch, PatchParams},
             runtime::wait::{await_condition, conditions},
         };
         let client = Client::try_default().await?;
@@ -261,6 +260,9 @@ mod test {
         });
         let o2 = foos.patch("baz", &ssapply, &Patch::Apply(patch)).await?;
         assert_eq!(o2.spec.replicas, 2);
+        assert_eq!(foos.get_scale("baz").await?.spec.unwrap().replicas, Some(2));
+        assert!(foos.get_status("baz").await?.status.is_none()); // nothing has set this
+        foos.delete("baz", &DeleteParams::default()).await?;
         Ok(())
     }
 }

--- a/tarpaulin.toml
+++ b/tarpaulin.toml
@@ -1,12 +1,12 @@
-[lib_coverage]
-workspace = true
-exclude = ["integration"]
-#exclude_files = ["integration/"]
-run-types = ["Doctests", "Tests"]
+# Usage cargo tarpaulin -- --test-threads 1
 
-[kube_lib_ignored_coverage]
+[one_pass_coverage]
+workspace = true
 features = "kube/derive kube/runtime"
 color = "Always"
-packages = ["kube"]
-workspace = false
 ignored = true
+timeout = "600s"
+exclude = ["integration"]
+# NB: skipping Doctests because they are slow to build and generally marked no_run
+run-types = ["Tests"]
+generate = ["Json"]

--- a/tarpaulin.toml
+++ b/tarpaulin.toml
@@ -1,0 +1,12 @@
+[lib_coverage]
+workspace = true
+exclude = ["integration"]
+#exclude_files = ["integration/"]
+run-types = ["Doctests", "Tests"]
+
+[kube_lib_ignored_coverage]
+features = "kube/derive kube/runtime"
+color = "Always"
+packages = ["kube"]
+workspace = false
+ignored = true


### PR DESCRIPTION
Getting it from [45% to 55% then 60%](https://app.codecov.io/gh/kube-rs/kube-rs/commits?page=1) by running some of the ignored lib tests in `k3d` on github actions and then porting a few example basics into ignored tests. Also moved from coveralls to codecov since it seems more modern (and was easy to plumb with the action).

[![codecov](https://codecov.io/gh/kube-rs/kube-rs/branch/coverage2/graph/badge.svg?token=9FCqEcyDTZ)](https://codecov.io/gh/kube-rs/kube-rs)

We should have a higher coverage than what it shows if we account for examples, but we need to either add an extra coverage run for examples (it is very slow with building all), or port some example tests into kube (like what I did for `crd_api` and `dynamic_api` here).

Ultimately, what's shown here is a tradeoff. Doc tests are slow, seems to require nightly. Example tests are slow because we need to build and run all of them sequentially. It's probably better to focus on coverage the traditional way with some core tests in `kube` or the relevant crates.

It doesn't seem to count `kube-derive` properly. Maybe it's possible to tweak the command to get that in. See [config "reference"](https://github.com/xd009642/tarpaulin/blob/develop/src/config/mod.rs#L29)

Commands to replicate what is running here (minus output format) is:

```sh
cargo tarpaulin -- --test-threads 1
```

with `cargo-tarpaulin 0.18.5` and the new embedded `tarpaulin.toml` to encapsulate flags (needed a lot of tweaks to get the ignored, feature-dependent tests in kube/src/lib to run).

For now this is at least enough to satisfy the "most code is covered" requirement from #737.