### PR TITLE
Add GroupVersion::with_kind and TypeMeta -> GroupVersionKind converters

### DIFF
--- a/kube-core/Cargo.toml
+++ b/kube-core/Cargo.toml
@@ -25,7 +25,6 @@ schema = ["schemars"]
 [dependencies]
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.68"
-serde_yaml = "0.8.23"
 thiserror = "1.0.29"
 form_urlencoded = "1.0.1"
 http = "0.2.5"
@@ -47,3 +46,4 @@ features = ["v1_23"]
 [dev-dependencies]
 assert-json-diff = "2.0.1"
 kube = { path = "../kube", version = "<1.0.0, >=0.53.0" }
+serde_yaml = "0.8.23"

--- a/kube-core/Cargo.toml
+++ b/kube-core/Cargo.toml
@@ -25,6 +25,7 @@ schema = ["schemars"]
 [dependencies]
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.68"
+serde_yaml = "0.8.23"
 thiserror = "1.0.29"
 form_urlencoded = "1.0.1"
 http = "0.2.5"
@@ -46,4 +47,3 @@ features = ["v1_23"]
 [dev-dependencies]
 assert-json-diff = "2.0.1"
 kube = { path = "../kube", version = "<1.0.0, >=0.53.0" }
-serde_yaml = "0.8.23"

--- a/kube-core/src/gvk.rs
+++ b/kube-core/src/gvk.rs
@@ -46,29 +46,18 @@ impl GroupVersionKind {
     /// Extract a GroupVersionKind from a yaml document
     ///
     /// ```rust
-    /// # use serde::Deserialize;
-    /// use kube::core::GroupVersionKind;
-    ///
-    /// # async fn wrapper() -> Result<(), Box<dyn std::error::Error>> {
-    /// let input = r#"
-    /// ---
+    /// # use kube::core::GroupVersionKind;
+    /// # fn wrapper() -> Result<(), Box<dyn std::error::Error>> {
+    /// let doc = serde_yaml::from_str(r#"---
     /// apiVersion: kube.rs/v1
     /// kind: Example
     /// metadata:
-    ///   name: doc1
-    /// ---
-    /// apiVersion: kube.rs/v1
-    /// kind: Other
-    /// metadata:
-    ///   name: doc2"#;
+    ///   name: doc1"#)?;
     ///
-    /// let mut gvks = vec![];
-    /// for de in serde_yaml::Deserializer::from_str(input) {
-    ///   let doc = serde_yaml::Value::deserialize(de)?;
-    ///   gvks.push(GroupVersionKind::from_yaml(&doc)?);
-    /// }
-    /// assert_eq!(gvks[0].kind, "Example");
-    /// assert_eq!(gvks[1].group, "kube.rs");
+    /// let gvk = GroupVersionKind::from_yaml(&doc)?;
+    /// assert_eq!(gvk.group, "kube.rs");
+    /// assert_eq!(gvk.version, "v1");
+    /// assert_eq!(gvk.kind, "Example");
     /// # Ok(())
     /// # }
     /// ```
@@ -183,5 +172,32 @@ impl GroupVersionResource {
             resource,
             api_version,
         }
+    }
+}
+
+mod test {
+    #[test]
+    fn gvk_yaml() {
+        use crate::GroupVersionKind;
+        use serde::Deserialize;
+        let input = r#"
+---
+apiVersion: kube.rs/v1
+kind: Example
+metadata:
+  name: doc1
+---
+apiVersion: kube.rs/v1
+kind: Other
+metadata:
+  name: doc2"#;
+
+        let mut gvks = vec![];
+        for de in serde_yaml::Deserializer::from_str(input) {
+            let doc = serde_yaml::Value::deserialize(de).unwrap();
+            gvks.push(GroupVersionKind::from_yaml(&doc).unwrap());
+        }
+        assert_eq!(gvks[0].kind, "Example");
+        assert_eq!(gvks[1].group, "kube.rs");
     }
 }

--- a/kube-core/src/gvk.rs
+++ b/kube-core/src/gvk.rs
@@ -75,7 +75,7 @@ impl GroupVersionKind {
     pub fn from_yaml(doc: &serde_yaml::Value) -> Result<Self, InferError> {
         if let (Some(avv), Some(kv)) = (doc.get("apiVersion"), doc.get("kind")) {
             if let (Some(apiver), Some(kind)) = (avv.as_str(), kv.as_str()) {
-                let gvk = GroupVersion::from_str(&apiver)
+                let gvk = GroupVersion::from_str(apiver)
                     .map_err(InferError::ParseGroupVersion)?
                     .with_kind(kind);
                 Ok(gvk)


### PR DESCRIPTION
for more efficiently working with kubernetes disk format.
was kind of boilerplatey to do elsewhere.