### PR TITLE
add hahaha/nais adopters

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -10,6 +10,7 @@
 - [kubeapps pinniped](https://github.com/kubeapps/kubeapps/tree/master/cmd/pinniped-proxy)
 - [kubectl-view-allocations](https://github.com/davidB/kubectl-view-allocations) - kubectl plugin to list resource allocations
 - [krator](https://github.com/krator-rs/krator) - kubernetes operators using state machines
+- [hahaha](https://github.com/nais/hahaha) - an operator that cleans up sidecars after Jobs
 
 ## Companies
 
@@ -22,5 +23,6 @@
 - [Qualified](https://www.qualified.io)
 - [TrueLayer](https://truelayer.com)
 - [ViacomCBS](https://viacomcbs.com)
+- [nais](https://nais.io)
 
 If you're using `kube-rs` in production and are not on this list, please [submit a pull request](https://github.com/kube-rs/kube-rs/edit/master/ADOPTERS.md)!


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation

The platform team over at the Norwegian Labour and Welfare administration has started using an operator ([hahaha](https://github.com/nais/hahaha)) to clean up after Jobs, and as such I thought it'd be fun to add ourselves to the ADOPTERS list. :)

## Solution

I've added both the operator repository in question under repos, and nais.io as an entry under companies.
