### PR TITLE
Fix schemas containing both properties and additionalProperties

### DIFF
--- a/kube-core/src/schema.rs
+++ b/kube-core/src/schema.rs
@@ -81,6 +81,8 @@ impl Visitor for StructuralSchemaRewriter {
                 }
             }
         }
+        // check for maps without with properties (i.e. flattnened maps)
+        // and allow these to persist dynamically
         if let Some(object) = &mut schema.object {
             if !object.properties.is_empty() {
                 if object.additional_properties.as_deref() == Some(&Schema::Bool(true)) {


### PR DESCRIPTION
Fixes https://github.com/kube-rs/kube-rs/issues/844 with a second rewrite rule in `StructuralSchemaRewriter`.

(Note: This doesn't work for `#[serde(flatten)] foo: serde_json::Value`. But I think that's the wrong thing to flatten anyway.)