### PR TITLE
Update docs and finalize for 0.72.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ pub struct DocumentSpec {
 Then you can use the generated wrapper struct `Document` as a [`kube::Resource`](https://docs.rs/kube/*/kube/trait.Resource.html):
 
 ```rust
-let docs: Api<DocumentSpec> = Api::default_namespaced(client);
+let docs: Api<Document> = Api::default_namespaced(client);
 let d = Document::new("guide", DocumentSpec::default());
 println!("doc: {:?}", d);
 println!("crd: {:?}", serde_yaml::to_string(&Document::crd()));


### PR DESCRIPTION
Plan on releasing 0.72.0 tomorrow (with or without the outstanding docs thing).

Stuff to put in highlights:
(NB: TODOs blocked by release on docs.rs)

### Ergonomics improvements
A new `runtime::WatchSteamExt` (#899 + #906) allows for simpler setups for streams from `watcher` or `reflector`.

```diff
- let stream = utils::try_flatten_applied(StreamBackoff::new(watcher(api, lp), b));
+ let stream = watcher(api, lp).backoff(b).applied_objects();
```

The `util::try_flatten_*` helpers have been marked as deprecated since they are not used in the new pipeline.

A new `reflector:store()` fn allows simpler reflector setups #907:

```diff
- let store = reflector::store::Writer::<Node>::default();
- let reader = store.as_reader();
+ let (reader, writer) = reflector::store();
```

Additional conveniences getters/settes to `ResourceExt` for manged_fields and creation_timestamp #888 + #898, plus a `GroupVersion::with_kind` path to a GVK, and a `TryFrom<TypeMeta> for GroupVersionKind` in #896.

### CRD Version Selection
Managing multiple [version in CustomResourceDefinitions](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/) can be pretty complicated, but we now have helpers and docs on how to tackle it.

A new function `kube::core::crd::merge_crds` (TODO: docs.rs link) have been added (in #889) to help push crd schemas generated by kube-derived crds with different `#[kube(version)]` properties. TODO: link to kube-derive segment.

A new example showcases [how one can manage two or more versions of a crd](https://github.com/kube-rs/kube-rs/blob/7715cabd4d1976493e6b8949471f283df927a79e/examples/crd_derive_multi.rs#L12-L31) and what the expected truncation outcomes are when moving between versions. 

### Examples
Examples now have moved to `tracing` for its logging, respects `RUST_LOG`, and namespace selection via the kubeconfig context. There is also a [larger kubectl example](https://github.com/kube-rs/kube-rs/blob/master/examples/kubectl.rs) showcasing `kubectl apply -f yaml` https://github.com/kube-rs/kube-rs/blob/7715cabd4d1976493e6b8949471f283df927a79e/examples/kubectl.rs#L149-L170 as well as `kubectl {edit,delete,get,watch}` via #885 + #897.
