### PR TITLE
Add helper for creating a controller owner_ref on Resource

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -82,3 +82,9 @@ version = "0.6"
 # https://github.com/rustls/hyper-rustls/pull/165
 name = "rustls-pemfile"
 version = "0.2"
+
+[[bans.skip]]
+# waiting for ahash/getrandom to bump wasi as we have two branches:
+# ahash -> getrandom -> wasi old
+# tokio -> mio -> wasi new
+name = "wasi"

--- a/examples/configmapgen_controller.rs
+++ b/examples/configmapgen_controller.rs
@@ -3,7 +3,7 @@ use anyhow::Result;
 use futures::StreamExt;
 use k8s_openapi::api::core::v1::ConfigMap;
 use kube::{
-    api::{Api, ListParams, Patch, PatchParams, Resource, ObjectMeta},
+    api::{Api, ListParams, ObjectMeta, Patch, PatchParams, Resource},
     runtime::controller::{Context, Controller, ReconcilerAction},
     Client, CustomResource,
 };

--- a/examples/configmapgen_controller.rs
+++ b/examples/configmapgen_controller.rs
@@ -1,12 +1,9 @@
 #[macro_use] extern crate log;
 use anyhow::Result;
 use futures::StreamExt;
-use k8s_openapi::{
-    api::core::v1::ConfigMap,
-    apimachinery::pkg::apis::meta::v1::{ObjectMeta, OwnerReference},
-};
+use k8s_openapi::api::core::v1::ConfigMap;
 use kube::{
-    api::{Api, ListParams, Patch, PatchParams, Resource},
+    api::{Api, ListParams, Patch, PatchParams, Resource, ObjectMeta},
     runtime::controller::{Context, Controller, ReconcilerAction},
     Client, CustomResource,
 };
@@ -31,18 +28,6 @@ struct ConfigMapGeneratorSpec {
     content: String,
 }
 
-fn object_to_owner_reference<K: Resource<DynamicType = ()>>(
-    meta: ObjectMeta,
-) -> Result<OwnerReference, Error> {
-    Ok(OwnerReference {
-        api_version: K::api_version(&()).to_string(),
-        kind: K::kind(&()).to_string(),
-        name: meta.name.ok_or(Error::MissingObjectKey(".metadata.name"))?,
-        uid: meta.uid.ok_or(Error::MissingObjectKey(".metadata.uid"))?,
-        ..OwnerReference::default()
-    })
-}
-
 /// Controller triggers this whenever our main object or our children changed
 async fn reconcile(
     generator: Arc<ConfigMapGenerator>,
@@ -56,13 +41,11 @@ async fn reconcile(
 
     let mut contents = BTreeMap::new();
     contents.insert("content".to_string(), generator.spec.content.clone());
+    let oref = generator.controller_owner_ref(&()).unwrap();
     let cm = ConfigMap {
         metadata: ObjectMeta {
             name: generator.metadata.name.clone(),
-            owner_references: Some(vec![OwnerReference {
-                controller: Some(true),
-                ..object_to_owner_reference::<ConfigMapGenerator>(generator.metadata.clone())?
-            }]),
+            owner_references: Some(vec![oref]),
             ..ObjectMeta::default()
         },
         data: Some(contents),

--- a/kube-core/src/resource.rs
+++ b/kube-core/src/resource.rs
@@ -82,6 +82,22 @@ pub trait Resource {
             ..Default::default()
         }
     }
+
+    /// Generates a controller owner reference pointing to this resource
+    ///
+    /// Note: this returns an `Option`, but for objects populated from the apiserver,
+    /// this Option can be safely unwrapped.
+    fn controller_owner_ref(&self, dt: &Self::DynamicType) -> Option<OwnerReference> {
+        let meta = self.meta();
+        Some(OwnerReference {
+            api_version: Self::api_version(dt).to_string(),
+            kind: Self::kind(dt).to_string(),
+            name: meta.name.clone()?,
+            uid: meta.uid.clone()?,
+            controller: Some(true),
+            ..OwnerReference::default()
+        })
+    }
 }
 
 /// Implement accessor trait for any ObjectMeta-using Kubernetes Resource


### PR DESCRIPTION
## Motivation

Controllers frequently have to create owned objects with owner references pointing back to the object we get passed to `reconcile`.

We would like a way to quickly populate the `OwnerReference` struct for this case to avoid having to hand-cook this in every controller.

## Solution

Grab the function in `configmapgen_controller` and add it as a `Resource::controller_owner_ref` impl.

It's possible we should put this elsewhere, am open to ideas, but we should have something like this.
