### PR TITLE
Bump CI to k8s-openapi v1_23

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ fmt:
 	rustfmt +nightly --edition 2021 $$(find . -type f -iname *.rs)
 
 doc:
-	RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --lib --workspace --features=derive,ws,oauth,jsonpatch,client,derive,runtime,admission,k8s-openapi/v1_22 --open
+	RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --lib --workspace --features=derive,ws,oauth,jsonpatch,client,derive,runtime,admission,k8s-openapi/v1_23 --open
 
 test:
 	cargo test --lib --all

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Select a version of `kube` along with the generated [k8s-openapi](https://github
 ```toml
 [dependencies]
 kube = { version = "0.71.0", features = ["runtime", "derive"] }
-k8s-openapi = { version = "0.14.0", features = ["v1_22"] }
+k8s-openapi = { version = "0.14.0", features = ["v1_23"] }
 ```
 
 [Features are available](https://github.com/kube-rs/kube-rs/blob/master/kube/Cargo.toml#L18).
@@ -157,7 +157,7 @@ Kube has basic support ([with caveats](https://github.com/kube-rs/kube-rs/issues
 ```toml
 [dependencies]
 kube = { version = "0.71.0", default-features = false, features = ["client", "rustls-tls"] }
-k8s-openapi = { version = "0.14.0", features = ["v1_22"] }
+k8s-openapi = { version = "0.14.0", features = ["v1_23"] }
 ```
 
 This will pull in `rustls` and `hyper-rustls`.

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -18,7 +18,7 @@ anyhow = "1.0.44"
 env_logger = "0.9.0"
 futures = "0.3.17"
 kube = { path = "../kube", version = "^0.71.0", default-features = false, features = ["client", "rustls-tls"] }
-k8s-openapi = { version = "0.14.0", features = ["v1_22"], default-features = false }
+k8s-openapi = { version = "0.14.0", features = ["v1_23"], default-features = false }
 log = "0.4.11"
 serde_json = "1.0.68"
 tokio = { version = "1.14.0", features = ["full"] }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -20,7 +20,7 @@ openssl-tls = ["kube/client", "kube/openssl-tls"]
 rustls-tls = ["kube/client", "kube/rustls-tls"]
 runtime = ["kube/runtime"]
 ws = ["kube/ws"]
-latest = ["k8s-openapi/v1_22"]
+latest = ["k8s-openapi/v1_23"]
 
 [dev-dependencies]
 tokio-util = "0.7.0"

--- a/kube-client/Cargo.toml
+++ b/kube-client/Cargo.toml
@@ -32,7 +32,7 @@ config = ["__non_core", "pem", "dirs"]
 __non_core = ["tracing", "serde_yaml", "base64"]
 
 [package.metadata.docs.rs]
-features = ["client", "native-tls", "rustls-tls", "openssl-tls", "ws", "oauth", "jsonpatch", "admission", "k8s-openapi/v1_22"]
+features = ["client", "native-tls", "rustls-tls", "openssl-tls", "ws", "oauth", "jsonpatch", "admission", "k8s-openapi/v1_23"]
 # Define the configuration attribute `docsrs`. Used to enable `doc_cfg` feature.
 rustdoc-args = ["--cfg", "docsrs"]
 
@@ -88,4 +88,4 @@ tower-test = "0.4.0"
 [dev-dependencies.k8s-openapi]
 version = "0.14.0"
 default-features = false
-features = ["v1_22"]
+features = ["v1_23"]

--- a/kube-core/Cargo.toml
+++ b/kube-core/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/kube-rs/kube-rs"
 readme = "../README.md"
 
 [package.metadata.docs.rs]
-features = ["ws", "admission", "jsonpatch", "k8s-openapi/v1_22"]
+features = ["ws", "admission", "jsonpatch", "k8s-openapi/v1_23"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
@@ -41,7 +41,7 @@ features = []
 [dev-dependencies.k8s-openapi]
 version = "0.14.0"
 default-features = false
-features = ["v1_22"]
+features = ["v1_23"]
 
 [dev-dependencies]
 assert-json-diff = "2.0.1"

--- a/kube-derive/Cargo.toml
+++ b/kube-derive/Cargo.toml
@@ -26,7 +26,7 @@ proc-macro = true
 serde = { version = "1.0.130", features = ["derive"] }
 serde_yaml = "0.8.21"
 kube = { path = "../kube", default-features = false, version = "<1.0.0, >=0.61.0", features = ["derive"] }
-k8s-openapi = { version = "0.14.0", default-features = false, features = ["v1_22"] }
+k8s-openapi = { version = "0.14.0", default-features = false, features = ["v1_23"] }
 schemars = { version = "0.8.6", features = ["chrono"] }
 validator = { version = "0.14.0", features = ["derive"] }
 chrono = { version = "0.4.19", default-features = false }

--- a/kube-runtime/Cargo.toml
+++ b/kube-runtime/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.56"
 edition = "2021"
 
 [package.metadata.docs.rs]
-features = ["k8s-openapi/v1_22"]
+features = ["k8s-openapi/v1_23"]
 # Define the configuration attribute `docsrs`. Used to enable `doc_cfg` feature.
 rustdoc-args = ["--cfg", "docsrs"]
 
@@ -50,4 +50,4 @@ schemars = "0.8.6"
 [dev-dependencies.k8s-openapi]
 version = "0.14.0"
 default-features = false
-features = ["v1_22"]
+features = ["v1_23"]

--- a/kube/Cargo.toml
+++ b/kube/Cargo.toml
@@ -31,7 +31,7 @@ config = ["kube-client/config"]
 runtime = ["kube-runtime"]
 
 [package.metadata.docs.rs]
-features = ["client", "native-tls", "rustls-tls", "openssl-tls", "derive", "ws", "oauth", "jsonpatch", "admission", "runtime", "k8s-openapi/v1_22"]
+features = ["client", "native-tls", "rustls-tls", "openssl-tls", "derive", "ws", "oauth", "jsonpatch", "admission", "runtime", "k8s-openapi/v1_23"]
 # Define the configuration attribute `docsrs`. Used to enable `doc_cfg` feature.
 rustdoc-args = ["--cfg", "docsrs"]
 
@@ -58,4 +58,4 @@ schemars = "0.8.6"
 [dev-dependencies.k8s-openapi]
 version = "0.14.0"
 default-features = false
-features = ["v1_22"]
+features = ["v1_23"]

--- a/release.toml
+++ b/release.toml
@@ -4,7 +4,7 @@
 #
 # 0. (optional) cargo release minor ; verify readme + changelog bumped; then git reset --hard
 # 1. PUBLISH_GRACE_SLEEP=20 cargo release minor --execute
-# 1X.  - on failure: follow plan manually, cd into next dirs and publish insequence with cargo publish --features=k8s-openapi/v1_22
+# 1X.  - on failure: follow plan manually, cd into next dirs and publish insequence with cargo publish --features=k8s-openapi/v1_23
 # 2. check consolidated commit
 # 2X.  - on failure: git commit --amend and insert version
 # 3. ./scripts/release-post.sh
@@ -21,4 +21,4 @@ push = false
 tag = false
 # A Kubernetes version is normally supplied by the application consuming the library in the end.
 # Since we don't have that when verifying, supply one ourselves.
-enable-features = ["k8s-openapi/v1_22"]
+enable-features = ["k8s-openapi/v1_23"]


### PR DESCRIPTION
No more `v1_22` matches in project after this PR.