### PR TITLE
Replace runtime::controller::Context with Arc

### DIFF
--- a/examples/kubectl.rs
+++ b/examples/kubectl.rs
@@ -138,7 +138,7 @@ impl App {
                 info!("updating changed object {}", orig.name());
                 let data: DynamicObject = serde_yaml::from_str(&edited)?;
                 // NB: simplified kubectl constructs a merge-patch of differences
-                api.replace(&n, &Default::default(), &data).await?;
+                api.replace(n, &Default::default(), &data).await?;
             }
         } else {
             warn!("need a name to edit");
@@ -185,7 +185,7 @@ async fn main() -> Result<()> {
     // Defer to methods for verbs
     if let Some(resource) = &app.resource {
         // Common discovery, parameters, and api configuration for a single resource
-        let (ar, caps) = resolve_api_resource(&discovery, &resource)
+        let (ar, caps) = resolve_api_resource(&discovery, resource)
             .with_context(|| format!("resource {:?} not found in cluster", resource))?;
         let mut lp = ListParams::default();
         if let Some(label) = &app.selector {

--- a/examples/secret_syncer.rs
+++ b/examples/secret_syncer.rs
@@ -9,7 +9,7 @@ use kube::{
     api::{Api, DeleteParams, ListParams, ObjectMeta, Patch, PatchParams, Resource},
     error::ErrorResponse,
     runtime::{
-        controller::{Action, Context, Controller},
+        controller::{Action, Controller},
         finalizer::{finalizer, Event},
     },
 };
@@ -101,7 +101,7 @@ async fn main() -> anyhow::Result<()> {
             }
         },
         |_err, _| Action::requeue(Duration::from_secs(2)),
-        Context::new(()),
+        Arc::new(()),
     )
     .for_each(|msg| async move { info!("Reconciled: {:?}", msg) })
     .await;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation

`controller::Context` was just a newtype around `std::sync::Arc` that was confusing, added no new features, had annoying name clashes (including with `kube::config::Context`) and had slightly worse ergonomics (had to use `Context::get_ref()` rather than there being a `Deref` implementation).

<!--
Explain the context and why you're making that change. What is the problem you're trying to solve?
If a new feature is being added, describe the intended use case that feature fulfills.
-->

## Solution

Replace it with using `std::sync::Arc` directly.

<!--
Summarize the solution and provide any necessary context needed to understand the code change.
-->
