### PR TITLE
runtime: Replace `DashMap` with a locked `AHashMap`

### DIFF
--- a/kube-runtime/Cargo.toml
+++ b/kube-runtime/Cargo.toml
@@ -25,9 +25,9 @@ kube-client = { path = "../kube-client", version = "^0.66.0", default-features =
 derivative = "2.1.1"
 serde = "1.0.130"
 smallvec = "1.7.0"
+parking_lot = "0.11"
 pin-project = "1.0.2"
 tokio = { version = "1.14.0", features = ["time"] }
-dashmap = "4.0.1"
 tokio-util = { version = "0.6.8", features = ["time"] }
 tracing = "0.1.29"
 json-patch = "0.2.6"

--- a/kube-runtime/Cargo.toml
+++ b/kube-runtime/Cargo.toml
@@ -25,6 +25,7 @@ kube-client = { path = "../kube-client", version = "^0.66.0", default-features =
 derivative = "2.1.1"
 serde = "1.0.130"
 smallvec = "1.7.0"
+ahash = "0.7"
 parking_lot = "0.11"
 pin-project = "1.0.2"
 tokio = { version = "1.14.0", features = ["time"] }

--- a/kube-runtime/src/reflector/store.rs
+++ b/kube-runtime/src/reflector/store.rs
@@ -1,11 +1,12 @@
 use super::ObjectRef;
 use crate::watcher;
+use ahash::AHashMap;
 use derivative::Derivative;
 use kube_client::Resource;
 use parking_lot::RwLock;
-use std::{collections::HashMap, fmt::Debug, hash::Hash, sync::Arc};
+use std::{fmt::Debug, hash::Hash, sync::Arc};
 
-type Cache<K> = Arc<RwLock<HashMap<ObjectRef<K>, K>>>;
+type Cache<K> = Arc<RwLock<AHashMap<ObjectRef<K>, K>>>;
 
 /// A writable Store handle
 ///
@@ -64,7 +65,7 @@ where
                 let new_objs = new_objs
                     .iter()
                     .map(|obj| (ObjectRef::from_obj_with(obj, self.dyntype.clone()), obj))
-                    .collect::<HashMap<_, _>>();
+                    .collect::<AHashMap<_, _>>();
                 // We can't do do the whole replacement atomically, but we should at least not delete objects that still exist
                 let mut store = self.store.write();
                 store.retain(|key, _old_value| new_objs.contains_key(key));

--- a/kube-runtime/src/reflector/store.rs
+++ b/kube-runtime/src/reflector/store.rs
@@ -64,14 +64,9 @@ where
             watcher::Event::Restarted(new_objs) => {
                 let new_objs = new_objs
                     .iter()
-                    .map(|obj| (ObjectRef::from_obj_with(obj, self.dyntype.clone()), obj))
+                    .map(|obj| (ObjectRef::from_obj_with(obj, self.dyntype.clone()), obj.clone()))
                     .collect::<AHashMap<_, _>>();
-                // We can't do do the whole replacement atomically, but we should at least not delete objects that still exist
-                let mut store = self.store.write();
-                store.retain(|key, _old_value| new_objs.contains_key(key));
-                for (key, obj) in new_objs {
-                    store.insert(key, obj.clone());
-                }
+                *self.store.write() = new_objs;
             }
         }
     }

--- a/kube-runtime/src/reflector/store.rs
+++ b/kube-runtime/src/reflector/store.rs
@@ -1,9 +1,11 @@
 use super::ObjectRef;
 use crate::watcher;
-use dashmap::DashMap;
 use derivative::Derivative;
 use kube_client::Resource;
+use parking_lot::RwLock;
 use std::{collections::HashMap, fmt::Debug, hash::Hash, sync::Arc};
+
+type Cache<K> = Arc<RwLock<HashMap<ObjectRef<K>, K>>>;
 
 /// A writable Store handle
 ///
@@ -15,7 +17,7 @@ pub struct Writer<K: 'static + Resource>
 where
     K::DynamicType: Eq + Hash,
 {
-    store: Arc<DashMap<ObjectRef<K>, K>>,
+    store: Cache<K>,
     dyntype: K::DynamicType,
 }
 
@@ -50,10 +52,12 @@ where
         match event {
             watcher::Event::Applied(obj) => {
                 self.store
+                    .write()
                     .insert(ObjectRef::from_obj_with(obj, self.dyntype.clone()), obj.clone());
             }
             watcher::Event::Deleted(obj) => {
                 self.store
+                    .write()
                     .remove(&ObjectRef::from_obj_with(obj, self.dyntype.clone()));
             }
             watcher::Event::Restarted(new_objs) => {
@@ -62,9 +66,10 @@ where
                     .map(|obj| (ObjectRef::from_obj_with(obj, self.dyntype.clone()), obj))
                     .collect::<HashMap<_, _>>();
                 // We can't do do the whole replacement atomically, but we should at least not delete objects that still exist
-                self.store.retain(|key, _old_value| new_objs.contains_key(key));
+                let mut store = self.store.write();
+                store.retain(|key, _old_value| new_objs.contains_key(key));
                 for (key, obj) in new_objs {
-                    self.store.insert(key, obj.clone());
+                    store.insert(key, obj.clone());
                 }
             }
         }
@@ -83,7 +88,7 @@ pub struct Store<K: 'static + Resource>
 where
     K::DynamicType: Hash + Eq,
 {
-    store: Arc<DashMap<ObjectRef<K>, K>>,
+    store: Cache<K>,
 }
 
 impl<K: 'static + Clone + Resource> Store<K>
@@ -101,24 +106,26 @@ where
     /// reasonable `error_policy`.
     #[must_use]
     pub fn get(&self, key: &ObjectRef<K>) -> Option<K> {
-        self.store
+        let store = self.store.read();
+        store
             .get(key)
             // Try to erase the namespace and try again, in case the object is cluster-scoped
             .or_else(|| {
-                self.store.get(&{
+                store.get(&{
                     let mut cluster_key = key.clone();
                     cluster_key.namespace = None;
                     cluster_key
                 })
             })
             // Clone to let go of the entry lock ASAP
-            .map(|entry| entry.value().clone())
+            .cloned()
     }
 
     /// Return a full snapshot of the current values
     #[must_use]
     pub fn state(&self) -> Vec<K> {
-        self.store.iter().map(|eg| eg.value().clone()).collect()
+        let s = self.store.read();
+        s.values().cloned().collect()
     }
 }
 


### PR DESCRIPTION
## Motivation

The `kube_runtime::reflector` module pulls in `dashmap`, a concurrent
hashmap implementation. This implementation necessarily uses `unsafe`,
which can lead to safety/correctness/security issues (like
[RUSTSEC-2022-02][sec]).

## Solution

This change replaces `dashmap` with a `RwLock<AHashMap<...>>` using
`parking_lot`.  `parking_lot` currently has greater than 10x the usage
(according to https://lib.rs) and is already used by existing
dependencies.
    
`dashmap` purports to be higher bandwidth and lower latency than a
simple `parking_lot` lock, but most kubernetes controllers should not
operate at the scale where these differences factor into application
performance. On the other hand, all users may be impacted by correctness
issues.

`AHash` is used to reduce contention incurred by hash latency. AHash
claims to be ~10x faster than the default hasher, while preserving DoS
resistance.

This change does not impact the public API in any way and it should not
impact users.

Fixes #781

[sec]: https://rustsec.org/advisories/RUSTSEC-2022-0002.html
[ahash]: https://github.com/tkaitchuck/aHash/blob/master/compare/readme.md#Speed