### PR TITLE
Silence false positive `significant_drop_in_scrutinee` for `SplitCase`

### DIFF
--- a/kube-runtime/src/utils/mod.rs
+++ b/kube-runtime/src/utils/mod.rs
@@ -94,7 +94,8 @@ where
         match inner_peek.poll(cx) {
             Poll::Ready(Some(x_ref)) => {
                 if (this.should_consume_item)(x_ref) {
-                    match inner.as_mut().poll_next(cx) {
+                    let item = inner.as_mut().poll_next(cx);
+                    match item {
                         Poll::Ready(Some(x)) => Poll::Ready(Some((this.try_extract_item_case)(x).expect(
                             "`try_extract_item_case` returned `None` despite `should_consume_item` returning `true`",
                         ))),


### PR DESCRIPTION
Fixes #930

This should ensure that we get a compile error if any temporary is even borrowed past the `poll_next()` call.

No need to include this in the changelog since it's purely an internal rephrasing (and Clippy ignores external dependencies).