### PR TITLE
Add support for passing the fieldValidation query parameter on patch

### DIFF
--- a/kube-client/src/api/mod.rs
+++ b/kube-client/src/api/mod.rs
@@ -34,7 +34,7 @@ pub use kube_core::{
     Resource, ResourceExt,
 };
 pub use params::{
-    DeleteParams, ListParams, Patch, PatchParams, PostParams, Preconditions, PropagationPolicy,
+    DeleteParams, ListParams, Patch, PatchParams, PostParams, Preconditions, PropagationPolicy, ValidationDirective,
 };
 
 use crate::Client;

--- a/kube-core/src/params.rs
+++ b/kube-core/src/params.rs
@@ -143,14 +143,20 @@ impl ListParams {
 /// The validation directive to use for `fieldValidation` when using server-side apply.
 #[derive(Clone, Debug)]
 pub enum ValidationDirective {
+    /// Strict mode will fail any invalid manifests.
+    /// 
     /// This will fail the request with a BadRequest error if any unknown fields would be dropped from the
     /// object, or if any duplicate fields are present. The error returned from the server will contain
     /// all unknown and duplicate fields encountered.
     Strict,
+    /// Warn mode will return a warning for invalid manifests.
+    /// 
     /// This will send a warning via the standard warning response header for each unknown field that
     /// is dropped from the object, and for each duplicate field that is encountered. The request will
     /// still succeed if there are no other errors, and will only persist the last of any duplicate fields.
     Warn,
+    /// Ignore mode will silently ignore any problems.
+    /// 
     /// This will ignore any unknown fields that are silently dropped from the object, and will ignore
     /// all but the last duplicate field that the decoder encounters.
     Ignore,
@@ -403,6 +409,7 @@ pub struct DeleteParams {
 
 impl DeleteParams {
     /// Construct `DeleteParams` with `PropagationPolicy::Background`.
+    /// 
     /// This allows the garbage collector to delete the dependents in the background.
     pub fn background() -> Self {
         Self {
@@ -412,6 +419,7 @@ impl DeleteParams {
     }
 
     /// Construct `DeleteParams` with `PropagationPolicy::Foreground`.
+    /// 
     /// This is a cascading policy that deletes all dependents in the foreground.
     pub fn foreground() -> Self {
         Self {
@@ -421,6 +429,7 @@ impl DeleteParams {
     }
 
     /// Construct `DeleteParams` with `PropagationPolicy::Orphan`.
+    /// 
     /// This orpans the dependents.
     pub fn orphan() -> Self {
         Self {

--- a/kube-core/src/params.rs
+++ b/kube-core/src/params.rs
@@ -144,19 +144,19 @@ impl ListParams {
 #[derive(Clone, Debug)]
 pub enum ValidationDirective {
     /// Strict mode will fail any invalid manifests.
-    /// 
+    ///
     /// This will fail the request with a BadRequest error if any unknown fields would be dropped from the
     /// object, or if any duplicate fields are present. The error returned from the server will contain
     /// all unknown and duplicate fields encountered.
     Strict,
     /// Warn mode will return a warning for invalid manifests.
-    /// 
+    ///
     /// This will send a warning via the standard warning response header for each unknown field that
     /// is dropped from the object, and for each duplicate field that is encountered. The request will
     /// still succeed if there are no other errors, and will only persist the last of any duplicate fields.
     Warn,
     /// Ignore mode will silently ignore any problems.
-    /// 
+    ///
     /// This will ignore any unknown fields that are silently dropped from the object, and will ignore
     /// all but the last duplicate field that the decoder encounters.
     Ignore,
@@ -426,7 +426,7 @@ pub struct DeleteParams {
 
 impl DeleteParams {
     /// Construct `DeleteParams` with `PropagationPolicy::Background`.
-    /// 
+    ///
     /// This allows the garbage collector to delete the dependents in the background.
     pub fn background() -> Self {
         Self {
@@ -436,7 +436,7 @@ impl DeleteParams {
     }
 
     /// Construct `DeleteParams` with `PropagationPolicy::Foreground`.
-    /// 
+    ///
     /// This is a cascading policy that deletes all dependents in the foreground.
     pub fn foreground() -> Self {
         Self {
@@ -446,7 +446,8 @@ impl DeleteParams {
     }
 
     /// Construct `DeleteParams` with `PropagationPolicy::Orphan`.
-    /// 
+    ///
+    ///
     /// This orpans the dependents.
     pub fn orphan() -> Self {
         Self {

--- a/kube-core/src/params.rs
+++ b/kube-core/src/params.rs
@@ -367,27 +367,27 @@ impl PatchParams {
     }
 
     /// Set the validation directive for `fieldValidation` during server-side apply.
-    fn field_validation(mut self, directive: ValidationDirective) -> Self {
-        self.field_validation = Some(directive);
+    pub fn validation(mut self, vd: ValidationDirective) -> Self {
+        self.field_validation = Some(vd);
         self
     }
 
     /// Set the validation directive to `Ignore`
     #[must_use]
     pub fn validation_ignore(self) -> Self {
-        self.field_validation(ValidationDirective::Ignore)
+        self.validation(ValidationDirective::Ignore)
     }
 
     /// Set the validation directive to `Warn`
     #[must_use]
     pub fn validation_warn(self) -> Self {
-        self.field_validation(ValidationDirective::Warn)
+        self.validation(ValidationDirective::Warn)
     }
 
     /// Set the validation directive to `Strict`
     #[must_use]
     pub fn validation_strict(self) -> Self {
-        self.field_validation(ValidationDirective::Strict)
+        self.validation(ValidationDirective::Strict)
     }
 }
 

--- a/kube-core/src/params.rs
+++ b/kube-core/src/params.rs
@@ -367,10 +367,27 @@ impl PatchParams {
     }
 
     /// Set the validation directive for `fieldValidation` during server-side apply.
-    #[must_use]
-    pub fn field_validation(mut self, directive: ValidationDirective) -> Self {
+    fn field_validation(mut self, directive: ValidationDirective) -> Self {
         self.field_validation = Some(directive);
         self
+    }
+
+    /// Set the validation directive to `Ignore`
+    #[must_use]
+    pub fn validation_ignore(self) -> Self {
+        self.field_validation(ValidationDirective::Ignore)
+    }
+
+    /// Set the validation directive to `Warn`
+    #[must_use]
+    pub fn validation_warn(self) -> Self {
+        self.field_validation(ValidationDirective::Warn)
+    }
+
+    /// Set the validation directive to `Strict`
+    #[must_use]
+    pub fn validation_strict(self) -> Self {
+        self.field_validation(ValidationDirective::Strict)
     }
 }
 
@@ -514,19 +531,19 @@ mod test {
 
     #[test]
     fn patch_param_serializes_field_validation() {
-        let pp = PatchParams::default().field_validation(ValidationDirective::Ignore);
+        let pp = PatchParams::default().validation_ignore();
         let mut qp = form_urlencoded::Serializer::new(String::from("some/resource?"));
         pp.populate_qp(&mut qp);
         let urlstr = qp.finish();
         assert_eq!(String::from("some/resource?&fieldValidation=Ignore"), urlstr);
 
-        let pp = PatchParams::default().field_validation(ValidationDirective::Warn);
+        let pp = PatchParams::default().validation_warn();
         let mut qp = form_urlencoded::Serializer::new(String::from("some/resource?"));
         pp.populate_qp(&mut qp);
         let urlstr = qp.finish();
         assert_eq!(String::from("some/resource?&fieldValidation=Warn"), urlstr);
 
-        let pp = PatchParams::default().field_validation(ValidationDirective::Strict);
+        let pp = PatchParams::default().validation_strict();
         let mut qp = form_urlencoded::Serializer::new(String::from("some/resource?"));
         pp.populate_qp(&mut qp);
         let urlstr = qp.finish();

--- a/kube-core/src/params.rs
+++ b/kube-core/src/params.rs
@@ -518,19 +518,19 @@ mod test {
         let mut qp = form_urlencoded::Serializer::new(String::from("some/resource?"));
         pp.populate_qp(&mut qp);
         let urlstr = qp.finish();
-        assert_eq!(String::from("some/resource?fieldValidation=Ignore"), urlstr);
+        assert_eq!(String::from("some/resource?&fieldValidation=Ignore"), urlstr);
 
         let pp = PatchParams::default().field_validation(ValidationDirective::Warn);
         let mut qp = form_urlencoded::Serializer::new(String::from("some/resource?"));
         pp.populate_qp(&mut qp);
         let urlstr = qp.finish();
-        assert_eq!(String::from("some/resource?fieldValidation=Warn"), urlstr);
+        assert_eq!(String::from("some/resource?&fieldValidation=Warn"), urlstr);
 
         let pp = PatchParams::default().field_validation(ValidationDirective::Strict);
         let mut qp = form_urlencoded::Serializer::new(String::from("some/resource?"));
         pp.populate_qp(&mut qp);
         let urlstr = qp.finish();
-        assert_eq!(String::from("some/resource?fieldValidation=Strict"), urlstr);
+        assert_eq!(String::from("some/resource?&fieldValidation=Strict"), urlstr);
     }
 }
 


### PR DESCRIPTION
The `fieldValidation` flag should be set to `Ignore` when doing a server-side
apply for a partial object. This introduces support to configure the
fieldValidation parameter to all the available options.

## Motivation

In order to increase parity with the Go library, and to support partial (invalid, but applicable for patch) server-side `Patch::Apply` requests, the `kube` library should support a way to configure the `fieldValidation` query parameter.

## Solution

This MR introduces a `field_validation` property and method on `PatchParams`, allowing the configuration of the `fieldValidation` query parameter.
