### PR TITLE
Revert "Update dashmap requirement from 4.0.1 to 5.0.0"

### DIFF
--- a/kube-runtime/Cargo.toml
+++ b/kube-runtime/Cargo.toml
@@ -27,7 +27,7 @@ serde = "1.0.130"
 smallvec = "1.7.0"
 pin-project = "1.0.2"
 tokio = { version = "1.14.0", features = ["time"] }
-dashmap = "5.0.0"
+dashmap = "4.0.1"
 tokio-util = { version = "0.6.8", features = ["time"] }
 tracing = "0.1.29"
 json-patch = "0.2.6"


### PR DESCRIPTION
Reverts kube-rs/kube-rs#755

Workaround for https://rustsec.org/advisories/RUSTSEC-2022-0002, it's not like we're using anything 5.x-specific anyway.