### PR TITLE
Add `DeleteParams` constructors for easily setting `PropagationPolicy`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 UNRELEASED
 ===================
  * see https://github.com/kube-rs/kube-rs/compare/0.65.0...master
+ * Added `DeleteParams::background()`, `DeleteParams::foreground()`, `DeleteParams::orphan()` constructors - [#747](https://github.com/kube-rs/kube-rs/issues/747)
 
 0.65.0 / 2021-12-10
 ===================

--- a/deny.toml
+++ b/deny.toml
@@ -69,4 +69,6 @@ skip = [
     { name = "webpki", version = "=0.21.4" },
     { name = "tokio-rustls", version = "=0.22.0" },
     { name = "sct", version = "=0.6.1" },
+    # http has not released a version using itoa v1
+    { name = "itoa", version = "^0.4" },
 ]

--- a/examples/job_api.rs
+++ b/examples/job_api.rs
@@ -1,5 +1,4 @@
-#[macro_use]
-extern crate log;
+#[macro_use] extern crate log;
 use futures::{StreamExt, TryStreamExt};
 use k8s_openapi::api::batch::v1::Job;
 use serde_json::json;

--- a/examples/job_api.rs
+++ b/examples/job_api.rs
@@ -1,4 +1,5 @@
-#[macro_use] extern crate log;
+#[macro_use]
+extern crate log;
 use futures::{StreamExt, TryStreamExt};
 use k8s_openapi::api::batch::v1::Job;
 use serde_json::json;
@@ -71,13 +72,15 @@ async fn main() -> anyhow::Result<()> {
 
     // Clean up the old job record..
     info!("Deleting the job record.");
-    jobs.delete("empty-job", &DeleteParams {
-        dry_run: true,
-        propagation_policy: Some(PropagationPolicy::Background),
-        ..Default::default()
-    })
+    jobs.delete(
+        "empty-job",
+        &DeleteParams {
+            dry_run: true,
+            propagation_policy: Some(PropagationPolicy::Background),
+            ..Default::default()
+        },
+    )
     .await?;
-    jobs.delete("empty-job", &DeleteParams::background())
-    .await?;
+    jobs.delete("empty-job", &DeleteParams::background()).await?;
     Ok(())
 }

--- a/examples/job_api.rs
+++ b/examples/job_api.rs
@@ -4,7 +4,7 @@ use k8s_openapi::api::batch::v1::Job;
 use serde_json::json;
 
 use kube::{
-    api::{Api, DeleteParams, ListParams, PostParams, ResourceExt, WatchEvent},
+    api::{Api, DeleteParams, ListParams, PostParams, PropagationPolicy, ResourceExt, WatchEvent},
     Client,
 };
 
@@ -73,13 +73,11 @@ async fn main() -> anyhow::Result<()> {
     info!("Deleting the job record.");
     jobs.delete("empty-job", &DeleteParams {
         dry_run: true,
-        ..DeleteParams::default()
+        propagation_policy: Some(PropagationPolicy::Background),
+        ..Default::default()
     })
     .await?;
-    jobs.delete("empty-job", &DeleteParams {
-        dry_run: false,
-        ..DeleteParams::default()
-    })
+    jobs.delete("empty-job", &DeleteParams::background())
     .await?;
     Ok(())
 }

--- a/examples/job_api.rs
+++ b/examples/job_api.rs
@@ -72,15 +72,8 @@ async fn main() -> anyhow::Result<()> {
 
     // Clean up the old job record..
     info!("Deleting the job record.");
-    jobs.delete(
-        "empty-job",
-        &DeleteParams {
-            dry_run: true,
-            propagation_policy: Some(PropagationPolicy::Background),
-            ..Default::default()
-        },
-    )
-    .await?;
+    jobs.delete("empty-job", &DeleteParams::background().dry_run())
+        .await?;
     jobs.delete("empty-job", &DeleteParams::background()).await?;
     Ok(())
 }

--- a/kube-core/src/params.rs
+++ b/kube-core/src/params.rs
@@ -422,16 +422,16 @@ mod test {
     #[test]
     fn delete_param_constructors() {
         let dp_background = DeleteParams::background();
-        let ser = serde_json::to_string(&dp_background).unwrap();
-        assert_eq!(ser, "{\"propagationPolicy\":\"Background\"}");
+        let ser = serde_json::to_value(&dp_background).unwrap();
+        assert_eq!(ser, serde_json::json!({"propagationPolicy": "Background"}));
 
         let dp_foreground = DeleteParams::foreground();
-        let ser = serde_json::to_string(&dp_foreground).unwrap();
-        assert_eq!(ser, "{\"propagationPolicy\":\"Foreground\"}");
+        let ser = serde_json::to_value(&dp_foreground).unwrap();
+        assert_eq!(ser, serde_json::json!({"propagationPolicy": "Foreground"}));
 
         let dp_orphan = DeleteParams::orphan();
-        let ser = serde_json::to_string(&dp_orphan).unwrap();
-        assert_eq!(ser, "{\"propagationPolicy\":\"Orphan\"}");
+        let ser = serde_json::to_value(&dp_orphan).unwrap();
+        assert_eq!(ser, serde_json::json!({"propagationPolicy": "Orphan"}));
     }
 }
 
@@ -447,8 +447,7 @@ pub struct Preconditions {
     pub uid: Option<String>,
 }
 
-/// Propagation policy when deleting single objects.
-/// The default used by the Kubernetes API Server varies based on resource.
+/// Propagation policy when deleting single objects
 #[derive(Clone, Debug, Serialize)]
 pub enum PropagationPolicy {
     /// Orphan dependents

--- a/kube-core/src/params.rs
+++ b/kube-core/src/params.rs
@@ -380,6 +380,24 @@ impl DeleteParams {
             ..Self::default()
         }
     }
+
+    /// Perform a dryRun only
+    pub fn dry_run(mut self) -> Self {
+        self.dry_run = true;
+        self
+    }
+
+    /// Set the duration in seconds before the object should be deleted.
+    pub fn grace_period_seconds(mut self, secs: u32) -> Self {
+        self.grace_period_seconds = Some(secs);
+        self
+    }
+
+    /// Set the condtions that must be fulfilled before a deletion is carried out.
+    pub fn preconditions(mut self, preconditions: Preconditions) -> Self {
+        self.preconditions = Some(preconditions);
+        self
+    }
 }
 
 // dryRun serialization differ when used as body parameters and query strings:


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation
closes #747
This PR should make it harder to accidentally orphan resources when deleting. The Kubernetes API default deletion policy (`PropagationPolicy`) varies based on the Kubernetes resource. For Jobs for example, the default is to orphan resources. This may be unexpected.

## Solution
Adding root constructors should more easily enable people to choose their policy. This also updates the `jobs_api.rs` example to show appropriate usage of a background deletion policy to prevent orphaning Pods -- foreground would also work. 
