### PR TITLE
Implement `Api::try_get`

### DIFF
--- a/kube-client/src/api/core_methods.rs
+++ b/kube-client/src/api/core_methods.rs
@@ -4,7 +4,7 @@ use serde::{de::DeserializeOwned, Serialize};
 use std::fmt::Debug;
 
 use crate::{api::Api, Error, Result};
-use kube_core::{object::ObjectList, params::*, response::Status, WatchEvent};
+use kube_core::{object::ObjectList, params::*, response::Status, ErrorResponse, WatchEvent};
 
 /// PUSH/PUT/POST/GET abstractions
 impl<K> Api<K>
@@ -28,6 +28,31 @@ where
         let mut req = self.request.get(name).map_err(Error::BuildRequest)?;
         req.extensions_mut().insert("get");
         self.client.request::<K>(req).await
+    }
+
+    /// [Get](`Api::get`) a named resource if it exists, returns [`None`] if it doesn't exist
+    ///
+    /// ```no_run
+    /// use kube::{Api, Client};
+    /// use k8s_openapi::api::core::v1::Pod;
+    /// #[tokio::main]
+    /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    ///     let client = Client::try_default().await?;
+    ///     let pods: Api<Pod> = Api::namespaced(client, "apps");
+    ///     if let Some(pod) = pods.try_get("blog").await? {
+    ///         // Pod was found
+    ///     } else {
+    ///         // Pod was not found
+    ///     }
+    ///     Ok(())
+    /// }
+    /// ```
+    pub async fn try_get(&self, name: &str) -> Result<Option<K>> {
+        match self.get(name).await {
+            Ok(obj) => Ok(Some(obj)),
+            Err(Error::Api(ErrorResponse { reason, .. })) if &reason == "NotFound" => Ok(None),
+            Err(err) => Err(err),
+        }
     }
 
     /// Get a list of resources

--- a/kube/src/lib.rs
+++ b/kube/src/lib.rs
@@ -224,7 +224,10 @@ mod test {
         assert_eq!(a1.resource_url(), a2.resource_url());
     }
 
-    use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::CustomResourceDefinition;
+    use k8s_openapi::{
+        api::core::v1::ConfigMap,
+        apiextensions_apiserver::pkg::apis::apiextensions::v1::CustomResourceDefinition,
+    };
     #[tokio::test]
     #[ignore] // needs cluster (creates + patches foo crd)
     #[cfg(all(feature = "derive", feature = "runtime"))]
@@ -495,6 +498,18 @@ mod test {
         // verify it is properly gone
         assert!(pods.get("busybox-kube4").await.is_err());
 
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[ignore] // needs cluster (lists cms)
+    async fn api_try_get_handles_404() -> Result<(), Box<dyn std::error::Error>> {
+        let client = Client::try_default().await?;
+        let api = Api::<ConfigMap>::default_namespaced(client);
+        assert_eq!(
+            api.try_get("this-cm-does-not-exist-ajklisdhfqkljwhreq").await?,
+            None
+        );
         Ok(())
     }
 }


### PR DESCRIPTION
## Motivation

Fixes https://github.com/kube-rs/kube-rs/issues/806

## Solution

Adds a new method `Api::try_get`, as described in #806 (called `get_opt` there).

I think an `Entry` API is still worthwhile, but that still requires this as groundwork.