### PR TITLE
Install OpenSSL library in Windows CI workflow using Chocolatey

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,7 @@ jobs:
       # Prevent GitHub from cancelling all in-progress jobs when a matrix job fails.
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
-        # TODO: add windows-latest (see #566)
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -23,6 +22,17 @@ jobs:
       # - https://github.com/rust-lang/cargo/issues/8603
       # - https://github.com/actions/cache/issues/403
       - uses: Swatinem/rust-cache@v1
+
+      # Install OpenSSL Libraries for Windows
+      - name: install openssl
+        if: matrix.os == 'windows-latest'
+        run: |
+          choco install --verbose openssl
+          openssl version
+          refreshenv
+          echo "OPENSSL_LIB_DIR=C:/Program Files/OpenSSL-Win64/lib" >> $env:GITHUB_ENV
+          echo "OPENSSL_DIR=C:/Program Files/OpenSSL-Win64/" >> $env:GITHUB_ENV
+          echo "OPENSSL_INCLUDE_DIR=C:/Program Files/OpenSSL-Win64/include" >> $env:GITHUB_ENV
 
       # Real CI work starts here
       - name: Build workspace


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation
Aims to solve #566.

<!--
Explain the context and why you're making that change. What is the problem you're trying to solve?
If a new feature is being added, describe the intended use case that feature fulfills.
-->

## Solution
Using Chocolatey to install the OpenSSL library; one big downside is that the installed version (OpenSSL 1.1.1  11 Sep 2018) is not the latest. Not sure if this is acceptable.
Have yet to figure out how to cache the files downloaded by OpenSSL, but the installation of OpenSSL only takes ~1 min.

As for the CI build time, linux and mac-os builds are not impacted (as expected).
The windows build takes ~11 min, which is ~3min more than the mac-os build: [master CI](https://github.com/ChinYing-Li/kube-rs/runs/4619368597?check_suite_focus=true) vs. [this branch](https://github.com/ChinYing-Li/kube-rs/runs/4619605303?check_suite_focus=true).

Any suggestion is appreciated!

<!--
Summarize the solution and provide any necessary context needed to understand the code change.
-->
