### PR TITLE
Support lowercase http_proxy & https_proxy evars

### DIFF
--- a/kube-client/src/config/file_loader.rs
+++ b/kube-client/src/config/file_loader.rs
@@ -111,7 +111,9 @@ impl ConfigLoader {
 
         if let Some(proxy) = nonempty(self.cluster.proxy_url.clone())
             .or_else(|| nonempty(std::env::var("HTTP_PROXY").ok()))
+            .or_else(|| nonempty(std::env::var("http_proxy").ok()))
             .or_else(|| nonempty(std::env::var("HTTPS_PROXY").ok()))
+            .or_else(|| nonempty(std::env::var("https_proxy").ok()))
         {
             Ok(Some(
                 proxy


### PR DESCRIPTION
ref: https://cs.opensource.google/go/go/+/master:src/vendor/golang.org/x/net/http/httpproxy/proxy.go;l=27;bpv=1;bpt=1?q=http_proxy&ss=go%2Fgo

proxy_url should be valid when setting env: http_proxy or https_proxy