### PR TITLE
Fix cargo-deny blocking on duplicate dependencies in examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,10 @@ coverage:
 	cargo tarpaulin --out=Html --output-dir=.
 	#xdg-open tarpaulin-report.html
 
+deny:
+	# might require rm Cargo.lock first to match CI
+	cargo deny --workspace --all-features check licenses sources
+
 readme:
 	rustdoc README.md --test --edition=2021
 

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ coverage:
 
 deny:
 	# might require rm Cargo.lock first to match CI
-	cargo deny --workspace --all-features check licenses sources
+	cargo deny --workspace --all-features check bans licenses sources
 
 readme:
 	rustdoc README.md --test --edition=2021

--- a/deny.toml
+++ b/deny.toml
@@ -1,3 +1,8 @@
+# examples sometimes lag behind as they use higher level dependencies
+# we exclude these from the check because they are not part of our
+# actual dependency tree
+exclude = ["kube-examples"]
+
 [advisories]
 db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
@@ -63,12 +68,4 @@ allow-git = []
 
 [bans]
 multiple-versions = "deny"
-skip = [
-    # warp uses an older version of rustls (warp is only used in the examples)
-    { name = "rustls", version = "=0.19.1" },
-    { name = "webpki", version = "=0.21.4" },
-    { name = "tokio-rustls", version = "=0.22.0" },
-    { name = "sct", version = "=0.6.1" },
-    # http has not released a version using itoa v1
-    { name = "itoa", version = "^0.4" },
-]
+skip = []


### PR DESCRIPTION
caused a deny failure elsewhere

EDIT: tired of fixing this the laborious way. just ignoring cross-dependencies between examples in workspace now.