### PR TITLE
Export Version priority parser with Ord impls in kube_core

### DIFF
--- a/kube-client/src/discovery/apigroup.rs
+++ b/kube-client/src/discovery/apigroup.rs
@@ -118,7 +118,7 @@ impl ApiGroup {
 
     fn sort_versions(&mut self) {
         self.data
-            .sort_by_cached_key(|gvd| Reverse(Version::parse(gvd.version.as_str())))
+            .sort_by_cached_key(|gvd| Reverse(Version::parse(gvd.version.as_str()).priority()))
     }
 
     // shortcut method to give cheapest return for a single GVK

--- a/kube-client/src/discovery/apigroup.rs
+++ b/kube-client/src/discovery/apigroup.rs
@@ -177,14 +177,11 @@ impl ApiGroup {
 
     /// Returns served versions (e.g. `["v1", "v2beta1"]`) of this group.
     ///
-    /// This list is always non-empty, and sorted in the following order:
+    /// This iterator is never empty, and returns elements in descending order of [`Version`](kube_core::Version):
     /// - Stable versions (with the last being the first)
     /// - Beta versions (with the last being the first)
     /// - Alpha versions (with the last being the first)
     /// - Other versions, alphabetically
-    ///
-    /// in accordance with [kubernetes version priority](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/#version-priority).
-    /// For more information, see [`Version`](kube_core::Version)
     pub fn versions(&self) -> impl Iterator<Item = &str> {
         self.data.as_slice().iter().map(|gvd| gvd.version.as_str())
     }
@@ -196,8 +193,9 @@ impl ApiGroup {
 
     /// Returns the preferred version or latest version for working with given group.
     ///
-    /// If server does not recommend one, we pick the "most stable and most recent" version
-    /// in accordance with [kubernetes version priority](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/#version-priority).
+    /// If server does not recommend a version, we pick the "most stable and most recent" version
+    /// in accordance with [kubernetes version priority](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/#version-priority)
+    /// via the descending sort order from [`Version`](kube_core::Version).
     pub fn preferred_version_or_latest(&self) -> &str {
         // NB: self.versions is non-empty by construction in ApiGroup
         self.preferred

--- a/kube-client/src/discovery/apigroup.rs
+++ b/kube-client/src/discovery/apigroup.rs
@@ -177,7 +177,7 @@ impl ApiGroup {
 
     /// Returns served versions (e.g. `["v1", "v2beta1"]`) of this group.
     ///
-    /// This iterator is never empty, and returns elements in descending order of [`Version`](kube_core::Version):
+    /// This [`Iterator`] is never empty, and returns elements in descending order of [`Version`](kube_core::Version):
     /// - Stable versions (with the last being the first)
     /// - Beta versions (with the last being the first)
     /// - Alpha versions (with the last being the first)
@@ -193,7 +193,7 @@ impl ApiGroup {
 
     /// Returns the preferred version or latest version for working with given group.
     ///
-    /// If server does not recommend a version, we pick the "most stable and most recent" version
+    /// If the server does not recommend a version, we pick the "most stable and most recent" version
     /// in accordance with [kubernetes version priority](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/#version-priority)
     /// via the descending sort order from [`Version`](kube_core::Version).
     pub fn preferred_version_or_latest(&self) -> &str {

--- a/kube-client/src/discovery/apigroup.rs
+++ b/kube-client/src/discovery/apigroup.rs
@@ -1,11 +1,12 @@
-use super::{
-    parse::{self, GroupVersionData},
-    version::Version,
-};
+use super::parse::{self, GroupVersionData};
 use crate::{error::DiscoveryError, Client, Error, Result};
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::{APIGroup, APIVersions};
 pub use kube_core::discovery::{verbs, ApiCapabilities, ApiResource, Scope};
-use kube_core::gvk::{GroupVersion, GroupVersionKind, ParseGroupVersionError};
+use kube_core::{
+    gvk::{GroupVersion, GroupVersionKind, ParseGroupVersionError},
+    Version,
+};
+use std::cmp::Reverse;
 
 
 /// Describes one API groups collected resources and capabilities.
@@ -117,7 +118,7 @@ impl ApiGroup {
 
     fn sort_versions(&mut self) {
         self.data
-            .sort_by_cached_key(|gvd| Version::parse(gvd.version.as_str()))
+            .sort_by_cached_key(|gvd| Reverse(Version::parse(gvd.version.as_str())))
     }
 
     // shortcut method to give cheapest return for a single GVK
@@ -183,6 +184,7 @@ impl ApiGroup {
     /// - Other versions, alphabetically
     ///
     /// in accordance with [kubernetes version priority](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/#version-priority).
+    /// For more information, see [`Version`](kube_core::Version)
     pub fn versions(&self) -> impl Iterator<Item = &str> {
         self.data.as_slice().iter().map(|gvd| gvd.version.as_str())
     }

--- a/kube-client/src/discovery/mod.rs
+++ b/kube-client/src/discovery/mod.rs
@@ -8,8 +8,6 @@ mod apigroup;
 pub mod oneshot;
 pub use apigroup::ApiGroup;
 mod parse;
-// an implementation of mentioned kubernetes version priority
-mod version;
 
 // re-export one-shots
 pub use oneshot::{group, pinned_group, pinned_kind};

--- a/kube-core/src/lib.rs
+++ b/kube-core/src/lib.rs
@@ -51,3 +51,6 @@ pub use watch::WatchEvent;
 
 mod error;
 pub use error::ErrorResponse;
+
+mod version;
+pub use version::Version;

--- a/kube-core/src/version.rs
+++ b/kube-core/src/version.rs
@@ -65,10 +65,9 @@ pub enum Version {
 impl Version {
     fn try_parse(v: &str) -> Option<Version> {
         let v = v.strip_prefix('v')?;
-        let major_chars = v.chars().take_while(|ch| ch.is_ascii_digit()).count();
-        let major = &v[..major_chars];
+        let major = v.split_terminator(|ch: char| !ch.is_ascii_digit()).next()?;
+        let v = &v[major.len()..];
         let major: u32 = major.parse().ok()?;
-        let v = &v[major_chars..];
         if v.is_empty() {
             return Some(Version::Stable(major));
         }

--- a/kube-core/src/version.rs
+++ b/kube-core/src/version.rs
@@ -60,7 +60,6 @@ pub enum Version {
     /// CRDs and APIServices can use arbitrary strings as versions.
     Nonconformant(String),
 }
-// NB:
 
 impl Version {
     fn try_parse(v: &str) -> Option<Version> {

--- a/kube-core/src/version.rs
+++ b/kube-core/src/version.rs
@@ -7,7 +7,7 @@ use std::{cmp::Reverse, convert::Infallible, str::FromStr};
 ///
 /// ```
 /// use kube_core::Version;
-/// use std::cmp::Reverse;
+/// use std::cmp::Reverse; // for DESCENDING sort
 /// let mut versions = vec![
 ///     "v10beta3",
 ///     "v2",
@@ -46,8 +46,6 @@ use std::{cmp::Reverse, convert::Infallible, str::FromStr};
 /// assert!(Version::Stable(1) > Version::Alpha(2, Some(2)));
 /// assert!(Version::Beta(1, None) > Version::Nonconformant("ver3".into()));
 /// ```
-///
-/// TODO: change Ord to reflect this
 #[derive(PartialEq, Eq, Debug, Clone)]
 pub enum Version {
     /// A major/GA release

--- a/kube-core/src/version.rs
+++ b/kube-core/src/version.rs
@@ -20,7 +20,7 @@ use std::{cmp::Reverse, convert::Infallible, str::FromStr};
 ///     "foo1",
 ///     "v10",
 /// ];
-/// versions.sort_by_cached_key(|v| Reverse(Version::parse(v)));
+/// versions.sort_by_cached_key(|v| Reverse(Version::parse(v).priority()));
 /// assert_eq!(versions, vec![
 ///     "v10",
 ///     "v2",
@@ -35,20 +35,6 @@ use std::{cmp::Reverse, convert::Infallible, str::FromStr};
 /// ]);
 /// ```
 ///
-/// You can also compare versions directly after parsing:
-///
-/// ```
-/// use kube_core::Version;
-/// assert!(Version::Stable(2) > Version::Stable(1));
-/// assert!(Version::Stable(1) > Version::Beta(1, None));
-/// assert!(Version::Stable(1) > Version::Beta(2, None));
-/// assert!(Version::Stable(2) > Version::Alpha(1, Some(2)));
-/// assert!(Version::Stable(1) > Version::Alpha(2, Some(2)));
-/// assert!(Version::Beta(1, None) > Version::Nonconformant("ver3".into()));
-/// ```
-///
-/// Note that the type of release matters more than the version numbers:
-/// Stable(x) > Beta(y) > Alpha(z) > Nonconformant(w) for all x,y,z,w
 #[derive(PartialEq, Eq, Debug, Clone)]
 pub enum Version {
     /// A major/GA release
@@ -122,34 +108,120 @@ impl FromStr for Version {
     }
 }
 
-// A key used to allow sorting Versions
 #[derive(PartialEq, Eq, PartialOrd, Ord)]
-enum VersionSortKey<'a> {
-    Nonconformant(Reverse<&'a str>),
-    Alpha(u32, Option<u32>),
-    Beta(u32, Option<u32>),
-    Stable(u32),
+enum Stability {
+    Nonconformant,
+    Alpha,
+    Beta,
+    Stable,
 }
+
+/// See [`Version::priority`]
+#[derive(PartialEq, Eq, PartialOrd, Ord)]
+struct Priority {
+    stability: Stability,
+    major: u32,
+    minor: Option<u32>,
+    nonconformant: Option<Reverse<String>>,
+}
+
+/// See [`Version::latest`]
+#[derive(PartialEq, Eq, PartialOrd, Ord)]
+struct Latest {
+    major: u32,
+    stability: Stability,
+    minor: Option<u32>,
+    nonconformant: Option<Reverse<String>>,
+}
+
 impl Version {
-    fn to_sort_key(&self) -> VersionSortKey {
+    /// An [`Ord`] for `Version` that prefers stable versions over later prereleases
+    ///
+    /// Implements the [Kubernetes version priority order](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/#version-priority)
+    ///
+    /// For example:
+    ///
+    /// ```
+    /// # use kube_core::Version;
+    /// assert!(Version::Stable(2).priority() > Version::Stable(1).priority());
+    /// assert!(Version::Stable(1).priority() > Version::Beta(1, None).priority());
+    /// assert!(Version::Stable(1).priority() > Version::Beta(2, None).priority());
+    /// assert!(Version::Stable(2).priority() > Version::Alpha(1, Some(2)).priority());
+    /// assert!(Version::Stable(1).priority() > Version::Alpha(2, Some(2)).priority());
+    /// assert!(Version::Beta(1, None).priority() > Version::Nonconformant("ver3".into()).priority());
+    /// ```
+    ///
+    /// Note that the type of release matters more than the version numbers:
+    /// `Stable(x)` > `Beta(y)` > `Alpha(z)` > `Nonconformant(w)` for all `x`,`y`,`z`,`w`
+    pub fn priority(&self) -> impl Ord {
         match self {
-            Version::Stable(v) => VersionSortKey::Stable(*v),
-            Version::Beta(v, beta) => VersionSortKey::Beta(*v, *beta),
-            Version::Alpha(v, alpha) => VersionSortKey::Alpha(*v, *alpha),
-            Version::Nonconformant(nc) => VersionSortKey::Nonconformant(Reverse(nc)),
+            &Version::Stable(major) => Priority {
+                stability: Stability::Stable,
+                major,
+                minor: None,
+                nonconformant: None,
+            },
+            &Version::Beta(major, minor) => Priority {
+                stability: Stability::Beta,
+                major,
+                minor,
+                nonconformant: None,
+            },
+            &Self::Alpha(major, minor) => Priority {
+                stability: Stability::Alpha,
+                major,
+                minor,
+                nonconformant: None,
+            },
+            Self::Nonconformant(nonconformant) => Priority {
+                stability: Stability::Nonconformant,
+                major: 0,
+                minor: None,
+                nonconformant: Some(Reverse(nonconformant.clone())),
+            },
         }
     }
-}
 
-impl Ord for Version {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.to_sort_key().cmp(&other.to_sort_key())
-    }
-}
-
-impl PartialOrd for Version {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
+    /// An [`Ord`] for `Version` that prefers the latest version, even if it is a prerelease
+    ///
+    /// For example:
+    ///
+    /// ```
+    /// # use kube_core::Version;
+    /// assert!(Version::Stable(2).latest() > Version::Stable(1).latest());
+    /// assert!(Version::Stable(1).latest() > Version::Beta(1, None).latest());
+    /// assert!(Version::Beta(2, None).latest() > Version::Stable(1).latest());
+    /// assert!(Version::Stable(2).latest() > Version::Alpha(1, Some(2)).latest());
+    /// assert!(Version::Alpha(2, Some(2)).latest() > Version::Stable(1).latest());
+    /// assert!(Version::Beta(1, None).latest() > Version::Nonconformant("ver3".into()).latest());
+    /// ```
+    pub fn latest(&self) -> impl Ord {
+        match self {
+            &Version::Stable(major) => Latest {
+                stability: Stability::Stable,
+                major,
+                minor: None,
+                nonconformant: None,
+            },
+            &Version::Beta(major, minor) => Latest {
+                stability: Stability::Beta,
+                major,
+                minor,
+                nonconformant: None,
+            },
+            &Self::Alpha(major, minor) => Latest {
+                stability: Stability::Alpha,
+                major,
+                minor,
+                nonconformant: None,
+            },
+            Self::Nonconformant(nonconformant) => Latest {
+                stability: Stability::Nonconformant,
+                major: 0,
+                minor: None,
+                nonconformant: Some(Reverse(nonconformant.clone())),
+            },
+        }
     }
 }
 
@@ -198,33 +270,39 @@ mod tests {
     }
 
     #[test]
-    fn test_version_ord() {
+    fn test_version_priority_ord() {
         // sorting makes sense from a "greater than" semantic perspective:
-        assert!(Version::Stable(2) > Version::Stable(1));
-        assert!(Version::Stable(1) > Version::Beta(1, None));
-        assert!(Version::Stable(1) > Version::Beta(2, None));
-        assert!(Version::Stable(2) > Version::Alpha(1, Some(2)));
-        assert!(Version::Stable(1) > Version::Alpha(2, Some(2)));
-        assert!(Version::Beta(1, None) > Version::Nonconformant("ver3".into()));
+        assert!(Version::Stable(2).priority() > Version::Stable(1).priority());
+        assert!(Version::Stable(1).priority() > Version::Beta(1, None).priority());
+        assert!(Version::Stable(1).priority() > Version::Beta(2, None).priority());
+        assert!(Version::Stable(2).priority() > Version::Alpha(1, Some(2)).priority());
+        assert!(Version::Stable(1).priority() > Version::Alpha(2, Some(2)).priority());
+        assert!(Version::Beta(1, None).priority() > Version::Nonconformant("ver3".into()).priority());
 
-        assert!(Version::Stable(2) > Version::Stable(1));
-        assert!(Version::Stable(1) > Version::Beta(2, None));
-        assert!(Version::Stable(1) > Version::Beta(2, Some(2)));
-        assert!(Version::Stable(1) > Version::Alpha(2, None));
-        assert!(Version::Stable(1) > Version::Alpha(2, Some(3)));
-        assert!(Version::Stable(1) > Version::Nonconformant("foo".to_string()));
-        assert!(Version::Beta(1, Some(1)) > Version::Beta(1, None));
-        assert!(Version::Beta(1, Some(2)) > Version::Beta(1, Some(1)));
-        assert!(Version::Beta(1, None) > Version::Alpha(1, None));
-        assert!(Version::Beta(1, None) > Version::Alpha(1, Some(3)));
-        assert!(Version::Beta(1, None) > Version::Nonconformant("foo".to_string()));
-        assert!(Version::Beta(1, Some(2)) > Version::Nonconformant("foo".to_string()));
-        assert!(Version::Alpha(1, Some(1)) > Version::Alpha(1, None));
-        assert!(Version::Alpha(1, Some(2)) > Version::Alpha(1, Some(1)));
-        assert!(Version::Alpha(1, None) > Version::Nonconformant("foo".to_string()));
-        assert!(Version::Alpha(1, Some(2)) > Version::Nonconformant("foo".to_string()));
-        assert!(Version::Nonconformant("bar".to_string()) > Version::Nonconformant("foo".to_string()));
-        assert!(Version::Nonconformant("foo1".to_string()) > Version::Nonconformant("foo10".to_string()));
+        assert!(Version::Stable(2).priority() > Version::Stable(1).priority());
+        assert!(Version::Stable(1).priority() > Version::Beta(2, None).priority());
+        assert!(Version::Stable(1).priority() > Version::Beta(2, Some(2)).priority());
+        assert!(Version::Stable(1).priority() > Version::Alpha(2, None).priority());
+        assert!(Version::Stable(1).priority() > Version::Alpha(2, Some(3)).priority());
+        assert!(Version::Stable(1).priority() > Version::Nonconformant("foo".to_string()).priority());
+        assert!(Version::Beta(1, Some(1)).priority() > Version::Beta(1, None).priority());
+        assert!(Version::Beta(1, Some(2)).priority() > Version::Beta(1, Some(1)).priority());
+        assert!(Version::Beta(1, None).priority() > Version::Alpha(1, None).priority());
+        assert!(Version::Beta(1, None).priority() > Version::Alpha(1, Some(3)).priority());
+        assert!(Version::Beta(1, None).priority() > Version::Nonconformant("foo".to_string()).priority());
+        assert!(Version::Beta(1, Some(2)).priority() > Version::Nonconformant("foo".to_string()).priority());
+        assert!(Version::Alpha(1, Some(1)).priority() > Version::Alpha(1, None).priority());
+        assert!(Version::Alpha(1, Some(2)).priority() > Version::Alpha(1, Some(1)).priority());
+        assert!(Version::Alpha(1, None).priority() > Version::Nonconformant("foo".to_string()).priority());
+        assert!(Version::Alpha(1, Some(2)).priority() > Version::Nonconformant("foo".to_string()).priority());
+        assert!(
+            Version::Nonconformant("bar".to_string()).priority()
+                > Version::Nonconformant("foo".to_string()).priority()
+        );
+        assert!(
+            Version::Nonconformant("foo1".to_string()).priority()
+                > Version::Nonconformant("foo10".to_string()).priority()
+        );
 
         // sort order by default is ascending
         // sorting with std::cmp::Reverse thus gives you the "most latest stable" first
@@ -236,13 +314,68 @@ mod tests {
             Version::Stable(2),
             Version::Beta(2, Some(3)),
         ];
-        vers.sort_by_cached_key(|x| Reverse(x.clone()));
+        vers.sort_by_cached_key(|x| Reverse(x.priority()));
         assert_eq!(vers, vec![
             Version::Stable(2),
             Version::Stable(1),
             Version::Beta(2, Some(3)),
             Version::Beta(2, Some(2)),
             Version::Alpha(3, Some(2)),
+            Version::Nonconformant("hi".into()),
+        ]);
+    }
+
+    #[test]
+    fn test_version_latest_ord() {
+        assert!(Version::Stable(2).latest() > Version::Stable(1).latest());
+        assert!(Version::Stable(1).latest() > Version::Beta(1, None).latest());
+        assert!(Version::Stable(1).latest() < Version::Beta(2, None).latest());
+        assert!(Version::Stable(2).latest() > Version::Alpha(1, Some(2)).latest());
+        assert!(Version::Stable(1).latest() < Version::Alpha(2, Some(2)).latest());
+        assert!(Version::Beta(1, None).latest() > Version::Nonconformant("ver3".into()).latest());
+
+        assert!(Version::Stable(2).latest() > Version::Stable(1).latest());
+        assert!(Version::Stable(1).latest() < Version::Beta(2, None).latest());
+        assert!(Version::Stable(1).latest() < Version::Beta(2, Some(2)).latest());
+        assert!(Version::Stable(1).latest() < Version::Alpha(2, None).latest());
+        assert!(Version::Stable(1).latest() < Version::Alpha(2, Some(3)).latest());
+        assert!(Version::Stable(1).latest() > Version::Nonconformant("foo".to_string()).latest());
+        assert!(Version::Beta(1, Some(1)).latest() > Version::Beta(1, None).latest());
+        assert!(Version::Beta(1, Some(2)).latest() > Version::Beta(1, Some(1)).latest());
+        assert!(Version::Beta(1, None).latest() > Version::Alpha(1, None).latest());
+        assert!(Version::Beta(1, None).latest() > Version::Alpha(1, Some(3)).latest());
+        assert!(Version::Beta(1, None).latest() > Version::Nonconformant("foo".to_string()).latest());
+        assert!(Version::Beta(1, Some(2)).latest() > Version::Nonconformant("foo".to_string()).latest());
+        assert!(Version::Alpha(1, Some(1)).latest() > Version::Alpha(1, None).latest());
+        assert!(Version::Alpha(1, Some(2)).latest() > Version::Alpha(1, Some(1)).latest());
+        assert!(Version::Alpha(1, None).latest() > Version::Nonconformant("foo".to_string()).latest());
+        assert!(Version::Alpha(1, Some(2)).latest() > Version::Nonconformant("foo".to_string()).latest());
+        assert!(
+            Version::Nonconformant("bar".to_string()).latest()
+                > Version::Nonconformant("foo".to_string()).latest()
+        );
+        assert!(
+            Version::Nonconformant("foo1".to_string()).latest()
+                > Version::Nonconformant("foo10".to_string()).latest()
+        );
+
+        // sort order by default is ascending
+        // sorting with std::cmp::Reverse thus gives you the "most latest stable" first
+        let mut vers = vec![
+            Version::Beta(2, Some(2)),
+            Version::Stable(1),
+            Version::Nonconformant("hi".into()),
+            Version::Alpha(3, Some(2)),
+            Version::Stable(2),
+            Version::Beta(2, Some(3)),
+        ];
+        vers.sort_by_cached_key(|x| Reverse(x.latest()));
+        assert_eq!(vers, vec![
+            Version::Alpha(3, Some(2)),
+            Version::Stable(2),
+            Version::Beta(2, Some(3)),
+            Version::Beta(2, Some(2)),
+            Version::Stable(1),
             Version::Nonconformant("hi".into()),
         ]);
     }

--- a/kube-core/src/version.rs
+++ b/kube-core/src/version.rs
@@ -125,25 +125,25 @@ impl FromStr for Version {
 // A key used to allow sorting Versions
 #[derive(PartialEq, Eq, PartialOrd, Ord)]
 enum VersionSortKey<'a> {
-    Stable(Reverse<u32>),
-    Beta(Reverse<u32>, Reverse<Option<u32>>),
-    Alpha(Reverse<u32>, Reverse<Option<u32>>),
-    Nonconformant(&'a str),
+    Nonconformant(Reverse<&'a str>),
+    Alpha(u32, Option<u32>),
+    Beta(u32, Option<u32>),
+    Stable(u32),
 }
 impl Version {
     fn to_sort_key(&self) -> VersionSortKey {
         match self {
-            Version::Stable(v) => VersionSortKey::Stable(Reverse(*v)),
-            Version::Beta(v, beta) => VersionSortKey::Beta(Reverse(*v), Reverse(*beta)),
-            Version::Alpha(v, alpha) => VersionSortKey::Alpha(Reverse(*v), Reverse(*alpha)),
-            Version::Nonconformant(nc) => VersionSortKey::Nonconformant(nc),
+            Version::Stable(v) => VersionSortKey::Stable(*v),
+            Version::Beta(v, beta) => VersionSortKey::Beta(*v, *beta),
+            Version::Alpha(v, alpha) => VersionSortKey::Alpha(*v, *alpha),
+            Version::Nonconformant(nc) => VersionSortKey::Nonconformant(Reverse(nc)),
         }
     }
 }
 
 impl Ord for Version {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        other.to_sort_key().cmp(&self.to_sort_key())
+        self.to_sort_key().cmp(&other.to_sort_key())
     }
 }
 


### PR DESCRIPTION
needed for https://github.com/kube-rs/kopium/issues/23

This does the self-comment cleanup steps described to make this worthy of exporting:

- reverse Ord impl so we have semantic coherence (stable 2 > stable 1)
- reverse sort usage internally to compensate (ascending version order default, matches rust conventions)

Also adds a small doctest for the thing, and an infallible `FromStr` impl (which may end up being useful to someone - maybe).