### PR TITLE
Make remote commands cancellable and remove panics

### DIFF
--- a/examples/pod_attach.rs
+++ b/examples/pod_attach.rs
@@ -92,8 +92,7 @@ async fn separate_outputs(mut attached: AttachedProcess) {
     });
 
     join!(stdouts, stderrs);
-
-    if let Some(status) = attached.await {
+    if let Some(status) = attached.take_status().unwrap().await {
         println!("{:?}", status);
     }
 }
@@ -109,8 +108,7 @@ async fn combined_output(mut attached: AttachedProcess) {
         }
     });
     outputs.await;
-
-    if let Some(status) = attached.await {
+    if let Some(status) = attached.take_status().unwrap().await {
         println!("{:?}", status);
     }
 }

--- a/examples/pod_exec.rs
+++ b/examples/pod_exec.rs
@@ -95,10 +95,11 @@ async fn main() -> anyhow::Result<()> {
         println!("{}", stdout);
         assert_eq!(stdout, "test string 1\n");
 
-        // AttachedProcess resolves with status object.
+        // AttachedProcess provides access to a future that resolves with a status object.
+        let status = attached.take_status().unwrap();
         // Send `exit 1` to get a failure status.
         stdin_writer.write(b"exit 1\n").await?;
-        if let Some(status) = attached.await {
+        if let Some(status) = status.await {
             println!("{:?}", status);
             assert_eq!(status.status, Some("Failure".to_owned()));
             assert_eq!(status.reason, Some("NonZeroExitCode".to_owned()));
@@ -122,6 +123,6 @@ async fn get_output(mut attached: AttachedProcess) -> String {
         .collect::<Vec<_>>()
         .await
         .join("");
-    attached.await;
+    attached.join().await.unwrap();
     out
 }

--- a/examples/pod_shell.rs
+++ b/examples/pod_shell.rs
@@ -73,7 +73,7 @@ async fn main() -> anyhow::Result<()> {
         tokio::io::copy(&mut stdout_reader, &mut stdout).await.unwrap();
     });
     // When done, type `exit\n` to end it, so the pod is deleted.
-    let status = attached.await;
+    let status = attached.take_status().unwrap().await;
     println!("{:?}", status);
 
     // Delete it

--- a/kube-client/src/lib.rs
+++ b/kube-client/src/lib.rs
@@ -336,7 +336,7 @@ mod test {
                 .collect::<Vec<_>>()
                 .await
                 .join("");
-            attached.await;
+            attached.join().await.unwrap();
             assert_eq!(out.lines().count(), 3);
             assert_eq!(out, "1\n2\n3\n");
         }
@@ -362,7 +362,8 @@ mod test {
             // AttachedProcess resolves with status object.
             // Send `exit 1` to get a failure status.
             stdin_writer.write(b"exit 1\n").await?;
-            if let Some(status) = attached.await {
+            let status = attached.take_status().unwrap();
+            if let Some(status) = status.await {
                 println!("{:?}", status);
                 assert_eq!(status.status, Some("Failure".to_owned()));
                 assert_eq!(status.reason, Some("NonZeroExitCode".to_owned()));


### PR DESCRIPTION
Make remote commands (`attach`, `exec`) cancellable like portforward (#854). Also add `Error` and remove panics.