### PR TITLE
portforward: Improve API and support background task cancelation

### DIFF
--- a/examples/pod_portforward.rs
+++ b/examples/pod_portforward.rs
@@ -37,8 +37,7 @@ async fn main() -> anyhow::Result<()> {
     let _ = tokio::time::timeout(std::time::Duration::from_secs(15), running).await?;
 
     let mut pf = pods.portforward("example", &[80]).await?;
-    let ports = pf.ports();
-    let mut port = ports[0].stream().unwrap();
+    let mut port = pf.take_stream(80).unwrap();
     port.write_all(b"GET / HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\nAccept: */*\r\n\r\n")
         .await?;
     let mut rstream = tokio_util::io::ReaderStream::new(port);

--- a/examples/pod_portforward_bind.rs
+++ b/examples/pod_portforward_bind.rs
@@ -47,7 +47,7 @@ async fn main() -> anyhow::Result<()> {
     // Get `Portforwarder` that handles the WebSocket connection.
     // There's no need to spawn a task to drive this, but it can be awaited to be notified on error.
     let mut forwarder = pods.portforward("example", &[80]).await?;
-    let port = forwarder.ports()[0].stream().unwrap();
+    let port = forwarder.take_stream(80).unwrap();
 
     // let hyper drive the HTTP state in our DuplexStream via a task
     let (sender, connection) = hyper::client::conn::handshake(port).await?;
@@ -59,7 +59,7 @@ async fn main() -> anyhow::Result<()> {
     // The following task is only used to show any error from the forwarder.
     // This example can be stopped with Ctrl-C if anything happens.
     tokio::spawn(async move {
-        if let Err(e) = forwarder.await {
+        if let Err(e) = forwarder.join().await {
             log::error!("forwarder errored: {}", e);
         }
     });

--- a/examples/pod_portforward_hyper_http.rs
+++ b/examples/pod_portforward_hyper_http.rs
@@ -36,8 +36,7 @@ async fn main() -> anyhow::Result<()> {
     let _ = tokio::time::timeout(std::time::Duration::from_secs(15), running).await?;
 
     let mut pf = pods.portforward("example", &[80]).await?;
-    let ports = pf.ports();
-    let port = ports[0].stream().unwrap();
+    let port = pf.take_stream(80).unwrap();
 
     // let hyper drive the HTTP state in our DuplexStream via a task
     let (mut sender, connection) = hyper::client::conn::handshake(port).await?;

--- a/kube-client/src/api/portforward.rs
+++ b/kube-client/src/api/portforward.rs
@@ -59,7 +59,7 @@ pub enum Error {
     ReceiveWebSocketMessage(#[source] ws::Error),
 
     #[error("failed to complete the background task: {0}")]
-    Spawn(#[from] tokio::task::JoinError),
+    Spawn(#[source] tokio::task::JoinError),
 }
 
 type ErrorReceiver = oneshot::Receiver<String>;
@@ -139,7 +139,7 @@ impl Portforwarder {
 
     /// Waits for port forwarding task to complete.
     pub async fn join(self) -> Result<(), Error> {
-        self.task.await.unwrap_or_else(|e| Err(e.into()))
+        self.task.await.unwrap_or_else(|e| Err(Error::Spawn(e)))
     }
 }
 


### PR DESCRIPTION
The portforward utility spawns a background task and returns a future
that completes when the background task completes, but the spawned
task's `JoinHandle` is discarded, so there's no way to cancel the
background tasks before all of the port forwards complete.

This change updates the `Portforwarder` type to hold the `JoinHandle`
and exposes a `Portforward::abort` method that cancels the spawned task.
`impl Future for Portforward` changes to await the background task's
completion. A portforward::Error variant is added to expose task
failures.