### PR TITLE
Allow merging multi-version CRDs into a single schema

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,6 @@
 
 	// These extensions are loaded for all users by default.
 	"extensions": [
-		"DavidAnson.vscode-markdownlint",
 		"matklad.rust-analyzer",
 		"NathanRidley.autotrim",
 		"samverschueren.final-newline",

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -86,6 +86,10 @@ name = "crd_derive_custom_schema"
 path = "crd_derive_custom_schema.rs"
 
 [[example]]
+name = "crd_derive_multi"
+path = "crd_derive_multi.rs"
+
+[[example]]
 name = "crd_derive_no_schema"
 path = "crd_derive_no_schema.rs"
 

--- a/examples/crd_derive_multi.rs
+++ b/examples/crd_derive_multi.rs
@@ -1,0 +1,132 @@
+#[macro_use] extern crate log;
+use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::CustomResourceDefinition;
+use kube::{
+    api::{Api, Patch, PatchParams},
+    core::crd::merge_crds,
+    runtime::wait::{await_condition, conditions},
+    Client, CustomResource, CustomResourceExt, ResourceExt,
+};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+mod v1 {
+    use super::*;
+    // spec that is forwards compatible with v2 (can upgrade by truncating)
+    #[derive(CustomResource, Serialize, Deserialize, Default, Debug, Clone, JsonSchema)]
+    #[kube(group = "kube.rs", version = "v1", kind = "ManyDerive", namespaced)]
+    pub struct ManyDeriveSpec {
+        pub name: String,
+        pub oldprop: u32,
+    }
+}
+mod v2 {
+    // spec that is NOT backwards compatible with v1 (cannot retrieve oldprop if truncated)
+    use super::*;
+    #[derive(CustomResource, Serialize, Deserialize, Default, Debug, Clone, JsonSchema)]
+    #[kube(group = "kube.rs", version = "v2", kind = "ManyDerive", namespaced)]
+    pub struct ManyDeriveSpec {
+        pub name: String,
+        pub extra: Option<String>,
+    }
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    std::env::set_var("RUST_LOG", "info,kube=info");
+    env_logger::init();
+
+    let client = Client::try_default().await?;
+    let ssapply = PatchParams::apply("crd_derive_multi").force();
+
+    let crd1 = v1::ManyDerive::crd();
+    let crd2 = v2::ManyDerive::crd();
+    let all_crds = vec![crd1.clone(), crd2.clone()];
+
+    // apply schema where v1 is the stored version
+    apply_crd(client.clone(), merge_crds(all_crds.clone(), "v1")?).await?;
+
+    // create apis
+    let v1api: Api<v1::ManyDerive> = Api::default_namespaced(client.clone());
+    let v2api: Api<v2::ManyDerive> = Api::default_namespaced(client.clone());
+
+    // create a v1 version
+    let v1m = v1::ManyDerive::new("old", v1::ManyDeriveSpec {
+        name: "i am old".into(),
+        oldprop: 5,
+    });
+    let oldvarv1 = v1api.patch("old", &ssapply, &Patch::Apply(&v1m)).await?;
+    info!("old instance on v1: {:?}", oldvarv1.spec);
+    let oldvarv2 = v2api.get("old").await?;
+    info!("old instance on v2 truncates: {:?}", oldvarv2.spec);
+
+    // create a v2 version
+    let v2m = v2::ManyDerive::new("new", v2::ManyDeriveSpec {
+        name: "i am new".into(),
+        extra: Some("hi".into()),
+    });
+    let newvarv2 = v2api.patch("new", &ssapply, &Patch::Apply(&v2m)).await?;
+    info!("new instance on v2 is force downgraded: {:?}", newvarv2.spec); // no extra field
+    let cannot_fetch_as_old = v1api.get("new").await.unwrap_err();
+    info!("cannot fetch new on v1: {:?}", cannot_fetch_as_old);
+
+    // apply schema upgrade
+    apply_crd(client.clone(), merge_crds(all_crds, "v2")?).await?;
+
+    // nothing changed with existing objects without conversion
+    //let oldvarv1_upg = v1api.get("old").await?;
+    //info!("old instance unchanged on v1: {:?}", oldvarv1_upg.spec);
+    //let oldvarv2_upg = v2api.get("old").await?;
+    //info!("old instance unchanged on v2: {:?}", oldvarv2_upg.spec);
+
+    // re-apply new now that v2 is stored gives us the extra properties
+    let newvarv2_2 = v2api.patch("new", &ssapply, &Patch::Apply(&v2m)).await?;
+    info!("new on v2 correct on reapply to v2: {:?}", newvarv2_2.spec);
+
+
+    // note we can apply old versions without them being truncated to the v2 schema
+    // in our case this means we cannot fetch them with our v1 schema (breaking change to not have oldprop)
+    let v1m2 = v1::ManyDerive::new("old", v1::ManyDeriveSpec {
+        name: "i am old2".into(),
+        oldprop: 5,
+    });
+    let v1err = v1api
+        .patch("old", &ssapply, &Patch::Apply(&v1m2))
+        .await
+        .unwrap_err();
+    info!("cannot get old on v1 anymore: {:?}", v1err); // mandatory field oldprop truncated
+                                                        // ...but the change is still there:
+    let old_still_there = v2api.get("old").await?;
+    assert_eq!(old_still_there.spec.name, "i am old2");
+
+    cleanup(client.clone()).await?;
+    Ok(())
+}
+
+
+async fn apply_crd(client: Client, crd: CustomResourceDefinition) -> anyhow::Result<()> {
+    let crds: Api<CustomResourceDefinition> = Api::all(client.clone());
+    info!("Creating crd: {}", serde_yaml::to_string(&crd)?);
+    let ssapply = PatchParams::apply("crd_derive_multi").force();
+    crds.patch("manyderives.kube.rs", &ssapply, &Patch::Apply(&crd))
+        .await?;
+    let establish = await_condition(
+        crds.clone(),
+        "manyderives.kube.rs",
+        conditions::is_crd_established(),
+    );
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(10), establish).await?;
+    Ok(())
+}
+
+async fn cleanup(client: Client) -> anyhow::Result<()> {
+    let crds: Api<CustomResourceDefinition> = Api::all(client.clone());
+    let obj = crds.delete("manyderives.kube.rs", &Default::default()).await?;
+    match obj {
+        either::Either::Left(o) => {
+            let uid = o.uid().unwrap();
+            await_condition(crds, "manyderives.kube.rs", conditions::is_deleted(&uid)).await?;
+        }
+        _ => {}
+    }
+    Ok(())
+}

--- a/kube-client/src/error.rs
+++ b/kube-client/src/error.rs
@@ -67,7 +67,7 @@ pub enum Error {
 
     /// Errors from OpenSSL TLS
     #[cfg(feature = "openssl-tls")]
-    #[cfg_attr(docsrs, doc(feature = "openssl-tls"))]
+    #[cfg_attr(docsrs, doc(cfg(feature = "openssl-tls")))]
     #[error("openssl tls error: {0}")]
     OpensslTls(#[source] crate::client::OpensslTlsError),
 

--- a/kube-core/Cargo.toml
+++ b/kube-core/Cargo.toml
@@ -44,4 +44,6 @@ default-features = false
 features = ["v1_22"]
 
 [dev-dependencies]
+assert-json-diff = "2.0.1"
 kube = { path = "../kube", version = "<1.0.0, >=0.53.0" }
+serde_yaml = "0.8.23"

--- a/kube-core/src/crd.rs
+++ b/kube-core/src/crd.rs
@@ -56,8 +56,6 @@ pub mod v1 {
         /// Mismatching kind
         #[error("Mismatching kinds from given CRDs")]
         KindMismatch,
-
-
         //#[error("failed to build request: {0}")]
         //BuildRequest(#[source] http::Error),
         //#[error("failed to serialize body: {0}")]
@@ -81,7 +79,11 @@ pub mod v1 {
         /// let final_crd = CrdMerger::new(crds).served("v1").merge()?;
         /// ```
         pub fn new(crds: Vec<Crd>) -> Self {
-            Self { crds, served: None, globals: None }
+            Self {
+                crds,
+                served: None,
+                globals: None,
+            }
         }
 
         /// Set the apiversion to be served
@@ -91,13 +93,14 @@ pub mod v1 {
         }
 
         /// Merge the crds with the given options
-        pub fn merge(self) -> Result<Crd, CrdError> { // TODO: error
+        pub fn merge(self) -> Result<Crd, CrdError> {
+            // TODO: error
             if self.crds.is_empty() {
-                return Err(CrdError::MissingCrds)
+                return Err(CrdError::MissingCrds);
             }
             for crd in self.crds.iter() {
                 if crd.spec.versions.len() != 1 {
-                    return Err(CrdError::TooManyVersions)
+                    return Err(CrdError::TooManyVersions);
                 }
             }
             let mut root = if let Some(g) = self.globals {
@@ -115,10 +118,10 @@ pub mod v1 {
             // validation
             for crd in self.crds.iter() {
                 if &crd.spec.group != group {
-                    return Err(CrdError::ApiGroupMismatch)
+                    return Err(CrdError::ApiGroupMismatch);
                 }
                 if &crd.spec.names.kind != kind {
-                    return Err(CrdError::KindMismatch)
+                    return Err(CrdError::KindMismatch);
                 }
                 // TODO: validate conversion hooks
             }

--- a/kube-core/src/crd.rs
+++ b/kube-core/src/crd.rs
@@ -61,8 +61,8 @@ pub mod v1 {
     /// Merge a collection of crds into a single multiversion crd
     ///
     /// Given multiple [`CustomResource`] derived types granting [`CRD`]s via [`CustomResourceExt::crd`],
-    /// we can merge them into a single [`CRD`] with multiple [`CRDVersion`] objects, marking only the specified apiversion
-    /// as `storage: true`.
+    /// we can merge them into a single [`CRD`] with multiple [`CRDVersion`] objects, marking only
+    /// the specified apiversion as `storage: true`.
     ///
     /// This merge algorithm assumes that every [`CRD`]:
     ///

--- a/kube-core/src/crd.rs
+++ b/kube-core/src/crd.rs
@@ -4,6 +4,7 @@ use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions as apiexts;
 
 /// Types for v1 CustomResourceDefinitions
 pub mod v1 {
+    use super::apiexts::v1::CustomResourceDefinition as Crd;
     /// Extension trait that is implemented by kube-derive
     ///
     /// This trait variant is implemented by default (or when `#[kube(apiextensions = "v1")]`)
@@ -11,7 +12,7 @@ pub mod v1 {
         /// Helper to generate the CRD including the JsonSchema
         ///
         /// This is using the stable v1::CustomResourceDefinitions (present in kubernetes >= 1.16)
-        fn crd() -> super::apiexts::v1::CustomResourceDefinition;
+        fn crd() -> Crd;
         /// Helper to return the name of this `CustomResourceDefinition` in kubernetes.
         ///
         /// This is not the name of an _instance_ of this custom resource but the `CustomResourceDefinition` object itself.
@@ -27,6 +28,111 @@ pub mod v1 {
         ///
         /// [`Pod`]: `k8s_openapi::api::core::v1::Pod`
         fn shortnames() -> &'static [&'static str];
+    }
+
+    /// Possible errors when merging CRDs
+    #[derive(Debug, thiserror::Error)]
+    pub enum CrdError {
+        /// No crds given
+        #[error("Empty list of CRDs cannot be merged")]
+        MissingCrds,
+
+        /// Served api not present
+        #[error("Served api version {0} not found")]
+        MissingServedApi(String),
+
+        /// Globals api not present
+        #[error("Globals api version {0} not found")]
+        MissingGlobalsApi(String),
+
+        /// Globals api not present
+        #[error("Given CRD must have exactly one version each")]
+        TooManyVersions,
+
+        /// Mismatching api group
+        #[error("Mismatching api groups from given CRDs")]
+        ApiGroupMismatch,
+
+        /// Mismatching kind
+        #[error("Mismatching kinds from given CRDs")]
+        KindMismatch,
+
+
+        //#[error("failed to build request: {0}")]
+        //BuildRequest(#[source] http::Error),
+        //#[error("failed to serialize body: {0}")]
+        //SerializeBody(#[source] serde_json::Error),
+    }
+
+    /// Merger for multi-version setups of kube-derived crd schemas
+    pub struct CrdMerger {
+        crds: Vec<Crd>,
+        served: Option<String>,
+        globals: Option<String>,
+    }
+
+    impl CrdMerger {
+        /// Create a CrdMerger from a list of crds
+        ///
+        /// ```no_run
+        /// #let mycrd_v1: CustomResourceDefinition = todo!(); // v1::MyCrd::crd();
+        /// #let mycrd_v2: CustomResourceDefinition = todo!(); // v2::MyCrd::crd();
+        /// let crds = vec![mycrd_v1, mycrd_v2];
+        /// let final_crd = CrdMerger::new(crds).served("v1").merge()?;
+        /// ```
+        pub fn new(crds: Vec<Crd>) -> Self {
+            Self { crds, served: None, globals: None }
+        }
+
+        /// Set the apiversion to be served
+        pub fn served(mut self, served_apiversion: impl Into<String>) -> Self {
+            self.served = Some(served_apiversion.into());
+            self
+        }
+
+        /// Merge the crds with the given options
+        pub fn merge(self) -> Result<Crd, CrdError> { // TODO: error
+            if self.crds.is_empty() {
+                return Err(CrdError::MissingCrds)
+            }
+            for crd in self.crds.iter() {
+                if crd.spec.versions.len() != 1 {
+                    return Err(CrdError::TooManyVersions)
+                }
+            }
+            let mut root = if let Some(g) = self.globals {
+                match self.crds.iter().find(|c| c.spec.versions[0].name == g) {
+                    None => return Err(CrdError::MissingGlobalsApi(g)),
+                    Some(g) => g.clone(),
+                }
+            } else {
+                self.crds.iter().next().unwrap().clone() // we know first is non-empty
+            };
+
+            let global_ver = root.spec.versions[0].name.clone();
+            let group = &root.spec.group;
+            let kind = &root.spec.names.kind;
+            // validation
+            for crd in self.crds.iter() {
+                if &crd.spec.group != group {
+                    return Err(CrdError::ApiGroupMismatch)
+                }
+                if &crd.spec.names.kind != kind {
+                    return Err(CrdError::KindMismatch)
+                }
+                // TODO: validate conversion hooks
+            }
+
+            // validation ok, smash them together:
+            let versions = &mut root.spec.versions;
+            for crd in self.crds {
+                if crd.spec.versions[0].name == global_ver {
+                    continue;
+                }
+                versions.push(crd.spec.versions[0].clone());
+            }
+            Ok(root)
+        }
     }
 }
 

--- a/kube-core/src/crd.rs
+++ b/kube-core/src/crd.rs
@@ -91,7 +91,7 @@ pub mod v1 {
     /// [`CRD`]: https://docs.rs/k8s-openapi/latest/k8s_openapi/apiextensions_apiserver/pkg/apis/apiextensions/v1/struct.CustomResourceDefinition.html
     /// [`CRDVersion`]: https://docs.rs/k8s-openapi/latest/k8s_openapi/apiextensions_apiserver/pkg/apis/apiextensions/v1/struct.CustomResourceDefinitionVersion.html
     /// [`CustomResource`]: https://docs.rs/kube/latest/kube/derive.CustomResource.html
-    pub fn merge_crds(mut crds: Vec<Crd>, stored_apiversion: impl Into<String>) -> Result<Crd, MergeError> {
+    pub fn merge_crds(mut crds: Vec<Crd>, stored_apiversion: &str) -> Result<Crd, MergeError> {
         if crds.is_empty() {
             return Err(MergeError::MissingCrds);
         }
@@ -103,11 +103,11 @@ pub mod v1 {
                 return Err(MergeError::MultiVersionCrd);
             }
         }
-        let ver: String = stored_apiversion.into();
+        let ver = stored_apiversion;
         let found = crds.iter().position(|c| c.spec.versions[0].name == ver);
         // Extract the root/first object to start with (the one we will merge into)
         let mut root = match found {
-            None => return Err(MergeError::MissingRootVersion(ver)),
+            None => return Err(MergeError::MissingRootVersion(ver.into())),
             Some(idx) => crds.remove(idx),
         };
         root.spec.versions[0].storage = true; // main version - set true in case modified

--- a/kube-core/src/crd.rs
+++ b/kube-core/src/crd.rs
@@ -138,4 +138,4 @@ pub mod v1 {
 
 /// re-export the current latest version until a newer one is available in cloud providers
 pub use v1::CustomResourceExt;
-pub use v1::{MergeError, merge_crds};
+pub use v1::{merge_crds, MergeError};

--- a/kube-core/src/crd.rs
+++ b/kube-core/src/crd.rs
@@ -34,27 +34,27 @@ pub mod v1 {
     #[derive(Debug, thiserror::Error)]
     pub enum MergeError {
         /// No crds given
-        #[error("Empty list of CRDs cannot be merged")]
+        #[error("empty list of CRDs cannot be merged")]
         MissingCrds,
 
         /// Stored api not present
-        #[error("Stored api version {0} not found")]
+        #[error("stored api version {0} not found")]
         MissingStoredApi(String),
 
         /// Root api not present
-        #[error("Root api version {0} not found")]
+        #[error("root api version {0} not found")]
         MissingRootVersion(String),
 
         /// No versions given in one crd to merge
-        #[error("Given CRD must have versions")]
+        #[error("given CRD must have versions")]
         MissingVersions,
 
         /// Too many versions given to individual crds
-        #[error("Mergeable CRDs cannot have multiple versions")]
+        #[error("mergeable CRDs cannot have multiple versions")]
         MultiVersionCrd,
 
         /// Mismatching spec properties on crds
-        #[error("Mismatching {0} property from given CRDs")]
+        #[error("mismatching {0} property from given CRDs")]
         PropertyMismatch(String),
     }
 
@@ -237,6 +237,5 @@ pub mod v1 {
     }
 }
 
-/// re-export the current latest version until a newer one is available in cloud providers
-pub use v1::CustomResourceExt;
-pub use v1::{merge_crds, MergeError};
+// re-export current latest (v1)
+pub use v1::{merge_crds, CustomResourceExt, MergeError};

--- a/kube-core/src/lib.rs
+++ b/kube-core/src/lib.rs
@@ -20,7 +20,7 @@ pub mod dynamic;
 pub use dynamic::{ApiResource, DynamicObject};
 
 pub mod crd;
-pub use crd::CustomResourceExt;
+pub use crd::{CustomResourceExt};
 
 pub mod gvk;
 pub use gvk::{GroupVersion, GroupVersionKind, GroupVersionResource};

--- a/kube-core/src/lib.rs
+++ b/kube-core/src/lib.rs
@@ -20,7 +20,7 @@ pub mod dynamic;
 pub use dynamic::{ApiResource, DynamicObject};
 
 pub mod crd;
-pub use crd::{CustomResourceExt};
+pub use crd::CustomResourceExt;
 
 pub mod gvk;
 pub use gvk::{GroupVersion, GroupVersionKind, GroupVersionResource};

--- a/kube-derive/src/lib.rs
+++ b/kube-derive/src/lib.rs
@@ -237,10 +237,20 @@ mod custom_resource;
 /// For sanity, you should review the generated schema before sending it to kubernetes.
 ///
 /// ## Versioning
-/// Note that any changes to your struct / validation rules / serialization attributes will require you to re-apply the generated
-/// schema to kubernetes, so that the apiserver can validate against the right version of your structs.
+/// Note that any changes to your struct / validation rules / serialization attributes will require you to re-apply the
+/// generated schema to kubernetes, so that the apiserver can validate against the right version of your structs.
 ///
-/// How to best deal with version changes has not been fully sketched out. See [#569](https://github.com/kube-rs/kube-rs/issues/569).
+/// Backwards compatibility between schema versions is recommended unless you are in a controlled environment
+/// where you can migrate manually. I.e. if you add new properties behind options, and simply mark old fields as deprecated,
+/// then you can safely roll schema out changes without bumping the version.
+///
+/// On the other hand, if you are making **breaking changes** to your schemas, you should have:
+///
+/// - one module for each version of your types (e.g. v1::MyCrd and v2::MyCrd)
+/// - use the [`merge_crds`](https://docs.rs/kube/latest/kube/core/crd/fn.merge_crds.html) fn to combine them
+/// - roll out new schemas utilizing conversion webhooks
+///
+/// Note that kube has not implemented conversion webhooks yet. See [#865](https://github.com/kube-rs/kube-rs/issues/865).
 ///
 /// ## Debugging
 /// Try `cargo-expand` to see your own macro expansion.


### PR DESCRIPTION
Implementation for #569. Follows [official docs](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/).

- [x] example showing how upgrades work in practice without conversion
- [x] tests doing a simple yaml schema merge
- [x] docs; how to maintain/upgrade versions with kube-derive

Docs touch on #865 because it's hard to recommend multi-versioning without it, but users can hack around it.
Tests add some dependencies use elsewhere in project (`assert_json_diff` from examples).

The example is the most interesting, found out this with 2 versions:

- while v1 is active (storage: true); writes to v2 will truncate schema as per v1 defn
- while v2 is active (storage: true); writes to v1 will truncate schema as per v2 defn

this means that you can end up:

- not being able to read from the v1 api if v2 is not backwards compat
- not being able to read from v2 api if v1 is not forwards compat

tried to clarify this as well as possible in the example and docs.