### PR TITLE
Replace `make` as a script running with `just`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,9 +25,9 @@ Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).
 ## Rust Guidelines
 
 - **Channel**: Code is built and tested using the **stable** channel of Rust, but documented and formatted with **nightly** <sup>[*](https://github.com/kube-rs/kube-rs/issues/707)</sup>
-- **Formatting**: To format the codebase, run `make fmt`
-- **Documentation** To check documentation, run `make doc`
-- **Testing**: To run tests, run `make test` and see below.
+- **Formatting**: To format the codebase, run `just fmt`
+- **Documentation** To check documentation, run `just doc`
+- **Testing**: To run tests, run `just test` and see below.
 
 For a list of tooling that we glue together everything see [TOOLS.md](https://kube.rs/tools/).
 
@@ -41,13 +41,13 @@ We have 3 classes of tests.
 
 The last two will try to access the Kubernetes cluster that is your `current-context`; i.e. via your local `KUBECONFIG` evar or `~/.kube/config` file.
 
-The easiest way set up a minimal Kubernetes cluster for these is with [`k3d`](https://k3d.io/) (`make k3d`).
+The easiest way set up a minimal Kubernetes cluster for these is with [`k3d`](https://k3d.io/) (`just k3d`).
 
 ### Unit Tests & Documentation Tests
 
 **Most** unit/doc tests are run from `cargo test --lib --doc --all`, but because of feature-sets, and examples, you will need a couple of extra invocations to replicate our CI.
 
-For the complete variations, run the `make test` target in the `Makefile`.
+For the complete variations, run the `just test` target in the `justfile`.
 
 All public interfaces must be documented, and most should have minor documentation examples to show usage.
 
@@ -57,7 +57,7 @@ Slower set of tests within the crates marked with an **`#[ignore]`** attribute.
 
 :warning: These  **WILL** try to modify resources in your current cluster :warning:
 
-Most integration tests are run with `cargo test --all --lib -- --ignored`, but because of feature-sets, you will need a few invocations of these to replicate our CI. See `make test-integration`
+Most integration tests are run with `cargo test --all --lib -- --ignored`, but because of feature-sets, you will need a few invocations of these to replicate our CI. See `just test-integration`
 
 ### End to End Tests
 
@@ -65,7 +65,7 @@ We have a small set of [e2e tests](https://github.com/kube-rs/kube-rs/tree/maste
 
 These tests are the heaviest tests we have because they require a full `docker build`, image import (or push/pull flow), yaml construction, and `kubectl` usage to verify that the outcome was sufficient.
 
-To run E2E tests, use (or follow) `make e2e` as appropriate.
+To run E2E tests, use (or follow) `just e2e` as appropriate.
 
 ### Test Guidelines
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -23,6 +23,6 @@ General process, optimized for time.
 It's successful if the app exits successfully, without encountering errors.
 
 ### Running
-Start a cluster first, e.g. `make k3d`.
+Start a cluster first, e.g. `just k3d`.
 
-Run `make integration` to cross compile `dapp` with `muslrust` locally using the same docker image, and then deploy it to the current active cluster.
+Run `just integration` to cross compile `dapp` with `muslrust` locally using the same docker image, and then deploy it to the current active cluster.

--- a/justfile
+++ b/justfile
@@ -1,0 +1,73 @@
+VERSION := `git rev-parse HEAD`
+
+default:
+  @just --list --unsorted --color=always | rg -v "    default"
+
+clippy:
+  #rustup component add clippy --toolchain nightly
+  cargo +nightly clippy --workspace
+  cargo +nightly clippy --no-default-features --features=rustls-tls
+
+fmt:
+  #rustup component add rustfmt --toolchain nightly
+  rustfmt +nightly --edition 2021 $$(find . -type f -iname *.rs)
+
+doc:
+  RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --lib --workspace --features=derive,ws,oauth,jsonpatch,client,derive,runtime,admission,k8s-openapi/v1_23 --open
+
+# Unit tests
+test:
+  cargo test --lib --all
+  cargo test --doc --all
+  cargo test -p kube-examples --examples
+  cargo test -p kube --lib --no-default-features --features=rustls-tls,ws,oauth
+  cargo test -p kube --lib --no-default-features --features=native-tls,ws,oauth
+  cargo test -p kube --lib --no-default-features --features=openssl-tls,ws,oauth
+  cargo test -p kube --lib --no-default-features
+
+test-integration:
+  kubectl delete pod -lapp=kube-rs-test
+  cargo test --lib --all -- --ignored # also run tests that fail on github actions
+  cargo test -p kube --lib --features=derive,runtime -- --ignored
+  cargo test -p kube-client --lib --features=rustls-tls,ws -- --ignored
+  cargo run -p kube-examples --example crd_derive
+  cargo run -p kube-examples --example crd_api
+
+coverage:
+  cargo tarpaulin --out=Html --output-dir=.
+  #xdg-open tarpaulin-report.html
+
+deny:
+  # might require rm Cargo.lock first to match CI
+  cargo deny --workspace --all-features check bans licenses sources
+
+readme:
+  rustdoc README.md --test --edition=2021
+
+e2e: dapp
+  ls -lah e2e/
+  docker build -t clux/kube-dapp:{{VERSION}} e2e/
+  k3d image import clux/kube-dapp:{{VERSION}} --cluster main
+  sed -i 's/latest/{{VERSION}}/g' e2e/deployment.yaml
+  kubectl apply -f e2e/deployment.yaml
+  sed -i 's/{{VERSION}}/latest/g' e2e/deployment.yaml
+  kubectl get all -n apps
+  kubectl describe jobs/dapp -n apps
+  kubectl wait --for=condition=complete job/dapp -n apps --timeout=50s || kubectl logs -f job/dapp -n apps
+  kubectl get all -n apps
+  kubectl wait --for=condition=complete job/dapp -n apps --timeout=10s || kubectl get pods -n apps | grep dapp | grep Completed
+
+dapp:
+  #!/usr/bin/env bash
+  docker run \
+    -v cargo-cache:/root/.cargo/registry \
+    -v "$PWD:/volume" -w /volume \
+    --rm -it clux/muslrust:stable cargo build --release -p e2e
+  cp target/x86_64-unknown-linux-musl/release/dapp e2e/dapp
+  chmod +x e2e/dapp
+
+k3d:
+  k3d cluster create main --servers 1 --agents 1 --registry-create main \
+    --k3s-arg "--no-deploy=traefik@server:*" \
+    --k3s-arg '--kubelet-arg=eviction-hard=imagefs.available<1%,nodefs.available<1%@agent:*' \
+    --k3s-arg '--kubelet-arg=eviction-minimum-reclaim=imagefs.available=1%,nodefs.available=1%@agent:*'

--- a/justfile
+++ b/justfile
@@ -71,3 +71,10 @@ k3d:
     --k3s-arg "--no-deploy=traefik@server:*" \
     --k3s-arg '--kubelet-arg=eviction-hard=imagefs.available<1%,nodefs.available<1%@agent:*' \
     --k3s-arg '--kubelet-arg=eviction-minimum-reclaim=imagefs.available=1%,nodefs.available=1%@agent:*'
+
+bump-k8s:
+  #!/usr/bin/env bash
+  current=$(cargo tree --format "{f}" -i k8s-openapi | head -n 1)
+  next=${current::-2}$((${current:3} + 1))
+  fastmod -m -d . --extensions toml "$current" "$next"
+  fastmod -m README.md "$current" "$next"


### PR DESCRIPTION
To follow conventions used in rest of org.

..triggered by needing to make a new target and stopped writing make pretty much everywhere else.
