### PR TITLE
Fix small typo in Client::try_default doc comment

### DIFF
--- a/kube-client/src/client/mod.rs
+++ b/kube-client/src/client/mod.rs
@@ -117,7 +117,7 @@ impl Client {
     /// Create and initialize a [`Client`] using the inferred
     /// configuration.
     ///
-    /// Will use [`Config::infer`] to try in-cluster enironment
+    /// Will use [`Config::infer`] to try in-cluster environment
     /// variables first, then fallback to the local kubeconfig.
     ///
     /// Will fail if neither configuration could be loaded.


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem you're trying to solve?
If a new feature is being added, describe the intended use case that feature fulfills.
-->

Fixes a minor typo in the documentation comment for `Client::try_default`

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand the code change.
-->

Fixes a small typo of misspelled environment in Client::try_default doc
comment.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>