### PR TITLE
Version export - explicitly request ordering

### DIFF
--- a/kube-client/src/discovery/apigroup.rs
+++ b/kube-client/src/discovery/apigroup.rs
@@ -118,7 +118,7 @@ impl ApiGroup {
 
     fn sort_versions(&mut self) {
         self.data
-            .sort_by_cached_key(|gvd| Reverse(Version::parse(gvd.version.as_str()).latest_stable()))
+            .sort_by_cached_key(|gvd| Reverse(Version::parse(gvd.version.as_str()).priority()))
     }
 
     // shortcut method to give cheapest return for a single GVK

--- a/kube-client/src/discovery/apigroup.rs
+++ b/kube-client/src/discovery/apigroup.rs
@@ -118,7 +118,7 @@ impl ApiGroup {
 
     fn sort_versions(&mut self) {
         self.data
-            .sort_by_cached_key(|gvd| Reverse(Version::parse(gvd.version.as_str())))
+            .sort_by_cached_key(|gvd| Reverse(Version::parse(gvd.version.as_str()).latest_stable()))
     }
 
     // shortcut method to give cheapest return for a single GVK

--- a/kube-core/src/version.rs
+++ b/kube-core/src/version.rs
@@ -118,7 +118,7 @@ enum Stability {
 
 /// See [`Version::priority`]
 #[derive(PartialEq, Eq, PartialOrd, Ord)]
-struct LatestStable {
+struct Priority {
     stability: Stability,
     major: u32,
     minor: Option<u32>,
@@ -155,25 +155,25 @@ impl Version {
     /// `Stable(x)` > `Beta(y)` > `Alpha(z)` > `Nonconformant(w)` for all `x`,`y`,`z`,`w`
     pub fn priority(&self) -> impl Ord {
         match self {
-            &Version::Stable(major) => LatestStable {
+            &Version::Stable(major) => Priority {
                 stability: Stability::Stable,
                 major,
                 minor: None,
                 nonconformant: None,
             },
-            &Version::Beta(major, minor) => LatestStable {
+            &Version::Beta(major, minor) => Priority {
                 stability: Stability::Beta,
                 major,
                 minor,
                 nonconformant: None,
             },
-            &Self::Alpha(major, minor) => LatestStable {
+            &Self::Alpha(major, minor) => Priority {
                 stability: Stability::Alpha,
                 major,
                 minor,
                 nonconformant: None,
             },
-            Self::Nonconformant(nonconformant) => LatestStable {
+            Self::Nonconformant(nonconformant) => Priority {
                 stability: Stability::Nonconformant,
                 major: 0,
                 minor: None,


### PR DESCRIPTION
Sub-PR for https://github.com/kube-rs/kube-rs/pull/764, as discussed in https://github.com/kube-rs/kube-rs/pull/764#discussion_r773670859.

This PR makes you explicitly specify which ordering you want for `Version`, rather than automatically assuming K8s' version priority (which makes sense for trying to pick an implicit version, but not for presenting a visual list to the user).