### PR TITLE
Add conversion for `ObjectRef<K>` to `ObjectReference`

### DIFF
--- a/kube-runtime/src/controller/mod.rs
+++ b/kube-runtime/src/controller/mod.rs
@@ -118,7 +118,7 @@ where
             .map(move |owner_ref| ReconcileRequest {
                 obj_ref: owner_ref,
                 reason: ReconcileReason::RelatedObjectUpdated {
-                    obj_ref: child_ref.clone(),
+                    obj_ref: Box::new(child_ref.clone()),
                 },
             })
     })
@@ -185,7 +185,7 @@ impl<K: Resource> From<ObjectRef<K>> for ReconcileRequest<K> {
 pub enum ReconcileReason {
     Unknown,
     ObjectUpdated,
-    RelatedObjectUpdated { obj_ref: ObjectRef<DynamicObject> },
+    RelatedObjectUpdated { obj_ref: Box<ObjectRef<DynamicObject>> },
     ReconcilerRequestedRetry,
     ErrorPolicyRequestedRetry,
     BulkReconcile,
@@ -577,7 +577,7 @@ where
                 .map(move |mapped_obj_ref| ReconcileRequest {
                     obj_ref: mapped_obj_ref,
                     reason: ReconcileReason::RelatedObjectUpdated {
-                        obj_ref: watched_obj_ref.clone(),
+                        obj_ref: Box::new(watched_obj_ref.clone()),
                     },
                 })
         });

--- a/kube-runtime/src/reflector/mod.rs
+++ b/kube-runtime/src/reflector/mod.rs
@@ -3,7 +3,7 @@
 mod object_ref;
 pub mod store;
 
-pub use self::object_ref::ObjectRef;
+pub use self::object_ref::{Extra as ObjectRefExtra, ObjectRef};
 use crate::watcher;
 use futures::{Stream, TryStreamExt};
 use kube_client::Resource;

--- a/kube-runtime/src/reflector/object_ref.rs
+++ b/kube-runtime/src/reflector/object_ref.rs
@@ -56,10 +56,15 @@ pub struct ObjectRef<K: Resource> {
     pub extra: Extra,
 }
 
+/// Non-vital information about an object being referred to
+///
+/// See [`ObjectRef::extra`].
 #[derive(Default, Debug, Clone)]
 #[non_exhaustive]
 pub struct Extra {
+    /// The version of the resource at the time of reference
     pub resource_version: Option<String>,
+    /// The uid of the object
     pub uid: Option<String>,
 }
 

--- a/kube-runtime/src/reflector/object_ref.rs
+++ b/kube-runtime/src/reflector/object_ref.rs
@@ -142,27 +142,6 @@ impl<K: Resource> ObjectRef<K> {
         }
     }
 
-    pub fn into_object_reference(self) -> ObjectReference {
-        let Self {
-            dyntype: dt,
-            name,
-            namespace,
-            extra: Extra {
-                resource_version,
-                uid,
-            },
-        } = self;
-        ObjectReference {
-            api_version: Some(K::api_version(&dt).into_owned()),
-            kind: Some(K::kind(&dt).into_owned()),
-            field_path: None,
-            name,
-            namespace,
-            resource_version,
-            uid,
-        }
-    }
-
     /// Convert into a reference to `K2`
     ///
     /// Note that no checking is done on whether this conversion makes sense. For example, every `Service`
@@ -183,6 +162,29 @@ impl<K: Resource> ObjectRef<K> {
             name: self.name,
             namespace: self.namespace,
             extra: self.extra,
+        }
+    }
+}
+
+impl<K: Resource> From<ObjectRef<K>> for ObjectReference {
+    fn from(val: ObjectRef<K>) -> Self {
+        let ObjectRef {
+            dyntype: dt,
+            name,
+            namespace,
+            extra: Extra {
+                resource_version,
+                uid,
+            },
+        } = val;
+        ObjectReference {
+            api_version: Some(K::api_version(&dt).into_owned()),
+            kind: Some(K::kind(&dt).into_owned()),
+            field_path: None,
+            name,
+            namespace,
+            resource_version,
+            uid,
         }
     }
 }


### PR DESCRIPTION
This covers step 1 and 2 of #812, allowing `ObjectRef` objects to be used for emitting events to a `Recorder`.

It does _not_ change the `Recorder` interface (yet), since we don't have a cheap way to convert an `ObjectReference` into an `ObjectRef<DynamicObject>` (since `ApiResource` requires knowing the pluralized resource name).