### PR TITLE
Change ReconcileAction to Action and add associated ctors

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -174,9 +174,9 @@ Once we have combined the stream of streams we essentially have a flattened supe
 1. new input events get sent to the `scheduler`
 2. scheduled events are then passed them through a `Runner` preventing duplicate parallel requests for the same object
 3. when running, we send the affected object to the users `reconciler` fn and await that future
-4. a) on success, prepare the users `ReconcilerAction` (generally a slow requeue several minutes from now)
-4. b) on failure, prepare a `ReconcilerAction` based on the users error policy (generally a backoff'd requeue with shorter initial delay)
-5. Map resulting `ReconcilerAction`s through an ad-hoc `scheduler` channel
+4. a) on success, prepare the users `Action` (generally a slow requeue several minutes from now)
+4. b) on failure, prepare a `Action` based on the users error policy (generally a backoff'd requeue with shorter initial delay)
+5. Map resulting `Action`s through an ad-hoc `scheduler` channel
 6. Resulting requeue requests through the channel are picked up at the top of `applier` and merged with input events in step 1.
 
 Ideally, the process runs forever, and it minimises unnecessary reconcile calls (like users changing more than one related object while one reconcile is already happening).

--- a/kube-client/src/api/entry.rs
+++ b/kube-client/src/api/entry.rs
@@ -8,7 +8,6 @@ use std::fmt::Debug;
 
 use kube_core::{params::PostParams, Resource};
 use serde::{de::DeserializeOwned, Serialize};
-
 use crate::{Api, Error, Result};
 
 impl<K: Resource + Clone + DeserializeOwned + Debug> Api<K> {
@@ -210,7 +209,7 @@ impl<'a, K> OccupiedEntry<'a, K> {
 
     /// Validate that [`Self::object`] is valid, and refers to the same object as the original [`Api::entry`] call
     ///
-    /// Defaults [`ObjectMeta::name`] and [`ObjectMeta::namespace`] if unset.
+    /// Defaults `ObjectMeta::name` and `ObjectMeta::namespace` if unset.
     fn prepare_for_commit(&mut self) -> Result<(), CommitValidationError>
     where
         K: Resource,
@@ -260,26 +259,26 @@ pub enum CommitError {
 #[derive(Debug, thiserror::Error)]
 /// Pre-commit validation errors
 pub enum CommitValidationError {
-    /// [`ObjectMeta::name`] does not match the name passed to [`Api::entry`]
+    /// `ObjectMeta::name` does not match the name passed to [`Api::entry`]
     #[error(".metadata.name does not match the name passed to Api::entry (got: {object_name:?}, expected: {expected:?})")]
     NameMismatch {
-        /// The name of the object ([`ObjectMeta::name`])
+        /// The name of the object (`ObjectMeta::name`)
         object_name: String,
         /// The name passed to [`Api::entry`]
         expected: String,
     },
-    /// [`ObjectMeta::namespace`] does not match the namespace of the [`Api`]
+    /// `ObjectMeta::namespace` does not match the namespace of the [`Api`]
     #[error(".metadata.namespace does not match the namespace of the Api (got: {object_namespace:?}, expected: {expected:?})")]
     NamespaceMismatch {
-        /// The name of the object ([`ObjectMeta::namespace`])
+        /// The name of the object (`ObjectMeta::namespace`)
         object_namespace: Option<String>,
         /// The namespace of the [`Api`]
         expected: Option<String>,
     },
-    /// [`ObjectMeta::generate_name`] must not be set
+    /// `ObjectMeta::generate_name` must not be set
     #[error(".metadata.generate_name must not be set (got: {object_generate_name:?})")]
     GenerateName {
-        /// The set name generation template of the object ([`ObjectMeta::generate_name`])
+        /// The set name generation template of the object (`ObjectMeta::generate_name`)
         object_generate_name: String,
     },
 }

--- a/kube-client/src/api/entry.rs
+++ b/kube-client/src/api/entry.rs
@@ -6,9 +6,9 @@
 #[allow(unused_imports)] use std::collections::HashMap;
 use std::fmt::Debug;
 
+use crate::{Api, Error, Result};
 use kube_core::{params::PostParams, Resource};
 use serde::{de::DeserializeOwned, Serialize};
-use crate::{Api, Error, Result};
 
 impl<K: Resource + Clone + DeserializeOwned + Debug> Api<K> {
     /// Gets a given object's "slot" on the Kubernetes API, designed for "get-or-create" and "get-and-modify" patterns

--- a/kube-runtime/src/controller/mod.rs
+++ b/kube-runtime/src/controller/mod.rs
@@ -64,6 +64,7 @@ impl Action {
     /// even in the case of missed changes (which can happen).
     ///
     /// Watch events are not normally missed, so running this once per hour (`Default`) as a fallback is reasonable.
+    #[must_use]
     pub fn requeue(duration: Duration) -> Self {
         Self {
             requeue_after: Some(duration),
@@ -78,6 +79,7 @@ impl Action {
     /// **Warning**: If you have watch desyncs, it is possible to miss changes entirely.
     /// It is therefore not recommended to disable requeuing this way, unless you have
     /// frequent changes to the underlying object, or some other hook to retain eventual consistency.
+    #[must_use]
     pub fn await_change() -> Self {
         Self { requeue_after: None }
     }

--- a/kube-runtime/src/controller/mod.rs
+++ b/kube-runtime/src/controller/mod.rs
@@ -85,12 +85,6 @@ impl Action {
     }
 }
 
-impl Default for Action {
-    fn default() -> Self {
-        Action::requeue(Duration::from_secs(3600))
-    }
-}
-
 /// Helper for building custom trigger filters, see the implementations of [`trigger_self`] and [`trigger_owners`] for some examples.
 pub fn trigger_with<T, K, I, S>(
     stream: S,

--- a/kube-runtime/src/controller/mod.rs
+++ b/kube-runtime/src/controller/mod.rs
@@ -385,15 +385,11 @@ where
 /// async fn reconcile(g: Arc<ConfigMapGenerator>, _ctx: Context<()>) -> Result<Action, Error> {
 ///     // .. use api here to reconcile a child ConfigMap with ownerreferences
 ///     // see configmapgen_controller example for full info
-///     Ok(Action {
-///         requeue: Some(Duration::from_secs(300)),
-///     })
+///     Ok(Action::requeue(Duration::from_secs(300)))
 /// }
 /// /// an error handler that will be called when the reconciler fails
 /// fn error_policy(_error: &Error, _ctx: Context<()>) -> Action {
-///     Action {
-///         requeue: Some(Duration::from_secs(60)),
-///     }
+///     Action::requeue(Duration::from_secs(60))
 /// }
 ///
 /// /// something to drive the controller
@@ -647,7 +643,7 @@ where
     /// .run(
     ///     |o, _| async move {
     ///         println!("Reconciling {}", o.name());
-    ///         Ok(Action { requeue: None })
+    ///         Ok(Action::await_change())
     ///     },
     ///     |err: &Infallible, _| Err(err).unwrap(),
     ///     Context::new(()),
@@ -702,7 +698,7 @@ where
     /// .run(
     ///     |o, _| async move {
     ///         println!("Reconciling {}", o.name());
-    ///         Ok(Action { requeue: None })
+    ///         Ok(Action::await_change())
     ///     },
     ///     |err: &Infallible, _| Err(err).unwrap(),
     ///     Context::new(()),


### PR DESCRIPTION
fixes #317

see https://github.com/kube-rs/kube-rs/issues/317#issuecomment-1070621137 for motivation.

leaves the original struct in place, but because we are renaming it, it might also make sense to make members private.