### PR TITLE
Fix event publishing for cluster scoped crds

### DIFF
--- a/kube-runtime/src/events.rs
+++ b/kube-runtime/src/events.rs
@@ -248,7 +248,7 @@ mod test {
     use super::{Event, EventType, Recorder};
 
     #[tokio::test]
-    // #[ignore] // needs cluster (creates a pointless event on the kubernetes main service)
+    #[ignore] // needs cluster (creates a pointless event on the kubernetes main service)
     async fn event_recorder_attaches_events() -> Result<(), Box<dyn std::error::Error>> {
         let client = Client::try_default().await?;
 
@@ -277,7 +277,7 @@ mod test {
     }
 
     #[tokio::test]
-    // #[ignore] // needs cluster (creates a pointless event on the kubernetes main service)
+    #[ignore] // needs cluster (creates a pointless event on the kubernetes main service)
     async fn event_recorder_attaches_events_without_namespace() -> Result<(), Box<dyn std::error::Error>> {
         let client = Client::try_default().await?;
 

--- a/kube-runtime/src/events.rs
+++ b/kube-runtime/src/events.rs
@@ -177,8 +177,7 @@ impl Recorder {
     #[must_use]
     pub fn new(client: Client, reporter: Reporter, reference: ObjectReference) -> Self {
         let default_namespace = "default".to_owned();
-        let events = Api::namespaced(client, reference.namespace.as_ref()
-            .unwrap_or_else(|| &default_namespace));
+        let events = Api::namespaced(client, reference.namespace.as_ref().unwrap_or(&default_namespace));
         Self {
             events,
             reporter,
@@ -241,8 +240,10 @@ impl Recorder {
 mod test {
     #![allow(unused_imports)]
 
-    use k8s_openapi::api::core::v1::{Event as CoreEvent, Service};
-    use k8s_openapi::api::rbac::v1::ClusterRole;
+    use k8s_openapi::api::{
+        core::v1::{Event as CoreEvent, Service},
+        rbac::v1::ClusterRole,
+    };
     use kube_client::{Api, Client, Resource};
 
     use super::{Event, EventType, Recorder};
@@ -300,7 +301,10 @@ mod test {
             .into_iter()
             .find(|e| std::matches!(e.reason.as_deref(), Some("VeryCoolServiceNoNamespace")))
             .unwrap();
-        assert_eq!(found_event.message.unwrap(), "Sending kubernetes to detention without namespace");
+        assert_eq!(
+            found_event.message.unwrap(),
+            "Sending kubernetes to detention without namespace"
+        );
 
         Ok(())
     }

--- a/kube-runtime/src/events.rs
+++ b/kube-runtime/src/events.rs
@@ -173,7 +173,7 @@ impl Recorder {
     ///
     /// This is intended to be created at the start of your controller's reconcile fn.
     ///
-    /// Cluster scoped object reference defaults to "default" namespace.
+    /// Cluster scoped objects will publish events in the "default" namespace.
     #[must_use]
     pub fn new(client: Client, reporter: Reporter, reference: ObjectReference) -> Self {
         let default_namespace = "default".to_owned();

--- a/kube-runtime/src/events.rs
+++ b/kube-runtime/src/events.rs
@@ -175,13 +175,8 @@ impl Recorder {
     ///
     /// Cluster scoped object reference defaults to "default" namespace.
     #[must_use]
-    pub fn new(client: Client, reporter: Reporter, reference: ObjectReference, namespace_override: Option<&str>) -> Self {
-        let namespace = match namespace_override {
-            Some(namespace) => namespace,
-            None => match reference.namespace.as_ref() {
-                Some(namespace) => namespace,
-                None => "default",
-            }
+    pub fn new(client: Client, reporter: Reporter, reference: ObjectReference) -> Self {
+        let events = Api::namespaced(client, reference.namespace.as_ref().unwrap_or_else(|| "default");
         };
         let events = Api::namespaced(client, namespace);
         Self {

--- a/kube-runtime/src/events.rs
+++ b/kube-runtime/src/events.rs
@@ -176,9 +176,9 @@ impl Recorder {
     /// Cluster scoped object reference defaults to "default" namespace.
     #[must_use]
     pub fn new(client: Client, reporter: Reporter, reference: ObjectReference) -> Self {
-        let events = Api::namespaced(client, reference.namespace.as_ref().unwrap_or_else(|| "default");
-        };
-        let events = Api::namespaced(client, namespace);
+        let default_namespace = "default".to_owned();
+        let events = Api::namespaced(client, reference.namespace.as_ref()
+            .unwrap_or_else(|| &default_namespace));
         Self {
             events,
             reporter,
@@ -248,13 +248,13 @@ mod test {
     use super::{Event, EventType, Recorder};
 
     #[tokio::test]
-    #[ignore] // needs cluster (creates a pointless event on the kubernetes main service)
+    // #[ignore] // needs cluster (creates a pointless event on the kubernetes main service)
     async fn event_recorder_attaches_events() -> Result<(), Box<dyn std::error::Error>> {
         let client = Client::try_default().await?;
 
         let svcs: Api<Service> = Api::namespaced(client.clone(), "default");
         let s = svcs.get("kubernetes").await?; // always a kubernetes service in default
-        let recorder = Recorder::new(client.clone(), "kube".into(), s.object_ref(&()), None);
+        let recorder = Recorder::new(client.clone(), "kube".into(), s.object_ref(&()));
         recorder
             .publish(Event {
                 type_: EventType::Normal,
@@ -277,13 +277,13 @@ mod test {
     }
 
     #[tokio::test]
-    #[ignore] // needs cluster (creates a pointless event on the kubernetes main service)
+    // #[ignore] // needs cluster (creates a pointless event on the kubernetes main service)
     async fn event_recorder_attaches_events_without_namespace() -> Result<(), Box<dyn std::error::Error>> {
         let client = Client::try_default().await?;
 
         let svcs: Api<ClusterRole> = Api::all(client.clone());
         let s = svcs.get("system:basic-user").await?; // always get this default ClusterRole
-        let recorder = Recorder::new(client.clone(), "kube".into(), s.object_ref(&()), None);
+        let recorder = Recorder::new(client.clone(), "kube".into(), s.object_ref(&()));
         recorder
             .publish(Event {
                 type_: EventType::Normal,

--- a/kube-runtime/src/events.rs
+++ b/kube-runtime/src/events.rs
@@ -171,7 +171,7 @@ pub struct Recorder {
 impl Recorder {
     /// Create a new recorder that can publish events for one specific object
     ///
-    /// This is intended to be createad at the start of your controller's reconcile fn.
+    /// This is intended to be created at the start of your controller's reconcile fn.
     ///
     /// Cluster scoped object reference defaults to "default" namespace.
     #[must_use]

--- a/kube-runtime/src/watcher.rs
+++ b/kube-runtime/src/watcher.rs
@@ -109,22 +109,16 @@ async fn step_trampolined<K: Resource + Clone + DeserializeOwned + Debug + Send 
 ) -> (Option<Result<Event<K>>>, State<K>) {
     match state {
         State::Empty => match api.list(list_params).await {
-            Ok(list) => (
-                Some(Ok(Event::Restarted(list.items))),
-                State::InitListed {
-                    resource_version: list.metadata.resource_version.unwrap(),
-                },
-            ),
+            Ok(list) => (Some(Ok(Event::Restarted(list.items))), State::InitListed {
+                resource_version: list.metadata.resource_version.unwrap(),
+            }),
             Err(err) => (Some(Err(err).map_err(Error::InitialListFailed)), State::Empty),
         },
         State::InitListed { resource_version } => match api.watch(list_params, &resource_version).await {
-            Ok(stream) => (
-                None,
-                State::Watching {
-                    resource_version,
-                    stream: stream.boxed(),
-                },
-            ),
+            Ok(stream) => (None, State::Watching {
+                resource_version,
+                stream: stream.boxed(),
+            }),
             Err(err) => (
                 Some(Err(err).map_err(Error::WatchStartFailed)),
                 State::InitListed { resource_version },
@@ -136,31 +130,22 @@ async fn step_trampolined<K: Resource + Clone + DeserializeOwned + Debug + Send 
         } => match stream.next().await {
             Some(Ok(WatchEvent::Added(obj) | WatchEvent::Modified(obj))) => {
                 let resource_version = obj.resource_version().unwrap();
-                (
-                    Some(Ok(Event::Applied(obj))),
-                    State::Watching {
-                        resource_version,
-                        stream,
-                    },
-                )
+                (Some(Ok(Event::Applied(obj))), State::Watching {
+                    resource_version,
+                    stream,
+                })
             }
             Some(Ok(WatchEvent::Deleted(obj))) => {
                 let resource_version = obj.resource_version().unwrap();
-                (
-                    Some(Ok(Event::Deleted(obj))),
-                    State::Watching {
-                        resource_version,
-                        stream,
-                    },
-                )
-            }
-            Some(Ok(WatchEvent::Bookmark(bm))) => (
-                None,
-                State::Watching {
-                    resource_version: bm.metadata.resource_version,
+                (Some(Ok(Event::Deleted(obj))), State::Watching {
+                    resource_version,
                     stream,
-                },
-            ),
+                })
+            }
+            Some(Ok(WatchEvent::Bookmark(bm))) => (None, State::Watching {
+                resource_version: bm.metadata.resource_version,
+                stream,
+            }),
             Some(Ok(WatchEvent::Error(err))) => {
                 // HTTP GONE, means we have desynced and need to start over and re-list :(
                 let new_state = if err.code == 410 {
@@ -173,13 +158,10 @@ async fn step_trampolined<K: Resource + Clone + DeserializeOwned + Debug + Send 
                 };
                 (Some(Err(err).map_err(Error::WatchError)), new_state)
             }
-            Some(Err(err)) => (
-                Some(Err(err).map_err(Error::WatchFailed)),
-                State::Watching {
-                    resource_version,
-                    stream,
-                },
-            ),
+            Some(Err(err)) => (Some(Err(err).map_err(Error::WatchFailed)), State::Watching {
+                resource_version,
+                stream,
+            }),
             None => (None, State::InitListed { resource_version }),
         },
     }
@@ -272,13 +254,10 @@ pub fn watch_object<K: Resource + Clone + DeserializeOwned + Debug + Send + 'sta
     api: Api<K>,
     name: &str,
 ) -> impl Stream<Item = Result<Option<K>>> + Send {
-    watcher(
-        api,
-        ListParams {
-            field_selector: Some(format!("metadata.name={}", name)),
-            ..Default::default()
-        },
-    )
+    watcher(api, ListParams {
+        field_selector: Some(format!("metadata.name={}", name)),
+        ..Default::default()
+    })
     .map(|event| match event? {
         Event::Deleted(_) => Ok(None),
         // We're filtering by object name, so getting more than one object means that either:


### PR DESCRIPTION
* There is no api for publishing cluster scoped events
* It default to `default` namespace
* Added ability to override namespace on Recorder::new

## Motivation

We were getting `405` when trying to publish events for cluster scoped crds.

## Solution

As there seems to be no endpoint for cluster scoped events.
I have added default namespace `default` for cluster scoped crds and I have added way to override it for all the cases.

I am not sure about the `namespace_override` but it seems good enough as is, maybe needs better comment/renaming.

cc: @teozkr 
