### PR TITLE
Token reloading with RwLock

### DIFF
--- a/kube-client/src/client/auth/mod.rs
+++ b/kube-client/src/client/auth/mod.rs
@@ -207,6 +207,7 @@ impl RefreshableToken {
 
             RefreshableToken::File(token_file) => {
                 if let Some(header) = {
+                    // Drop `RwLockReadGuard` before a write lock attempt to prevent deadlock.
                     let guard = token_file.read().await;
                     guard.cached_token().map(bearer_header)
                 } {

--- a/kube-client/src/client/auth/mod.rs
+++ b/kube-client/src/client/auth/mod.rs
@@ -206,7 +206,10 @@ impl RefreshableToken {
             }
 
             RefreshableToken::File(token_file) => {
-                if let Some(header) = { let guard = token_file.read().await; guard.cached_token().map(bearer_header) } {
+                if let Some(header) = {
+                    let guard = token_file.read().await;
+                    guard.cached_token().map(bearer_header)
+                } {
                     header
                 } else {
                     bearer_header(token_file.write().await.token())


### PR DESCRIPTION
The original implementation deadlocked (#829) because it was accidentally trying to lock for write while holding read lock, then attempting to read.
The guard not dropped before `else` was surprising, so here's a minimal demo showing when a temporary value is dropped: https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=401eaf29aecf31d4e2d434d005e1c24b

I've tested this fix with in-cluster `controller-rs` and it's been working fine, but please test it again. I'm assuming `RwLock` is more efficient than `Mutex` for this, but I haven't benchmarked. If we want to keep `Mutex`, we should remove `cached_token`.