### PR TITLE
Update `tower-http` to 0.2.0

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -48,7 +48,7 @@ warp = { version = "0.3", features = ["tls"] }
 http = "0.2.5"
 json-patch = "0.2.6"
 tower = { version = "0.4.6", features = ["limit"] }
-tower-http = { version = "0.1.0", features = ["trace", "decompression-gzip"] }
+tower-http = { version = "0.2.0", features = ["trace", "decompression-gzip"] }
 hyper = { version = "0.14.13", features = ["client", "http1", "stream", "tcp"] }
 thiserror = "1.0.29"
 

--- a/kube-client/Cargo.toml
+++ b/kube-client/Cargo.toml
@@ -64,7 +64,7 @@ hyper-tls = { version = "0.5.0", optional = true }
 hyper-rustls = { version = "0.23.0", optional = true }
 tokio-tungstenite = { version = "0.15.0", optional = true }
 tower = { version = "0.4.6", optional = true, features = ["buffer", "util"] }
-tower-http = { version = "0.1.1", optional = true, features = ["auth", "map-response-body", "trace"] }
+tower-http = { version = "0.2.0", optional = true, features = ["auth", "map-response-body", "trace"] }
 hyper-timeout = {version = "0.4.1", optional = true }
 tame-oauth = { version = "0.6.0", features = ["gcp"], optional = true }
 pin-project = { version = "1.0.4", optional = true }

--- a/kube-client/src/client/mod.rs
+++ b/kube-client/src/client/mod.rs
@@ -101,7 +101,7 @@ impl Client {
         S::Future: Send + 'static,
         S::Error: Into<BoxError>,
         B: http_body::Body<Data = bytes::Bytes> + Send + 'static,
-        B::Error: std::error::Error + Send + Sync + 'static,
+        B::Error: Into<BoxError>,
         T: Into<String>,
     {
         // Transform response body to `hyper::Body` and use type erased error to avoid type parameters.


### PR DESCRIPTION
Change the bounds of body's error type for better compatibility with middleware like `DecompressionLayer`. Shouldn't be a breaking change.

Closes #742