### PR TITLE
Add a `kube/cache` feature

### DIFF
--- a/kube-runtime/Cargo.toml
+++ b/kube-runtime/Cargo.toml
@@ -19,6 +19,11 @@ features = ["k8s-openapi/v1_22"]
 # Define the configuration attribute `docsrs`. Used to enable `doc_cfg` feature.
 rustdoc-args = ["--cfg", "docsrs"]
 
+[features]
+default = []
+controller = ["reflector"]
+reflector = ["dashmap"]
+
 [dependencies]
 futures = "0.3.17"
 kube-client = { path = "../kube-client", version = "^0.65.0", default-features = false, features = ["jsonpatch", "client"] }
@@ -27,7 +32,7 @@ serde = "1.0.130"
 smallvec = "1.7.0"
 pin-project = "1.0.2"
 tokio = { version = "1.14.0", features = ["time"] }
-dashmap = "4.0.1"
+dashmap = { version = "4.0.1", optional = true }
 tokio-util = { version = "0.6.8", features = ["time"] }
 tracing = "0.1.29"
 json-patch = "0.2.6"

--- a/kube-runtime/src/lib.rs
+++ b/kube-runtime/src/lib.rs
@@ -17,19 +17,23 @@
 // Triggered by Tokio macros
 #![allow(clippy::semicolon_if_nothing_returned)]
 
+#[cfg(feature = "controller")]
 pub mod controller;
 k8s_openapi::k8s_if_ge_1_19! {
     pub mod events;
 }
 pub mod finalizer;
+#[cfg(feature = "reflector")]
 pub mod reflector;
 pub mod scheduler;
 pub mod utils;
 pub mod wait;
 pub mod watcher;
 
+#[cfg(feature = "controller")]
 pub use controller::{applier, Controller};
 pub use finalizer::finalizer;
+#[cfg(feature = "reflector")]
 pub use reflector::reflector;
 pub use scheduler::scheduler;
 pub use watcher::watcher;

--- a/kube/Cargo.toml
+++ b/kube/Cargo.toml
@@ -29,6 +29,7 @@ admission = ["kube-core/admission"]
 derive = ["kube-derive"]
 config = ["kube-client/config"]
 runtime = ["kube-runtime"]
+cache = ["kube-runtime/controller"]
 deprecated-crd-v1beta1 = ["kube-core/deprecated-crd-v1beta1"]
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
## Motivation

`kube_runtime::reflector`, which is used by `kube_runtime::controller`,
pulls in a dependency on `dashmap`, which is only needed when this
caching logic is desired.

## Solution

This change adds new feature flags to optionally enable these
components:

* `kube-runtime/reflector` enables the `kube_runtime::reflector` module
  (including the `dashmap` dependency).
* `kube-runtime/controller` enables the `kube_rutime::controller`
  module, including the `kube-runtime/reflector` feature.
* `kube/cache` enable `kube-runtime/controller`

These features are not enabled by default.

Fixes #781
