### PR TITLE
Make dependency pins between sibling crates stricter

### DIFF
--- a/kube-client/Cargo.toml
+++ b/kube-client/Cargo.toml
@@ -56,7 +56,7 @@ rustls = { version = "0.20.3", features = ["dangerous_configuration"], optional 
 rustls-pemfile = { version = "0.3.0", optional = true }
 bytes = { version = "1.1.0", optional = true }
 tokio = { version = "1.14.0", features = ["time", "signal", "sync"], optional = true }
-kube-core = { path = "../kube-core", version = "^0.70.0" }
+kube-core = { path = "../kube-core", version = "=0.70.0" }
 jsonpath_lib = { version = "0.3.0", optional = true }
 tokio-util = { version = "0.7.0", optional = true, features = ["io", "codec"] }
 hyper = { version = "0.14.13", optional = true, features = ["client", "http1", "stream", "tcp"] }

--- a/kube-runtime/Cargo.toml
+++ b/kube-runtime/Cargo.toml
@@ -21,7 +21,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 futures = "0.3.17"
-kube-client = { path = "../kube-client", version = "^0.70.0", default-features = false, features = ["jsonpatch", "client"] }
+kube-client = { path = "../kube-client", version = "=0.70.0", default-features = false, features = ["jsonpatch", "client"] }
 derivative = "2.1.1"
 serde = "1.0.130"
 smallvec = "1.7.0"

--- a/kube/Cargo.toml
+++ b/kube/Cargo.toml
@@ -37,10 +37,10 @@ features = ["client", "native-tls", "rustls-tls", "openssl-tls", "derive", "ws",
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-kube-derive = { path = "../kube-derive", version = "^0.70.0", optional = true }
-kube-core = { path = "../kube-core", version = "^0.70.0" }
-kube-client = { path = "../kube-client", version = "^0.70.0", default-features = false, optional = true }
-kube-runtime = { path = "../kube-runtime", version = "^0.70.0", optional = true}
+kube-derive = { path = "../kube-derive", version = "=0.70.0", optional = true }
+kube-core = { path = "../kube-core", version = "=0.70.0" }
+kube-client = { path = "../kube-client", version = "=0.70.0", default-features = false, optional = true }
+kube-runtime = { path = "../kube-runtime", version = "=0.70.0", optional = true}
 
 # Not used directly, but required by resolver 2.0 to ensure that the k8s-openapi dependency
 # is considered part of the "deps" graph rather than just the "dev-deps" graph


### PR DESCRIPTION
Fix dependency pins between crates to be exact to fix people potentially not getting patch updates #833

```
kube v0.70.0 (/home/clux/kube/kube-rs/kube)
├── kube-client v0.70.0
│   └── kube-core v0.70.0
├── kube-core v0.70.0
├── kube-derive v0.70.0
└── kube-runtime v0.70.0
    └── kube-client v0.70.0
```