### PR TITLE
Add support for EC private keys

### DIFF
--- a/kube-client/Cargo.toml
+++ b/kube-client/Cargo.toml
@@ -53,7 +53,7 @@ pem = { version = "1.0.1", optional = true }
 openssl = { version = "0.10.36", optional = true }
 tokio-native-tls = { version = "0.3.0", optional = true }
 rustls = { version = "0.20.1", features = ["dangerous_configuration"], optional = true }
-rustls-pemfile = { version = "0.2.1", optional = true }
+rustls-pemfile = { version = "0.3.0", optional = true }
 bytes = { version = "1.1.0", optional = true }
 tokio = { version = "1.14.0", features = ["time", "signal", "sync"], optional = true }
 kube-core = { path = "../kube-core", version = "^0.68.0"}

--- a/kube-client/Cargo.toml
+++ b/kube-client/Cargo.toml
@@ -52,7 +52,7 @@ futures = { version = "0.3.17", optional = true }
 pem = { version = "1.0.1", optional = true }
 openssl = { version = "0.10.36", optional = true }
 tokio-native-tls = { version = "0.3.0", optional = true }
-rustls = { version = "0.20.1", features = ["dangerous_configuration"], optional = true }
+rustls = { version = "0.20.3", features = ["dangerous_configuration"], optional = true }
 rustls-pemfile = { version = "0.3.0", optional = true }
 bytes = { version = "1.1.0", optional = true }
 tokio = { version = "1.14.0", features = ["time", "signal", "sync"], optional = true }


### PR DESCRIPTION
## Motivation

Allows to use kube-rs with e.g. k3s and k3d default installs that use the Sec1 private keys.

## Solution

This depends on
- [x] https://github.com/rustls/pemfile/pull/5
- [x] https://github.com/rustls/rustls/pull/998
- [x] waiting for the rustls release to catch up