### PR TITLE
Disable unused default features of chrono crate

### DIFF
--- a/kube-client/Cargo.toml
+++ b/kube-client/Cargo.toml
@@ -39,7 +39,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 base64 = { version = "0.13.0", optional = true }
-chrono = { version = "0.4.19", optional = true }
+chrono = { version = "0.4.19", optional = true, default-features = false }
 dirs = { package = "dirs-next", optional = true, version = "2.0.0" }
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.68"

--- a/kube-core/Cargo.toml
+++ b/kube-core/Cargo.toml
@@ -31,7 +31,7 @@ form_urlencoded = "1.0.1"
 http = "0.2.5"
 json-patch = { version = "0.2.6", optional = true }
 once_cell = "1.8.0"
-chrono = "0.4.19"
+chrono = { version = "0.4.19", default-features = false, features = ["clock"] }
 schemars = { version = "0.8.6", optional = true }
 
 [dependencies.k8s-openapi]

--- a/kube-derive/Cargo.toml
+++ b/kube-derive/Cargo.toml
@@ -29,5 +29,5 @@ kube = { path = "../kube", default-features = false, version = "<1.0.0, >=0.61.0
 k8s-openapi = { version = "0.14.0", default-features = false, features = ["v1_22"] }
 schemars = { version = "0.8.6", features = ["chrono"] }
 validator = { version = "0.14.0", features = ["derive"] }
-chrono = "0.4.19"
+chrono = { version = "0.4.19", default-features = false }
 trybuild = "1.0.48"


### PR DESCRIPTION
Chrono crate has some default features that are not used by kube-rs;
by disabling them we can avoid pulling in time crate as dependency thus
trimming the dependency tree for all users and potentially speeding up
compilation time.

Signed-off-by: Patryk Obara <dreamer.tan@gmail.com>

<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation

In the project I'm working on we want to get rid of unused `time` dependency. This dependency is almost always pulled-in via `chrono` crate (by optional default feature `oldtime`), but rarely anyone is using it. Almost all our dependencies already disable the default features on `chrono` - but `kube-rs` is the only exception I found so far. Turns out you don't use `oldtime` feature either.

## Solution

Simply disable the default features :)