### PR TITLE
Remove unused features from `warp` dependency in examples

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -44,7 +44,7 @@ static_assertions = "1.1.0"
 tar = "0.4.37"
 tracing = "0.1.29"
 tracing-subscriber = "0.3.3"
-warp = { version = "0.3", features = ["tls"] }
+warp = { version = "0.3", default-features = false, features = ["tls"] }
 http = "0.2.5"
 json-patch = "0.2.6"
 tower = { version = "0.4.6", features = ["limit"] }


### PR DESCRIPTION
`warp` depends on old `tokio-tungstenite` (#732).