### PR TITLE
update k8s-openapi for kubernetes 1.23 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,11 @@ Select a version of `kube` along with the generated [k8s-openapi](https://github
 
 ```toml
 [dependencies]
-kube = { version = "0.66.0", features = ["runtime","derive"] }
-k8s-openapi = { version = "0.13.1", default-features = false, features = ["v1_22"] }
+kube = { version = "0.66.0", features = ["runtime", "derive"] }
+k8s-openapi = { version = "0.14.0", features = ["v1_22"] }
 ```
 
 [Features are available](https://github.com/kube-rs/kube-rs/blob/master/kube/Cargo.toml#L18).
-
-We recommend turning off `default-features` for `k8s-openapi` to speed up your compilation.
 
 ## Upgrading
 
@@ -159,7 +157,7 @@ Kube has basic support ([with caveats](https://github.com/kube-rs/kube-rs/issues
 ```toml
 [dependencies]
 kube = { version = "0.66.0", default-features = false, features = ["client", "rustls-tls"] }
-k8s-openapi = { version = "0.13.1", default-features = false, features = ["v1_22"] }
+k8s-openapi = { version = "0.14.0", features = ["v1_22"] }
 ```
 
 This will pull in `rustls` and `hyper-rustls`.

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -18,7 +18,7 @@ anyhow = "1.0.44"
 env_logger = "0.9.0"
 futures = "0.3.17"
 kube = { path = "../kube", version = "^0.66.0", default-features = false, features = ["client", "rustls-tls"] }
-k8s-openapi = { version = "0.13.1", features = ["v1_22"], default-features = false }
+k8s-openapi = { version = "0.14.0", features = ["v1_22"], default-features = false }
 log = "0.4.11"
 serde_json = "1.0.68"
 tokio = { version = "1.14.0", features = ["full"] }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -33,7 +33,7 @@ futures = "0.3.17"
 jsonpath_lib = "0.3.0"
 kube = { path = "../kube", version = "^0.66.0", default-features = false, features = ["admission"] }
 kube-derive = { path = "../kube-derive", version = "^0.66.0", default-features = false } # only needed to opt out of schema
-k8s-openapi = { version = "0.13.1", default-features = false }
+k8s-openapi = { version = "0.14.0", default-features = false }
 log = "0.4.11"
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.68"

--- a/kube-client/Cargo.toml
+++ b/kube-client/Cargo.toml
@@ -74,7 +74,7 @@ tracing = { version = "0.1.29", features = ["log"], optional = true }
 hyper-openssl = { version = "0.9.1", optional = true }
 
 [dependencies.k8s-openapi]
-version = "0.13.1"
+version = "0.14.0"
 default-features = false
 features = []
 
@@ -87,6 +87,6 @@ tokio-test = "0.4.0"
 tower-test = "0.4.0"
 
 [dev-dependencies.k8s-openapi]
-version = "0.13.1"
+version = "0.14.0"
 default-features = false
 features = ["v1_22"]

--- a/kube-core/Cargo.toml
+++ b/kube-core/Cargo.toml
@@ -35,12 +35,12 @@ chrono = "0.4.19"
 schemars = { version = "0.8.6", optional = true }
 
 [dependencies.k8s-openapi]
-version = "0.13.1"
+version = "0.14.0"
 default-features = false
 features = []
 
 [dev-dependencies.k8s-openapi]
-version = "0.13.1"
+version = "0.14.0"
 default-features = false
 features = ["v1_22"]
 

--- a/kube-derive/Cargo.toml
+++ b/kube-derive/Cargo.toml
@@ -26,7 +26,7 @@ proc-macro = true
 serde = { version = "1.0.130", features = ["derive"] }
 serde_yaml = "0.8.21"
 kube = { path = "../kube", default-features = false, version = "<1.0.0, >=0.61.0", features = ["derive"] }
-k8s-openapi = { version = "0.13.1", default-features = false, features = ["v1_22"] }
+k8s-openapi = { version = "0.14.0", default-features = false, features = ["v1_22"] }
 schemars = { version = "0.8.6", features = ["chrono"] }
 validator = { version = "0.14.0", features = ["derive"] }
 chrono = "0.4.19"

--- a/kube-runtime/Cargo.toml
+++ b/kube-runtime/Cargo.toml
@@ -37,7 +37,7 @@ thiserror = "1.0.29"
 backoff = "0.4.0"
 
 [dependencies.k8s-openapi]
-version = "0.13.1"
+version = "0.14.0"
 default-features = false
 
 [dev-dependencies]
@@ -48,6 +48,6 @@ rand = "0.8.0"
 schemars = "0.8.6"
 
 [dev-dependencies.k8s-openapi]
-version = "0.13.1"
+version = "0.14.0"
 default-features = false
 features = ["v1_22"]

--- a/kube/Cargo.toml
+++ b/kube/Cargo.toml
@@ -45,7 +45,7 @@ kube-runtime = { path = "../kube-runtime", version = "^0.66.0", optional = true}
 # Not used directly, but required by resolver 2.0 to ensure that the k8s-openapi dependency
 # is considered part of the "deps" graph rather than just the "dev-deps" graph
 [dependencies.k8s-openapi]
-version = "0.13.1"
+version = "0.14.0"
 default-features = false
 
 [dev-dependencies]
@@ -57,6 +57,6 @@ serde = { version = "1.0.130", features = ["derive"] }
 schemars = "0.8.6"
 
 [dev-dependencies.k8s-openapi]
-version = "0.13.1"
+version = "0.14.0"
 default-features = false
 features = ["v1_22"]


### PR DESCRIPTION
removing instructions on default features since they are all turned off by default.

https://github.com/Arnavion/k8s-openapi/releases/tag/v0.14.0
