### PR TITLE
Bump parking_lot to 0.12, but allow dep duplicates

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -76,3 +76,18 @@ multiple-versions = "deny"
 # https://github.com/tower-rs/tower-http/pull/221
 name = "tokio-util"
 version = "0.6"
+
+[[bans.skip]]
+# The following dependencies are still working on upgrading to 0.3
+# https://github.com/rustls/hyper-rustls/pull/165
+name = "rustls-pemfile"
+version = "0.2"
+
+# The following dependencies are still working on upgrading parking_lot
+# https://github.com/sfackler/hyper-openssl/pull/31
+[[bans.skip]]
+name = "parking_lot"
+version = "0.11"
+[[bans.skip]]
+name = "parking_lot_core"
+version = "0.8"

--- a/kube-runtime/Cargo.toml
+++ b/kube-runtime/Cargo.toml
@@ -26,7 +26,7 @@ derivative = "2.1.1"
 serde = "1.0.130"
 smallvec = "1.7.0"
 ahash = "0.7"
-parking_lot = "0.11"
+parking_lot = "0.12.0"
 pin-project = "1.0.2"
 tokio = { version = "1.14.0", features = ["time"] }
 tokio-util = { version = "0.7.0", features = ["time"] }


### PR DESCRIPTION
have raised a pr for the hyper-openssl duplicate: https://github.com/sfackler/hyper-openssl/pull/31

whitelists duplicates of:
- old parking lot (0.12 and transitive core dep - duplicate in openssl case)
- pemfile 0.2 (for EC issue - duplicate in rustls case)

this replaces #799 and unblocks #804

NB: we already have dep-duplicates of parking_lot due to a pulled in tokio-utils 0.7 - this mostly just makes this explicit and moves us slightly more forward.