### PR TITLE
Add a WatchStreamExt trait for better event chaining

### DIFF
--- a/examples/node_watcher.rs
+++ b/examples/node_watcher.rs
@@ -3,10 +3,7 @@ use futures::{pin_mut, TryStreamExt};
 use k8s_openapi::api::core::v1::{Event, Node};
 use kube::{
     api::{Api, ListParams, ResourceExt},
-    runtime::{
-        utils::{try_flatten_applied, StreamBackoff},
-        watcher,
-    },
+    runtime::{watcher, WatchStreamExt},
     Client,
 };
 use tracing::*;
@@ -18,10 +15,10 @@ async fn main() -> anyhow::Result<()> {
     let events: Api<Event> = Api::all(client.clone());
     let nodes: Api<Node> = Api::all(client.clone());
 
-    let obs = try_flatten_applied(StreamBackoff::new(
-        watcher(nodes, ListParams::default().labels("beta.kubernetes.io/os=linux")),
-        ExponentialBackoff::default(),
-    ));
+    let lp = ListParams::default().labels("beta.kubernetes.io/arch=amd64");
+    let obs = watcher(nodes, lp)
+        .backoff(ExponentialBackoff::default())
+        .watch_applies();
 
     pin_mut!(obs);
     while let Some(n) = obs.try_next().await? {
@@ -58,7 +55,7 @@ async fn check_for_node_failures(events: &Api<Event>, o: Node) -> anyhow::Result
         }
     } else {
         // Turn node_watcher=debug in log to see all
-        debug!("Healthy node: {}", name);
+        info!("Healthy node: {}", name);
     }
     Ok(())
 }

--- a/kube-runtime/src/lib.rs
+++ b/kube-runtime/src/lib.rs
@@ -32,4 +32,5 @@ pub use controller::{applier, Controller};
 pub use finalizer::finalizer;
 pub use reflector::reflector;
 pub use scheduler::scheduler;
+pub use utils::WatchStreamExt;
 pub use watcher::watcher;

--- a/kube-runtime/src/utils/mod.rs
+++ b/kube-runtime/src/utils/mod.rs
@@ -2,9 +2,11 @@
 
 mod backoff_reset_timer;
 mod stream_backoff;
+mod watch_ext;
 
 pub use backoff_reset_timer::ResetTimerBackoff;
 pub use stream_backoff::StreamBackoff;
+pub use watch_ext::WatchStreamExt;
 
 use crate::watcher;
 use futures::{

--- a/kube-runtime/src/utils/watch_ext.rs
+++ b/kube-runtime/src/utils/watch_ext.rs
@@ -1,0 +1,113 @@
+use crate::{utils::stream_backoff::StreamBackoff, watcher};
+use backoff::backoff::Backoff;
+use core::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+use futures::{Stream, TryStream};
+use pin_project::pin_project;
+
+// grab from private part of tokio
+macro_rules! ready {
+    ($e:expr $(,)?) => {
+        match $e {
+            std::task::Poll::Ready(t) => t,
+            std::task::Poll::Pending => return std::task::Poll::Pending,
+        }
+    };
+}
+
+/// Extension trait for streams of returned by [`watcher`] or [`reflector`]
+pub trait WatchStreamExt: Stream {
+    /// Apply a [`Backoff`] policy to a [`Stream`] using [`StreamBackoff`]
+    fn backoff<B>(self, b: B) -> StreamBackoff<Self, B>
+    where
+        B: Backoff,
+        Self: TryStream + Sized,
+    {
+        StreamBackoff::new(self, b)
+    }
+
+    // This works with bottom setup - but is extremely specific with input/output types
+    fn watch_applies<K>(self) -> EventFlatten<Self, K>
+    where
+        Self: Stream<Item = Result<watcher::Event<K>, watcher::Error>> + Sized,
+    {
+        EventFlatten::new(self, false)
+    }
+
+    // This works with bottom setup - but is extremely specific with input/output types
+    fn watch_touches<K>(self) -> EventFlatten<Self, K>
+    where
+        Self: Stream<Item = Result<watcher::Event<K>, watcher::Error>> + Sized,
+    {
+        EventFlatten::new(self, true)
+    }
+}
+impl<St: ?Sized> WatchStreamExt for St where St: Stream {}
+
+#[pin_project]
+/// Stream returned by the [`watch_applies`](super::WatchStreamExt::watch_applies) method.
+#[must_use = "streams do nothing unless polled"]
+pub struct EventFlatten<St, K> {
+    #[pin]
+    stream: St,
+    delete: bool,
+    state: Option<Result<watcher::Event<K>, watcher::Error>>,
+}
+impl<St: TryStream<Ok = watcher::Event<K>>, K> EventFlatten<St, K> {
+    pub(super) fn new(stream: St, delete: bool) -> Self {
+        Self {
+            stream,
+            state: None,
+            delete,
+        }
+    }
+}
+impl<St, K> Stream for EventFlatten<St, K>
+where
+    St: Stream<Item = Result<watcher::Event<K>, watcher::Error>>,
+{
+    type Item = Result<K, watcher::Error>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let mut me = self.project();
+        loop {
+            if let Some(curr) = me.state.take() {
+                match curr {
+                    Ok(event) => {
+                        // drain an individual event as per Event::into_iter_applied
+                        match event {
+                            watcher::Event::Applied(obj) => {
+                                return Poll::Ready(Some(Ok(obj)));
+                            }
+                            watcher::Event::Deleted(obj) => {
+                                // only pass delete events for touches
+                                if *me.delete {
+                                    return Poll::Ready(Some(Ok(obj)));
+                                }
+                            }
+                            watcher::Event::Restarted(mut reslist) => {
+                                if let Some(last) = reslist.pop() {
+                                    // store the remainder
+                                    *me.state = Some(Ok(watcher::Event::Restarted(reslist)));
+                                    return Poll::Ready(Some(Ok(last)));
+                                }
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        return Poll::Ready(Some(Err(e)));
+                    }
+                }
+            }
+            let next = ready!(me.stream.as_mut().poll_next(cx));
+            match next {
+                Some(event) => {
+                    *me.state = Some(event); // continue around loop to extract from it
+                }
+                None => return Poll::Pending,
+            }
+        }
+    }
+}


### PR DESCRIPTION
From discussion with @teozkr after #698 .
This tries to solve the problem in a more generic way using `Stream` helpers.
A single example using it is included for now. Want to have some reviews before tidying this up properly.

It was not trivial, and I'm not convinced this is the easiest way to do it, but every other path i tried failed.


<details><summary>failed path</summary>
<p>
tried a smarter setup without having to reimplement `into_iter_applied` inlined into an `impl Stream` but i just couldn't get the types to line up. the `impl Stream` we get is opaque and cannot be put inside the struct `AppliesGen`
```rust
#[pin_project]
/// Stream returned by the [`Applies`](super::WatchStreamExt::watch_applies) method.
#[must_use = "streams do nothing unless polled"]
pub struct AppliesGen<St, K> {
    #[pin]
    stream: St,
    phantom: PhantomData<K>,
}
impl<St, K> AppliesGen<St, K>
where
    K: Sized + Send + 'static,
    St: Stream<Item = Result<watcher::Event<K>, watcher::Error>> + 'static,
{
    pub(super) fn new(st: St) -> Self {
        let stream = utils::try_flatten_applied(st); // opaque type :(
        AppliesGen { stream, phantom: PhantomData }
    }
}
impl<St, K> Stream for AppliesGen<St, K>
where
{
   type Item = Result<K, watcher::Error>;

   fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
       self.as_mut()
           .project()
           .stream
           .poll_next(cx)
   }
}
```
</p>
</details>