### PR TITLE
Fix invalid CRD when Enum variants have descriptions

### DIFF
--- a/kube-core/src/schema.rs
+++ b/kube-core/src/schema.rs
@@ -49,7 +49,7 @@ impl Visitor for StructuralSchemaRewriter {
                         if let Some(description) = std::mem::take(&mut variant_metadata.description) {
                             if let Some(Schema::Object(variant_object)) = only_item(variant_obj.properties.values_mut()) {
                                 let metadata = variant_object.metadata.get_or_insert_with(|| Box::new(Metadata::default()));
-                                metadata.description = Some(description.to_string());
+                                metadata.description = Some(description);
                             }
                         }
                     }

--- a/kube-core/src/schema.rs
+++ b/kube-core/src/schema.rs
@@ -123,19 +123,8 @@ impl Visitor for StructuralSchemaRewriter {
                             if let Some(Schema::Object(variant_object)) =
                                 variant_obj.properties.values_mut().next()
                             {
-                                match variant_object {
-                                    SchemaObject {
-                                        metadata: Some(metadata),
-                                        ..
-                                    } => {
-                                        metadata.description = Some(description.to_string());
-                                    }
-                                    _ => {
-                                        let mut metadata = Metadata::default();
-                                        metadata.description = Some(description.to_string());
-                                        variant_object.metadata = Some(Box::new(metadata));
-                                    }
-                                };
+                                let metadata = variant_object.metadata.get_or_insert_with(|| Box::new(Metadata::default()));
+                                metadata.description = Some(description.to_string());
                             }
                         }
                     }

--- a/kube-core/src/schema.rs
+++ b/kube-core/src/schema.rs
@@ -7,9 +7,8 @@ use std::collections::btree_map::Entry;
 // Used in docs
 #[allow(unused_imports)] use schemars::gen::SchemaSettings;
 
-use schemars::schema::Metadata;
 use schemars::{
-    schema::{ObjectValidation, Schema, SchemaObject},
+    schema::{Metadata, ObjectValidation, Schema, SchemaObject},
     visit::Visitor,
 };
 
@@ -47,8 +46,12 @@ impl Visitor for StructuralSchemaRewriter {
                     if let Some(variant_metadata) = variant_metadata {
                         // Move enum variant description from oneOf clause to its corresponding property
                         if let Some(description) = std::mem::take(&mut variant_metadata.description) {
-                            if let Some(Schema::Object(variant_object)) = only_item(variant_obj.properties.values_mut()) {
-                                let metadata = variant_object.metadata.get_or_insert_with(|| Box::new(Metadata::default()));
+                            if let Some(Schema::Object(variant_object)) =
+                                only_item(variant_obj.properties.values_mut())
+                            {
+                                let metadata = variant_object
+                                    .metadata
+                                    .get_or_insert_with(|| Box::new(Metadata::default()));
                                 metadata.description = Some(description);
                             }
                         }

--- a/kube-core/src/schema.rs
+++ b/kube-core/src/schema.rs
@@ -118,8 +118,8 @@ impl Visitor for StructuralSchemaRewriter {
                     ..
                 }) = variant
                 {
-                    if variant_obj.properties.len() == 1 {
-                        if let Some(description) = std::mem::take(&mut variant_metadata.description) {
+                    if let Some(description) = std::mem::take(&mut variant_metadata.description) {
+                        if variant_obj.properties.len() == 1 {
                             if let Some(Schema::Object(variant_object)) =
                                 variant_obj.properties.values_mut().next()
                             {

--- a/kube-derive/tests/crd_schema_test.rs
+++ b/kube-derive/tests/crd_schema_test.rs
@@ -37,6 +37,7 @@ struct FooSpec {
     // Using feature `chrono`
     timestamp: DateTime<Utc>,
 
+    /// This is a complex enum
     complex_enum: ComplexEnum,
 }
 
@@ -51,8 +52,12 @@ fn default_nullable() -> Option<String> {
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 enum ComplexEnum {
+    /// First variant with an int
     VariantOne { int: i32 },
+    /// Second variant with an String
     VariantTwo { str: String },
+    /// Third variant which doesn't has an attribute
+    VariantThree {}
 }
 
 #[test]
@@ -177,7 +182,8 @@ fn test_crd_schema_matches_expected() {
                                                                 "format": "int32"
                                                             }
                                                         },
-                                                        "required": ["int"]
+                                                        "required": ["int"],
+                                                        "description": "First variant with an int"
                                                     },
                                                     "variantTwo": {
                                                         "type": "object",
@@ -186,7 +192,12 @@ fn test_crd_schema_matches_expected() {
                                                                 "type": "string"
                                                             }
                                                         },
-                                                        "required": ["str"]
+                                                        "required": ["str"],
+                                                        "description": "Second variant with an String"
+                                                    },
+                                                    "variantThree": {
+                                                        "type": "object",
+                                                        "description": "Third variant which doesn't has an attribute"
                                                     }
                                                 },
                                                 "oneOf": [
@@ -195,8 +206,12 @@ fn test_crd_schema_matches_expected() {
                                                     },
                                                     {
                                                         "required": ["variantTwo"]
+                                                    },
+                                                    {
+                                                        "required": ["variantThree"]
                                                     }
-                                                ]
+                                                ],
+                                                "description": "This is a complex enum"
                                             }
                                         },
                                         "required": [

--- a/kube-derive/tests/crd_schema_test.rs
+++ b/kube-derive/tests/crd_schema_test.rs
@@ -57,7 +57,7 @@ enum ComplexEnum {
     /// Second variant with an String
     VariantTwo { str: String },
     /// Third variant which doesn't has an attribute
-    VariantThree {}
+    VariantThree {},
 }
 
 #[test]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation
I would like to document the different enum variants of my CRDs with Rust doc. By doing so a description attribute should be added to the CRD enum variants. Currently placing an description on an enum variant produces an invalid CRD.
<!--
Explain the context and why you're making that change. What is the problem you're trying to solve?
If a new feature is being added, describe the intended use case that feature fulfills.
-->

## Solution
This PR fixes the problem by moving the description attribute to the correct location inside the CRD schema.
Details can be found in the code comments.
<!--
Summarize the solution and provide any necessary context needed to understand the code change.
-->
Signed-off-by: Sebastian Bernauer <sebastian.bernauer@stackable.de>