### PR TITLE
Fix Rust 1.60 clippy lint warnings

### DIFF
--- a/examples/crd_derive_multi.rs
+++ b/examples/crd_derive_multi.rs
@@ -121,12 +121,9 @@ async fn apply_crd(client: Client, crd: CustomResourceDefinition) -> anyhow::Res
 async fn cleanup(client: Client) -> anyhow::Result<()> {
     let crds: Api<CustomResourceDefinition> = Api::all(client.clone());
     let obj = crds.delete("manyderives.kube.rs", &Default::default()).await?;
-    match obj {
-        either::Either::Left(o) => {
-            let uid = o.uid().unwrap();
-            await_condition(crds, "manyderives.kube.rs", conditions::is_deleted(&uid)).await?;
-        }
-        _ => {}
+    if let either::Either::Left(o) = obj {
+        let uid = o.uid().unwrap();
+        await_condition(crds, "manyderives.kube.rs", conditions::is_deleted(&uid)).await?;
     }
     Ok(())
 }

--- a/examples/pod_cp.rs
+++ b/examples/pod_cp.rs
@@ -73,7 +73,7 @@ async fn main() -> anyhow::Result<()> {
         let mut tar = pods
             .exec("example", vec!["tar", "xf", "-", "-C", "/"], &ap)
             .await?;
-        tar.stdin().unwrap().write(&data).await?;
+        tar.stdin().unwrap().write_all(&data).await?;
     }
 
     // Check that the file was written

--- a/examples/pod_exec.rs
+++ b/examples/pod_exec.rs
@@ -90,7 +90,7 @@ async fn main() -> anyhow::Result<()> {
         let mut stdin_writer = attached.stdin().unwrap();
         let mut stdout_stream = tokio_util::io::ReaderStream::new(attached.stdout().unwrap());
         let next_stdout = stdout_stream.next();
-        stdin_writer.write(b"echo test string 1\n").await?;
+        stdin_writer.write_all(b"echo test string 1\n").await?;
         let stdout = String::from_utf8(next_stdout.await.unwrap().unwrap().to_vec()).unwrap();
         println!("{}", stdout);
         assert_eq!(stdout, "test string 1\n");
@@ -98,7 +98,7 @@ async fn main() -> anyhow::Result<()> {
         // AttachedProcess provides access to a future that resolves with a status object.
         let status = attached.take_status().unwrap();
         // Send `exit 1` to get a failure status.
-        stdin_writer.write(b"exit 1\n").await?;
+        stdin_writer.write_all(b"exit 1\n").await?;
         if let Some(status) = status.await {
             println!("{:?}", status);
             assert_eq!(status.status, Some("Failure".to_owned()));

--- a/kube-client/src/lib.rs
+++ b/kube-client/src/lib.rs
@@ -369,14 +369,14 @@ mod test {
             let mut stdin_writer = attached.stdin().unwrap();
             let mut stdout_stream = tokio_util::io::ReaderStream::new(attached.stdout().unwrap());
             let next_stdout = stdout_stream.next();
-            stdin_writer.write(b"echo test string 1\n").await?;
+            stdin_writer.write_all(b"echo test string 1\n").await?;
             let stdout = String::from_utf8(next_stdout.await.unwrap().unwrap().to_vec()).unwrap();
             println!("{}", stdout);
             assert_eq!(stdout, "test string 1\n");
 
             // AttachedProcess resolves with status object.
             // Send `exit 1` to get a failure status.
-            stdin_writer.write(b"exit 1\n").await?;
+            stdin_writer.write_all(b"exit 1\n").await?;
             let status = attached.take_status().unwrap();
             if let Some(status) = status.await {
                 println!("{:?}", status);

--- a/kube-core/src/schema.rs
+++ b/kube-core/src/schema.rs
@@ -99,13 +99,13 @@ impl Visitor for StructuralSchemaRewriter {
         // check for maps without with properties (i.e. flattnened maps)
         // and allow these to persist dynamically
         if let Some(object) = &mut schema.object {
-            if !object.properties.is_empty() {
-                if object.additional_properties.as_deref() == Some(&Schema::Bool(true)) {
-                    object.additional_properties = None;
-                    schema
-                        .extensions
-                        .insert("x-kubernetes-preserve-unknown-fields".into(), true.into());
-                }
+            if !object.properties.is_empty()
+                && object.additional_properties.as_deref() == Some(&Schema::Bool(true))
+            {
+                object.additional_properties = None;
+                schema
+                    .extensions
+                    .insert("x-kubernetes-preserve-unknown-fields".into(), true.into());
             }
         }
     }

--- a/kube-derive/tests/crd_enum_test.rs
+++ b/kube-derive/tests/crd_enum_test.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 #[kube(group = "clux.dev", version = "v1", kind = "FooEnum")]
 #[kube(apiextensions = "v1")]
 #[serde(rename_all = "camelCase")]
+#[allow(clippy::enum_variant_names)]
 enum FooEnumSpec {
     /// First variant with an int
     VariantOne { int: i32 },


### PR DESCRIPTION
Fairly mechanical fix of the warnings generated by `cargo clippy --all-targets`.