### PR TITLE
Remove `#[kube(apiextensions)]` flag from `kube-derive`

### DIFF
--- a/examples/crd_derive_schema.rs
+++ b/examples/crd_derive_schema.rs
@@ -28,7 +28,6 @@ use serde::{Deserialize, Serialize};
     derive = "PartialEq",
     derive = "Default"
 )]
-#[kube(apiextensions = "v1")]
 pub struct FooSpec {
     // Non-nullable without default is required.
     //

--- a/kube-core/src/crd.rs
+++ b/kube-core/src/crd.rs
@@ -6,8 +6,6 @@ use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions as apiexts;
 pub mod v1 {
     use super::apiexts::v1::CustomResourceDefinition as Crd;
     /// Extension trait that is implemented by kube-derive
-    ///
-    /// This trait variant is implemented by default (or when `#[kube(apiextensions = "v1")]`)
     pub trait CustomResourceExt {
         /// Helper to generate the CRD including the JsonSchema
         ///

--- a/kube-derive/src/custom_resource.rs
+++ b/kube-derive/src/custom_resource.rs
@@ -597,6 +597,5 @@ mod tests {
         };
         let input = syn::parse2(input).unwrap();
         let kube_attrs = KubeAttrs::from_derive_input(&input).unwrap();
-        assert_eq!(kube_attrs.apiextensions, "v1");
     }
 }

--- a/kube-derive/src/custom_resource.rs
+++ b/kube-derive/src/custom_resource.rs
@@ -17,8 +17,6 @@ struct KubeAttrs {
     singular: Option<String>,
     #[darling(default)]
     namespaced: bool,
-    #[darling(default = "default_apiext")]
-    apiextensions: String,
     #[darling(multiple, rename = "derive")]
     derives: Vec<String>,
     schema: Option<SchemaMode>,
@@ -82,10 +80,6 @@ impl Crates {
     fn default_std() -> Path {
         parse_quote! { ::std }
     }
-}
-
-fn default_apiext() -> String {
-    "v1".to_owned()
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -159,7 +153,6 @@ pub(crate) fn derive(input: proc_macro2::TokenStream) -> proc_macro2::TokenStrea
         categories,
         shortnames,
         printcolums,
-        apiextensions,
         scale,
         crates:
             Crates {
@@ -231,12 +224,8 @@ pub(crate) fn derive(input: proc_macro2::TokenStream) -> proc_macro2::TokenStrea
         }
     }
 
-    // Enable schema generation by default for v1 because it's mandatory.
-    let schema_mode = schema_mode.unwrap_or(if apiextensions == "v1" {
-        SchemaMode::Derived
-    } else {
-        SchemaMode::Disabled
-    });
+    // Enable schema generation by default as in v1 it is mandatory.
+    let schema_mode = schema_mode.unwrap_or(SchemaMode::Derived);
     // We exclude fields `apiVersion`, `kind`, and `metadata` from our schema because
     // these are validated by the API server implicitly. Also, we can't generate the
     // schema for `metadata` (`ObjectMeta`) because it doesn't implement `JsonSchema`.
@@ -346,20 +335,15 @@ pub(crate) fn derive(input: proc_macro2::TokenStream) -> proc_macro2::TokenStrea
     // 4. Implement CustomResource
 
     // Compute a bunch of crd props
-    let mut printers = format!("[ {} ]", printcolums.join(",")); // hacksss
-    if apiextensions == "v1beta1" {
-        // only major api inconsistency..
-        printers = printers.replace("jsonPath", "JSONPath");
-    }
+    let printers = format!("[ {} ]", printcolums.join(",")); // hacksss
     let scale_code = if let Some(s) = scale { s } else { "".to_string() };
 
-    // Ensure it generates for the correct CRD version
-    let v1ident = format_ident!("{}", apiextensions);
+    // Ensure it generates for the correct CRD version (only v1 supported now)
     let apiext = quote! {
-        #k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::#v1ident
+        #k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1
     };
     let extver = quote! {
-        #kube_core::crd::#v1ident
+        #kube_core::crd::v1
     };
 
     let shortnames_slice = {
@@ -396,61 +380,33 @@ pub(crate) fn derive(input: proc_macro2::TokenStream) -> proc_macro2::TokenStrea
         }
     };
 
-    let jsondata = if apiextensions == "v1" {
-        quote! {
-            #schemagen
+    let jsondata = quote! {
+        #schemagen
 
-            let jsondata = #serde_json::json!({
-                "metadata": #crd_meta,
-                "spec": {
-                    "group": #group,
-                    "scope": #scope,
-                    "names": {
-                        "categories": categories,
-                        "plural": #plural,
-                        "singular": #name,
-                        "kind": #kind,
-                        "shortNames": shorts
+        let jsondata = #serde_json::json!({
+            "metadata": #crd_meta,
+            "spec": {
+                "group": #group,
+                "scope": #scope,
+                "names": {
+                    "categories": categories,
+                    "plural": #plural,
+                    "singular": #name,
+                    "kind": #kind,
+                    "shortNames": shorts
+                },
+                "versions": [{
+                    "name": #version,
+                    "served": true,
+                    "storage": true,
+                    "schema": {
+                        "openAPIV3Schema": schema,
                     },
-                    "versions": [{
-                        "name": #version,
-                        "served": true,
-                        "storage": true,
-                        "schema": {
-                            "openAPIV3Schema": schema,
-                        },
-                        "additionalPrinterColumns": columns,
-                        "subresources": subres,
-                    }],
-                }
-            });
-        }
-    } else {
-        // TODO Include schema if enabled
-        quote! {
-            let jsondata = #serde_json::json!({
-                "metadata": #crd_meta,
-                "spec": {
-                    "group": #group,
-                    "scope": #scope,
-                    "names": {
-                        "categories": categories,
-                        "plural": #plural,
-                        "singular": #name,
-                        "kind": #kind,
-                        "shortNames": shorts
-                    },
-                    // printer columns can't be on versions reliably in v1beta..
                     "additionalPrinterColumns": columns,
-                    "versions": [{
-                        "name": #version,
-                        "served": true,
-                        "storage": true,
-                    }],
                     "subresources": subres,
-                }
-            });
-        }
+                }],
+            }
+        });
     };
 
     // Implement the CustomResourceExt trait to allow users writing generic logic on top of them

--- a/kube-derive/src/lib.rs
+++ b/kube-derive/src/lib.rs
@@ -68,13 +68,6 @@ mod custom_resource;
 ///
 /// # Optional `#[kube]` attributes
 ///
-/// ## `#[kube(apiextensions = "v1beta1")]`
-/// The version for `CustomResourceDefinition` desired in the `apiextensions.k8s.io` group.
-/// Default is `v1` (for clusters >= 1.17). If using kubernetes <= 1.16 please use `v1beta1`.
-///
-/// - **NOTE**: Support for `v1` requires deriving the openapi v3 `JsonSchema` via the `schemars` dependency.
-/// - **NOTE**: When using `v1beta` the associated `CustomResourceExt` trait lives in `kube::core::crd::v1beta`
-///
 /// ## `#[kube(singular = "nonstandard-singular")]`
 /// To specify the singular name. Defaults to lowercased `kind`.
 ///
@@ -122,9 +115,9 @@ mod custom_resource;
 /// This can be used to provide a completely custom schema, or to interact with third-party custom resources
 /// where you are not responsible for installing the `CustomResourceDefinition`.
 ///
-/// Defaults to `"disabled"` when `apiextensions = "v1beta1"`, otherwise `"derived"`.
+/// Defaults to `"derived"`.
 ///
-/// NOTE: `apiextensions = "v1"` `CustomResourceDefinition`s require a schema. If `schema = "disabled"` then
+/// NOTE: `CustomResourceDefinition`s require a schema. If `schema = "disabled"` then
 /// `Self::crd()` will not be installable into the cluster as-is.
 ///
 /// ## `#[kube(scale = r#"json"#)]`

--- a/kube-derive/tests/crd_enum_test.rs
+++ b/kube-derive/tests/crd_enum_test.rs
@@ -4,7 +4,6 @@ use serde::{Deserialize, Serialize};
 
 #[derive(CustomResource, Serialize, Deserialize, Debug, Clone, JsonSchema)]
 #[kube(group = "clux.dev", version = "v1", kind = "FooEnum")]
-#[kube(apiextensions = "v1")]
 #[serde(rename_all = "camelCase")]
 #[allow(clippy::enum_variant_names)]
 enum FooEnumSpec {

--- a/kube-derive/tests/crd_schema_test.rs
+++ b/kube-derive/tests/crd_schema_test.rs
@@ -16,7 +16,6 @@ use std::collections::HashMap;
     shortname = "fo",
     shortname = "f"
 )]
-#[kube(apiextensions = "v1")]
 #[serde(rename_all = "camelCase")]
 struct FooSpec {
     non_nullable: String,


### PR DESCRIPTION
Using this in the non-default setting relies on `CustomResourceDefinition` at the removed `v1beta1` api version which we also previously removed support for in #890, so the flag serves no purpose anymore.