### PR TITLE
runtime: Store resources in an `Arc`

### DIFF
--- a/examples/crd_reflector.rs
+++ b/examples/crd_reflector.rs
@@ -46,7 +46,7 @@ async fn main() -> anyhow::Result<()> {
             // Periodically read our state
             // while this runs you can kubectl apply -f crd-baz.yaml or crd-qux.yaml and see it works
             tokio::time::sleep(std::time::Duration::from_secs(5)).await;
-            let crds = reader.state().iter().map(ResourceExt::name).collect::<Vec<_>>();
+            let crds = reader.state().iter().map(|r| r.name()).collect::<Vec<_>>();
             info!("Current crds: {:?}", crds);
         }
     });

--- a/examples/deployment_reflector.rs
+++ b/examples/deployment_reflector.rs
@@ -29,7 +29,7 @@ async fn main() -> anyhow::Result<()> {
     tokio::spawn(async move {
         loop {
             // Periodically read our state
-            let deploys: Vec<_> = reader.state().iter().map(ResourceExt::name).collect();
+            let deploys: Vec<_> = reader.state().iter().map(|r| r.name()).collect();
             info!("Current deploys: {:?}", deploys);
             tokio::time::sleep(std::time::Duration::from_secs(30)).await;
         }

--- a/examples/node_reflector.rs
+++ b/examples/node_reflector.rs
@@ -25,7 +25,7 @@ async fn main() -> anyhow::Result<()> {
     // Periodically read our state in the background
     tokio::spawn(async move {
         loop {
-            let nodes = reader.state().iter().map(ResourceExt::name).collect::<Vec<_>>();
+            let nodes = reader.state().iter().map(|r| r.name()).collect::<Vec<_>>();
             info!("Current {} nodes: {:?}", nodes.len(), nodes);
             tokio::time::sleep(std::time::Duration::from_secs(10)).await;
         }

--- a/kube-runtime/src/reflector/mod.rs
+++ b/kube-runtime/src/reflector/mod.rs
@@ -55,7 +55,7 @@ mod tests {
         .map(|_| ())
         .collect::<()>()
         .await;
-        assert_eq!(store.get(&ObjectRef::from_obj(&cm)), Some(cm));
+        assert_eq!(store.get(&ObjectRef::from_obj(&cm)).as_deref(), Some(&cm));
     }
 
     #[tokio::test]
@@ -87,7 +87,7 @@ mod tests {
         .map(|_| ())
         .collect::<()>()
         .await;
-        assert_eq!(store.get(&ObjectRef::from_obj(&cm)), Some(updated_cm));
+        assert_eq!(store.get(&ObjectRef::from_obj(&cm)).as_deref(), Some(&updated_cm));
     }
 
     #[tokio::test]
@@ -143,7 +143,7 @@ mod tests {
         .collect::<()>()
         .await;
         assert_eq!(store.get(&ObjectRef::from_obj(&cm_a)), None);
-        assert_eq!(store.get(&ObjectRef::from_obj(&cm_b)), Some(cm_b));
+        assert_eq!(store.get(&ObjectRef::from_obj(&cm_b)).as_deref(), Some(&cm_b));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Motivation

The read-side of `kube_runtime::reflector`  is allocation-heavy: each read incurs a clone of the entire resource data structure. This can incur substantial unnecessary load in read-heavy use cases, especially for larger resources. Furthermore, with f66dd90, these allocations are frequently performed while a read-lock is held.

## Solution

This change modifies the `kube_runtime::reflector` to store resources in an atomic, reference-counted cell (`std::sync::Arc`) so that clones do not incur allocation. The goal of this change is to amortize costs so that these allocations are only incurred once--at update-time, before the write-lock is acquired--making reads cheaper and generally reducing lock contention.
    
This changes the public APIs of `kube_runtime`'s `controller`, `reflector`, and `finalizer` modules.