### PR TITLE
[0.69.x] Fix deadlock in token reloading

### DIFF
--- a/kube-client/src/client/auth/mod.rs
+++ b/kube-client/src/client/auth/mod.rs
@@ -14,7 +14,7 @@ use jsonpath_lib::select as jsonpath_select;
 use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use tokio::sync::{Mutex, RwLock};
+use tokio::sync::Mutex;
 use tower::{filter::AsyncPredicate, BoxError};
 
 use crate::config::{AuthInfo, AuthProviderConfig, ExecConfig};
@@ -148,7 +148,7 @@ impl TokenFile {
 #[derive(Debug, Clone)]
 pub enum RefreshableToken {
     Exec(Arc<Mutex<(SecretString, DateTime<Utc>, AuthInfo)>>),
-    File(Arc<RwLock<TokenFile>>),
+    File(Arc<Mutex<TokenFile>>),
     #[cfg(feature = "oauth")]
     GcpOauth(Arc<Mutex<oauth::Gcp>>),
 }
@@ -206,10 +206,11 @@ impl RefreshableToken {
             }
 
             RefreshableToken::File(token_file) => {
-                if let Some(token) = token_file.read().await.cached_token() {
+                let mut locked = token_file.lock().await;
+                if let Some(token) = locked.cached_token() {
                     bearer_header(token)
                 } else {
-                    bearer_header(token_file.write().await.token())
+                    bearer_header(locked.token())
                 }
             }
 
@@ -278,7 +279,7 @@ impl TryFrom<&AuthInfo> for Auth {
         // Token file reference. Must be reloaded at least once a minute.
         if let Some(file) = &auth_info.token_file {
             return Ok(Self::RefreshableToken(RefreshableToken::File(Arc::new(
-                RwLock::new(TokenFile::new(file)?),
+                Mutex::new(TokenFile::new(file)?),
             ))));
         }
 


### PR DESCRIPTION
Fix deadlock in token reloading

Backport of #830 (fixes #829) for the 0.69.x release track.