### PR TITLE
Fix the changelog nesting for 0.66.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ UNRELEASED
  * see https://github.com/kube-rs/kube-rs/compare/0.65.0...master
  * Added `DeleteParams::background()`, `DeleteParams::foreground()`, `DeleteParams::orphan()` constructors - [#747](https://github.com/kube-rs/kube-rs/issues/747)
  * Introduced `StreamBackoff` mechanism for backing off watchers - #703
-  * BREAKING: `Controller` now uses `backoff` for trigger watches by default, use `Controller::trigger_backoff` to override
+   * BREAKING: `Controller` now uses `backoff` for trigger watches by default, use `Controller::trigger_backoff` to override
  * `#[derive(CustomResource)]` now supports structs containing enums with fields - #779
-  * BREAKING: If you depend on `kube-derive` directly rather than via `kube` then you must now add the `schema` feature to `kube-core`
+   * BREAKING: If you depend on `kube-derive` directly rather than via `kube` then you must now add the `schema` feature to `kube-core`
 
 0.65.0 / 2021-12-10
 ===================


### PR DESCRIPTION
Otherwise the notes didn't relate clearly to the PRs in the rendered version.