### PR TITLE
Reload token file at least once a minute

### DIFF
--- a/kube-client/src/config/incluster_config.rs
+++ b/kube-client/src/config/incluster_config.rs
@@ -27,10 +27,6 @@ pub enum Error {
     #[error("failed to read the default namespace: {0}")]
     ReadDefaultNamespace(#[source] std::io::Error),
 
-    /// Failed to read the token for the service account
-    #[error("failed to read the SA token: {0}")]
-    ReadToken(#[source] std::io::Error),
-
     /// Failed to read a certificate bundle
     #[error("failed to read a certificate bundle: {0}")]
     ReadCertificateBundle(#[source] std::io::Error),
@@ -75,9 +71,8 @@ fn kube_port() -> Option<String> {
     env::var(SERVICE_PORTENV).ok()
 }
 
-/// Returns token from specified path in cluster.
-pub fn load_token() -> Result<String, Error> {
-    std::fs::read_to_string(&SERVICE_TOKENFILE).map_err(Error::ReadToken)
+pub fn token_file() -> String {
+    SERVICE_TOKENFILE.to_owned()
 }
 
 /// Returns certification from specified path in cluster.

--- a/kube-client/src/config/mod.rs
+++ b/kube-client/src/config/mod.rs
@@ -4,7 +4,6 @@
 //! The [`Config`] has several constructors plus logic to infer environment.
 //!
 //! Unless you have issues, prefer using [`Config::infer`], and pass it to a [`Client`][crate::Client].
-use secrecy::SecretString;
 use std::{path::PathBuf, time::Duration};
 
 use thiserror::Error;
@@ -202,7 +201,6 @@ impl Config {
 
         let default_namespace = incluster_config::load_default_ns()?;
         let root_cert = incluster_config::load_cert()?;
-        let token = incluster_config::load_token()?;
 
         Ok(Self {
             cluster_url,
@@ -211,7 +209,7 @@ impl Config {
             timeout: Some(DEFAULT_TIMEOUT),
             accept_invalid_certs: false,
             auth_info: AuthInfo {
-                token: Some(SecretString::from(token)),
+                token_file: Some(incluster_config::token_file()),
                 ..Default::default()
             },
             proxy_url: None,


### PR DESCRIPTION
## Motivation

Client library requirement was updated in March to require reloading the token file at least once per minute. https://github.com/kubernetes/community/commit/fdaf2135a590b7da3895ae7564020e130d6c3822

## Solution

Add a new variant to `RefreshableToken` that reloads a token from the token file every minute with a leeway of 10s ([client-go](https://github.com/kubernetes/kubernetes/blob/a6299aa2abde8e1fce4d41733f63aeb9d75c2178/staging/src/k8s.io/client-go/transport/token_source.go#L69-L82)).

### TODO

- [x] Allow reloading to fail and use the current token.
    > If reload from file fails, the last-read token should be used to avoid breaking clients that make token files available on process start and then remove them to limit credential exposure.
    > https://github.com/kubernetes/kubernetes/issues/68164
- [x] Change in-cluster config to use `token_file` set to `SERVICE_TOKENFILE`. Currently reads the file once at start.
- [x] Use `SecretString` (can be done after #766)
- [x] Test. Added unit test.

---

Resolves #572