### PR TITLE
Change the default TLS to OpenSSL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
       - name: install openssl
         if: matrix.os == 'windows-latest'
         run: |
+          $ErrorActionPreference = "Stop"
           choco install --verbose openssl
           openssl version
           refreshenv
@@ -62,10 +63,10 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
       # Feature tests in examples
       - name: Test crd_derive_no_schema example
-        run: cargo test -p kube-examples --example crd_derive_no_schema --no-default-features --features=native-tls,latest
+        run: cargo test -p kube-examples --example crd_derive_no_schema --no-default-features --features=openssl-tls,latest
         if: matrix.os == 'ubuntu-latest'
       - name: Test crd_api example with deprecated crd
-        run: cargo test -p kube-examples --example crd_api --no-default-features --features=deprecated,kubederive,native-tls
+        run: cargo test -p kube-examples --example crd_api --no-default-features --features=deprecated,kubederive,openssl-tls
         if: matrix.os == 'ubuntu-latest'
 
   check-msrv:

--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,9 @@ test:
 	cargo test -p kube-examples --examples
 	cargo test -p kube --lib --no-default-features --features=rustls-tls,ws,oauth
 	cargo test -p kube --lib --no-default-features --features=native-tls,ws,oauth
+	cargo test -p kube --lib --no-default-features --features=openssl-tls,ws,oauth
 	cargo test -p kube --lib --no-default-features
-	cargo test -p kube-examples --example crd_api --no-default-features --features=deprecated,kubederive,native-tls
+	cargo test -p kube-examples --example crd_api --no-default-features --features=deprecated,kubederive,openssl-tls
 
 test-integration:
 	kubectl delete pod -lapp=kube-rs-test

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -14,9 +14,9 @@ license = "Apache-2.0"
 release = false
 
 [features]
-default = ["native-tls", "kubederive", "ws", "latest", "runtime"]
+default = ["openssl-tls", "kubederive", "ws", "latest", "runtime"]
 kubederive = ["kube/derive"]
-native-tls = ["kube/client", "kube/native-tls"]
+openssl-tls = ["kube/client", "kube/openssl-tls"]
 rustls-tls = ["kube/client", "kube/rustls-tls"]
 runtime = ["kube/runtime"]
 ws = ["kube/ws"]
@@ -197,7 +197,7 @@ path = "custom_client.rs"
 [[example]]
 name = "custom_client_tls"
 path = "custom_client_tls.rs"
-required-features = ["native-tls", "rustls-tls"]
+required-features = ["openssl-tls", "rustls-tls"]
 
 [[example]]
 name = "custom_client_trace"

--- a/examples/README.md
+++ b/examples/README.md
@@ -41,7 +41,7 @@ How deriving `CustomResource` works in practice, and how it interacts with the [
 cargo run --example crd_api
 cargo run --example crd_derive
 cargo run --example crd_derive_schema
-cargo run --example crd_derive_no_schema --no-default-features --features=native-tls,latest
+cargo run --example crd_derive_no_schema --no-default-features --features=openssl-tls,latest
 ```
 
 The last one opts out from the default `schema` feature from `kube-derive` (and thus the need for you to derive/impl `JsonSchema`).
@@ -51,7 +51,7 @@ The last one opts out from the default `schema` feature from `kube-derive` (and 
 It is also possible to run the `crd_api` example against the legacy `v1beta1` CustomResourceDefinition endpoint. To do this you need to run the example with the `deprecated` feature and opt out of defaults:
 
 ```sh
-cargo run --example crd_api --no-default-features --features=deprecated,native-tls,kubederive
+cargo run --example crd_api --no-default-features --features=deprecated,openssl-tls,kubederive
 ```
 
 Note that these examples also contain tests for CI, and are invoked with the same parameters, but using `cargo test` rather than `cargo run`.

--- a/examples/custom_client.rs
+++ b/examples/custom_client.rs
@@ -9,7 +9,7 @@ async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt::init();
 
     let config = Config::infer().await?;
-    let https = config.native_tls_https_connector()?;
+    let https = config.openssl_https_connector()?;
     let service = tower::ServiceBuilder::new()
         .layer(config.base_uri_layer())
         .option_layer(config.auth_layer()?)

--- a/examples/custom_client_tls.rs
+++ b/examples/custom_client_tls.rs
@@ -22,7 +22,7 @@ async fn main() -> anyhow::Result<()> {
             .service(hyper::Client::builder().build(https));
         Client::new(service, config.default_namespace)
     } else {
-        let https = config.native_tls_https_connector()?;
+        let https = config.openssl_https_connector()?;
         let service = ServiceBuilder::new()
             .layer(config.base_uri_layer())
             .service(hyper::Client::builder().build(https));

--- a/examples/custom_client_trace.rs
+++ b/examples/custom_client_trace.rs
@@ -16,7 +16,7 @@ async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt::init();
 
     let config = Config::infer().await?;
-    let https = config.native_tls_https_connector()?;
+    let https = config.openssl_https_connector()?;
     let service = ServiceBuilder::new()
         .layer(config.base_uri_layer())
         // showcase rate limiting; max 10rps, and 4 concurrent

--- a/kube-client/Cargo.toml
+++ b/kube-client/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.56"
 edition = "2021"
 
 [features]
-default = ["client", "native-tls"]
+default = ["client", "openssl-tls"]
 native-tls = ["openssl", "hyper-tls", "tokio-native-tls"]
 rustls-tls = ["rustls", "rustls-pemfile", "hyper-rustls"]
 openssl-tls = ["openssl", "hyper-openssl"]

--- a/kube-client/src/lib.rs
+++ b/kube-client/src/lib.rs
@@ -174,6 +174,21 @@ mod test {
     }
 
     #[tokio::test]
+    #[ignore] // needs cluster (lists pods)
+    #[cfg(all(feature = "openssl-tls"))]
+    async fn custom_client_openssl_tls_configuration() -> Result<(), Box<dyn std::error::Error>> {
+        let config = Config::infer().await?;
+        let https = config.openssl_https_connector()?;
+        let service = ServiceBuilder::new()
+            .layer(config.base_uri_layer())
+            .service(hyper::Client::builder().build(https));
+        let client = Client::new(service, config.default_namespace);
+        let pods: Api<Pod> = Api::default_namespaced(client);
+        pods.list(&Default::default()).await?;
+        Ok(())
+    }
+
+    #[tokio::test]
     #[ignore] // needs cluster (lists api resources)
     #[cfg(all(feature = "discovery"))]
     async fn group_discovery_oneshot() -> Result<(), Box<dyn std::error::Error>> {


### PR DESCRIPTION
## Motivation

`native-tls` feature exists because `kube` used to depend on `reqwest`.

The feature doesn't make sense for us because all targets still depend on `openssl` anyway. This is because `native-tls` requires PKCS#12 to create `Identity` for authentication with client certificates, and `openssl` is the only trusted option to generate them.
A feature to create `Identity` from PKCS#8 was added a few days ago, but `openssl` is still necessary because we need to support more private key formats.

`native-tls` feature is currently broken on macOS because Security Framework cannot import PKCS#12 generated by OpenSSL v3 (#691). I'm sure more users will run into this, especially the new ones, so it's not a good default.

## Solution

Make OpenSSL the default because we can't make Rustls due to #153. I don't think there are any downsides?

We can also remove `native-tls` feature. `openssl` will continue to be required because I don't think the different key formats we need will be supported anytime soon.