### PR TITLE
Remove deprecated legacy crd v1beta1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,9 +65,6 @@ jobs:
       - name: Test crd_derive_no_schema example
         run: cargo test -p kube-examples --example crd_derive_no_schema --no-default-features --features=openssl-tls,latest
         if: matrix.os == 'ubuntu-latest'
-      - name: Test crd_api example with deprecated crd
-        run: cargo test -p kube-examples --example crd_api --no-default-features --features=deprecated,kubederive,openssl-tls
-        if: matrix.os == 'ubuntu-latest'
 
   check-msrv:
     # Run `cargo check` on our minimum supported Rust version

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,6 @@ test:
 	cargo test -p kube --lib --no-default-features --features=native-tls,ws,oauth
 	cargo test -p kube --lib --no-default-features --features=openssl-tls,ws,oauth
 	cargo test -p kube --lib --no-default-features
-	cargo test -p kube-examples --example crd_api --no-default-features --features=deprecated,kubederive,openssl-tls
 
 test-integration:
 	kubectl delete pod -lapp=kube-rs-test

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -21,7 +21,6 @@ rustls-tls = ["kube/client", "kube/rustls-tls"]
 runtime = ["kube/runtime"]
 ws = ["kube/ws"]
 latest = ["k8s-openapi/v1_22"]
-deprecated = ["kube/deprecated-crd-v1beta1", "k8s-openapi/v1_21"]
 
 [dev-dependencies]
 tokio-util = "0.7.0"

--- a/examples/README.md
+++ b/examples/README.md
@@ -48,12 +48,6 @@ The last one opts out from the default `schema` feature from `kube-derive` (and 
 
 **However**: without the `schema` feature, it's left **up to you to fill in a valid openapi v3 schema**, as schemas are **required** for [v1::CustomResourceDefinitions](https://docs.rs/k8s-openapi/0.10.0/k8s_openapi/apiextensions_apiserver/pkg/apis/apiextensions/v1/struct.CustomResourceDefinition.html), and the generated crd will be rejected by the apiserver if it's missing. As the last example shows, you can do this directly without `schemars`.
 
-It is also possible to run the `crd_api` example against the legacy `v1beta1` CustomResourceDefinition endpoint. To do this you need to run the example with the `deprecated` feature and opt out of defaults:
-
-```sh
-cargo run --example crd_api --no-default-features --features=deprecated,openssl-tls,kubederive
-```
-
 Note that these examples also contain tests for CI, and are invoked with the same parameters, but using `cargo test` rather than `cargo run`.
 
 ## kube-runtime focused examples

--- a/examples/crd_api.rs
+++ b/examples/crd_api.rs
@@ -8,26 +8,16 @@ use std::time::Duration;
 use tokio::time::sleep;
 use validator::Validate;
 
-// Using the old v1beta1 extension requires the deprecated-crd-v1beta1 feature on kube
-#[cfg(feature = "deprecated")]
-use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1beta1 as apiexts;
-#[cfg(feature = "deprecated")] use kube::core::crd::v1beta1::CustomResourceExt;
-
-// Recommended: no deprecated features (v1 crd)
-#[cfg(not(feature = "deprecated"))]
-use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1 as apiexts;
-#[cfg(not(feature = "deprecated"))] use kube::core::crd::v1::CustomResourceExt;
-
-use apiexts::CustomResourceDefinition;
+use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::CustomResourceDefinition;
 use kube::{
     api::{Api, DeleteParams, ListParams, Patch, PatchParams, PostParams, ResourceExt},
+    core::crd::CustomResourceExt,
     Client, CustomResource,
 };
 
 // Own custom resource
 #[derive(CustomResource, Deserialize, Serialize, Clone, Debug, Validate, JsonSchema)]
 #[kube(group = "clux.dev", version = "v1", kind = "Foo", namespaced)]
-#[cfg_attr(feature = "deprecated", kube(apiextensions = "v1beta1"))]
 #[kube(status = "FooStatus")]
 #[kube(scale = r#"{"specReplicasPath":".spec.replicas", "statusReplicasPath":".status.replicas"}"#)]
 #[kube(printcolumn = r#"{"name":"Team", "jsonPath": ".spec.metadata.team", "type": "string"}"#)]

--- a/kube-client/Cargo.toml
+++ b/kube-client/Cargo.toml
@@ -27,7 +27,6 @@ client = ["config", "__non_core", "hyper", "http-body", "tower", "tower-http", "
 jsonpatch = ["kube-core/jsonpatch"]
 admission = ["kube-core/admission"]
 config = ["__non_core", "pem", "dirs"]
-deprecated-crd-v1beta1 = ["kube-core/deprecated-crd-v1beta1"]
 
 # private feature sets; do not use
 __non_core = ["tracing", "serde_yaml", "base64"]

--- a/kube-core/Cargo.toml
+++ b/kube-core/Cargo.toml
@@ -20,7 +20,6 @@ rustdoc-args = ["--cfg", "docsrs"]
 ws = []
 admission = ["json-patch"]
 jsonpatch = ["json-patch"]
-deprecated-crd-v1beta1 = []
 schema = ["schemars"]
 
 [dependencies]

--- a/kube-core/src/crd.rs
+++ b/kube-core/src/crd.rs
@@ -30,34 +30,5 @@ pub mod v1 {
     }
 }
 
-/// Types for legacy v1beta1 CustomResourceDefinitions
-#[cfg(feature = "deprecated-crd-v1beta1")]
-pub mod v1beta1 {
-    /// Extension trait that is implemented by kube-derive for legacy v1beta1::CustomResourceDefinitions
-    ///
-    /// This trait variant is only implemented with `#[kube(apiextensions = "v1beta1")]`
-    pub trait CustomResourceExt {
-        /// Helper to generate the legacy CRD without a JsonSchema
-        ///
-        /// This is using v1beta1::CustomResourceDefinitions (which will be removed in kubernetes 1.22)
-        fn crd() -> super::apiexts::v1beta1::CustomResourceDefinition;
-        /// Helper to return the name of this `CustomResourceDefinition` in kubernetes.
-        ///
-        /// This is not the name of an _instance_ of this custom resource but the `CustomResourceDefinition` object itself.
-        fn crd_name() -> &'static str;
-        /// Helper to generate the api information type for use with the dynamic `Api`
-        fn api_resource() -> crate::discovery::ApiResource;
-        /// Shortnames of this resource type.
-        ///
-        /// For example: [`Pod`] has the shortname alias `po`.
-        ///
-        /// NOTE: This function returns *declared* short names (at compile-time, using the `#[kube(shortname = "foo")]`), not the
-        /// shortnames registered with the Kubernetes API (which is what tools such as `kubectl` look at).
-        ///
-        /// [`Pod`]: `k8s_openapi::api::core::v1::Pod`
-        fn shortnames() -> &'static [&'static str];
-    }
-}
-
 /// re-export the current latest version until a newer one is available in cloud providers
 pub use v1::CustomResourceExt;

--- a/kube/Cargo.toml
+++ b/kube/Cargo.toml
@@ -29,7 +29,6 @@ admission = ["kube-core/admission"]
 derive = ["kube-derive", "kube-core/schema"]
 config = ["kube-client/config"]
 runtime = ["kube-runtime"]
-deprecated-crd-v1beta1 = ["kube-core/deprecated-crd-v1beta1"]
 
 [package.metadata.docs.rs]
 features = ["client", "native-tls", "rustls-tls", "openssl-tls", "derive", "ws", "oauth", "jsonpatch", "admission", "runtime", "k8s-openapi/v1_22"]


### PR DESCRIPTION
no major cloud providers needs it anymore ([removed in 1.22](https://kubernetes.io/blog/2021/07/14/upcoming-changes-in-kubernetes-1-22/) but you need to be on Kubernetes < 1.16 to not have v1 - [see this](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/))

might create a thing for MK8SV as 1.16 as well if this is approved.
(1.16 is lower than what we would support with the [future version plan](https://github.com/kube-rs/k8s-pb/issues/10))

EDIT: The debatable point is whether we should keep it around until the version of kubernetes that removed it becomes unavailable, in which case we might wait for another while. I think it's fine, it's in line with the future versioning plan. It's not only deprecated, it's fully removed upstream, we should do the same.