### PR TITLE
Remove crate private `identity_pem` field from `Config`

### DIFF
--- a/kube-client/src/client/config_ext.rs
+++ b/kube-client/src/client/config_ext.rs
@@ -184,7 +184,7 @@ impl ConfigExt for Config {
     #[cfg(feature = "native-tls")]
     fn native_tls_connector(&self) -> Result<tokio_native_tls::native_tls::TlsConnector> {
         tls::native_tls::native_tls_connector(
-            self.identity_pem.as_ref(),
+            self.identity_pem().as_ref(),
             self.root_cert.as_ref(),
             self.accept_invalid_certs,
         )
@@ -202,7 +202,7 @@ impl ConfigExt for Config {
     #[cfg(feature = "rustls-tls")]
     fn rustls_client_config(&self) -> Result<rustls::ClientConfig> {
         tls::rustls_tls::rustls_client_config(
-            self.identity_pem.as_deref(),
+            self.identity_pem().as_deref(),
             self.root_cert.as_deref(),
             self.accept_invalid_certs,
         )
@@ -219,7 +219,7 @@ impl ConfigExt for Config {
 
     #[cfg(feature = "openssl-tls")]
     fn openssl_ssl_connector_builder(&self) -> Result<openssl::ssl::SslConnectorBuilder> {
-        tls::openssl_tls::ssl_connector_builder(self.identity_pem.as_ref(), self.root_cert.as_ref())
+        tls::openssl_tls::ssl_connector_builder(self.identity_pem().as_ref(), self.root_cert.as_ref())
             .map_err(|e| Error::OpensslTls(tls::openssl_tls::Error::CreateSslConnector(e)))
     }
 

--- a/kube-client/src/config/file_config.rs
+++ b/kube-client/src/config/file_config.rs
@@ -402,12 +402,24 @@ impl Cluster {
 }
 
 impl AuthInfo {
+    pub(crate) fn identity_pem(&self) -> Result<Vec<u8>, KubeconfigError> {
+        let client_cert = &self.load_client_certificate()?;
+        let client_key = &self.load_client_key()?;
+        let mut buffer = client_key.clone();
+        buffer.extend_from_slice(client_cert);
+        Ok(buffer)
+    }
+
     pub(crate) fn load_client_certificate(&self) -> Result<Vec<u8>, KubeconfigError> {
+        // TODO Shouldn't error when `self.client_certificate_data.is_none() && self.client_certificate.is_none()`
+
         load_from_base64_or_file(&self.client_certificate_data, &self.client_certificate)
             .map_err(KubeconfigError::LoadClientCertificate)
     }
 
     pub(crate) fn load_client_key(&self) -> Result<Vec<u8>, KubeconfigError> {
+        // TODO Shouldn't error when `self.client_key_data.is_none() && self.client_key.is_none()`
+
         load_from_base64_or_file(&self.client_key_data, &self.client_key)
             .map_err(KubeconfigError::LoadClientKey)
     }

--- a/kube-client/src/config/file_loader.rs
+++ b/kube-client/src/config/file_loader.rs
@@ -96,14 +96,6 @@ impl ConfigLoader {
         })
     }
 
-    pub fn identity_pem(&self) -> Result<Vec<u8>, KubeconfigError> {
-        let client_cert = &self.user.load_client_certificate()?;
-        let client_key = &self.user.load_client_key()?;
-        let mut buffer = client_key.clone();
-        buffer.extend_from_slice(client_cert);
-        Ok(buffer)
-    }
-
     pub fn ca_bundle(&self) -> Result<Option<Vec<Vec<u8>>>, KubeconfigError> {
         if let Some(bundle) = self.cluster.load_certificate_authority()? {
             Ok(Some(

--- a/kube-client/src/config/mod.rs
+++ b/kube-client/src/config/mod.rs
@@ -134,9 +134,6 @@ pub struct Config {
     pub timeout: Option<std::time::Duration>,
     /// Whether to accept invalid ceritifacts
     pub accept_invalid_certs: bool,
-    // TODO should keep client key and certificate separate. It's split later anyway.
-    /// Client certificate and private key in PEM.
-    pub(crate) identity_pem: Option<Vec<u8>>,
     /// Stores information to tell the cluster who you are.
     pub(crate) auth_info: AuthInfo,
     // TODO Actually support proxy or create an example with custom client
@@ -157,7 +154,6 @@ impl Config {
             root_cert: None,
             timeout: Some(DEFAULT_TIMEOUT),
             accept_invalid_certs: false,
-            identity_pem: None,
             auth_info: AuthInfo::default(),
             proxy_url: None,
         }
@@ -211,7 +207,6 @@ impl Config {
             root_cert: Some(root_cert),
             timeout: Some(DEFAULT_TIMEOUT),
             accept_invalid_certs: false,
-            identity_pem: None,
             auth_info: AuthInfo {
                 token: Some(token),
                 ..Default::default()
@@ -254,9 +249,8 @@ impl Config {
             .clone()
             .unwrap_or_else(|| String::from("default"));
 
-        let mut accept_invalid_certs = false;
+        let mut accept_invalid_certs = loader.cluster.insecure_skip_tls_verify.unwrap_or(false);
         let mut root_cert = None;
-        let mut identity_pem = None;
 
         if let Some(ca_bundle) = loader.ca_bundle()? {
             for ca in &ca_bundle {
@@ -265,28 +259,20 @@ impl Config {
             root_cert = Some(ca_bundle);
         }
 
-        // REVIEW Changed behavior. This no longer fails with invalid data in PEM.
-        match loader.identity_pem() {
-            Ok(id) => identity_pem = Some(id),
-            Err(e) => {
-                tracing::debug!("failed to load client identity from kubeconfig: {}", e);
-                // last resort only if configs ask for it, and no client certs
-                if let Some(true) = loader.cluster.insecure_skip_tls_verify {
-                    accept_invalid_certs = true;
-                }
-            }
-        }
-
         Ok(Self {
             cluster_url,
             default_namespace,
             root_cert,
             timeout: Some(DEFAULT_TIMEOUT),
             accept_invalid_certs,
-            identity_pem,
             proxy_url: loader.proxy_url()?,
             auth_info: loader.user,
         })
+    }
+
+    /// Client certificate and private key in PEM.
+    pub(crate) fn identity_pem(&self) -> Option<Vec<u8>> {
+        self.auth_info.identity_pem().ok()
     }
 }
 


### PR DESCRIPTION
The concatenated `identity_pem` field shouldn't be necessary. At least, it shouldn't be necessary to be stored in `Config` because the client certificates and the private key are in `config.auth_info`.

I'm not sure _why_ we're doing the following:

https://github.com/kube-rs/kube-rs/blob/52f69b9a89aa9e23605eb7f9c3ca673260e21853/kube-client/src/config/mod.rs#L269-L278

where `accept_invalid_certs` only respects the config when failing to load `identity_pem` and when `insecure_skip_tls_verify` is set true.

The following should be fine:
```rust
let mut accept_invalid_certs = loader.cluster.insecure_skip_tls_verify.unwrap_or(false);
```

Also, the error from `identity_pem()` is ignored. I don't think `load_client_certificate()` and `load_client_key()` called in `identity_pem()` are defined correctly.

https://github.com/kube-rs/kube-rs/blob/52f69b9a89aa9e23605eb7f9c3ca673260e21853/kube-client/src/config/file_config.rs#L404-L414

These errors when the fields are not present in config, but that's valid and should return `None` in that case.

Ideally, we should validate the configured fields when creating a `Config` and error when it's configured with an invalid Base64 or path.

This PR removes `identity_pem` field with minimal changes.