### PR TITLE
Deprecate ResourceExt::name in favour of safe name_* alternatives

### DIFF
--- a/e2e/boot.rs
+++ b/e2e/boot.rs
@@ -7,7 +7,7 @@ async fn main() -> anyhow::Result<()> {
     let client = Client::try_default().await?;
     let pods: Api<Pod> = Api::all(client);
     for p in pods.list(&Default::default()).await? {
-        tracing::info!("Found pod {}", p.name());
+        tracing::info!("Found pod {}", p.name_any());
     }
     Ok(())
 }

--- a/examples/admission_controller.rs
+++ b/examples/admission_controller.rs
@@ -45,7 +45,7 @@ async fn mutate_handler(body: AdmissionReview<DynamicObject>) -> Result<impl Rep
     let mut res = AdmissionResponse::from(&req);
     // req.Object always exists for us, but could be None if extending to DELETE events
     if let Some(obj) = req.object {
-        let name = obj.name_or_generatename().unwrap(); // apiserver may not have generated a name yet
+        let name = obj.name_any(); // apiserver may not have generated a name yet
         res = match mutate(res.clone(), &obj) {
             Ok(res) => {
                 info!("accepted: {:?} on Foo {}", req.operation, name);

--- a/examples/admission_controller.rs
+++ b/examples/admission_controller.rs
@@ -45,13 +45,14 @@ async fn mutate_handler(body: AdmissionReview<DynamicObject>) -> Result<impl Rep
     let mut res = AdmissionResponse::from(&req);
     // req.Object always exists for us, but could be None if extending to DELETE events
     if let Some(obj) = req.object {
+        let name = obj.name_or_generatename().unwrap(); // apiserver may not have generated a name yet
         res = match mutate(res.clone(), &obj) {
             Ok(res) => {
-                info!("accepted: {:?} on Foo {}", req.operation, obj.name());
+                info!("accepted: {:?} on Foo {}", req.operation, name);
                 res
             }
             Err(err) => {
-                warn!("denied: {:?} on {} ({})", req.operation, obj.name(), err);
+                warn!("denied: {:?} on {} ({})", req.operation, name, err);
                 res.deny(err.to_string())
             }
         };

--- a/examples/crd_api.rs
+++ b/examples/crd_api.rs
@@ -49,7 +49,7 @@ async fn main() -> Result<()> {
         res.map_left(|o| {
             info!(
                 "Deleting {}: ({:?})",
-                o.name(),
+                o.name_unchecked(),
                 o.status.unwrap().conditions.unwrap().last()
             );
         })
@@ -68,7 +68,7 @@ async fn main() -> Result<()> {
     let patch_params = PatchParams::default();
     match crds.create(&pp, &foocrd).await {
         Ok(o) => {
-            info!("Created {} ({:?})", o.name(), o.status.unwrap());
+            info!("Created {} ({:?})", o.name_unchecked(), o.status.unwrap());
             debug!("Created CRD: {:?}", o.spec);
         }
         Err(kube::Error::Api(ae)) => assert_eq!(ae.code, 409), // if you skipped delete, for instance
@@ -88,8 +88,8 @@ async fn main() -> Result<()> {
         replicas: 1,
     });
     let o = foos.create(&pp, &f1).await?;
-    assert_eq!(ResourceExt::name(&f1), ResourceExt::name(&o));
-    info!("Created {}", o.name());
+    assert_eq!(ResourceExt::name_unchecked(&f1), ResourceExt::name_unchecked(&o));
+    info!("Created {}", o.name_unchecked());
 
     // Verify we can get it
     info!("Get Foo baz");
@@ -128,7 +128,7 @@ async fn main() -> Result<()> {
     f2.status = Some(FooStatus::default());
 
     let o = foos.create(&pp, &f2).await?;
-    info!("Created {}", o.name());
+    info!("Created {}", o.name_unchecked());
 
     // Update status on qux
     info!("Replace Status on Foo instance qux");
@@ -143,7 +143,7 @@ async fn main() -> Result<()> {
         "status": FooStatus { is_bad: true, replicas: 0 }
     });
     let o = foos.replace_status("qux", &pp, serde_json::to_vec(&fs)?).await?;
-    info!("Replaced status {:?} for {}", o.status, o.name());
+    info!("Replaced status {:?} for {}", o.status, o.name_unchecked());
     assert!(o.status.unwrap().is_bad);
 
     info!("Patch Status on Foo instance qux");
@@ -153,12 +153,12 @@ async fn main() -> Result<()> {
     let o = foos
         .patch_status("qux", &patch_params, &Patch::Merge(&fs))
         .await?;
-    info!("Patched status {:?} for {}", o.status, o.name());
+    info!("Patched status {:?} for {}", o.status, o.name_unchecked());
     assert!(!o.status.unwrap().is_bad);
 
     info!("Get Status on Foo instance qux");
     let o = foos.get_status("qux").await?;
-    info!("Got status {:?} for {}", o.status, o.name());
+    info!("Got status {:?} for {}", o.status, o.name_unchecked());
     assert!(!o.status.unwrap().is_bad);
 
     // Check scale subresource:
@@ -172,7 +172,7 @@ async fn main() -> Result<()> {
         "spec": { "replicas": 2 }
     });
     let o = foos.patch_scale("qux", &patch_params, &Patch::Merge(&fs)).await?;
-    info!("Patched scale {:?} for {}", o.spec, o.name());
+    info!("Patched scale {:?} for {}", o.spec, o.name_unchecked());
     assert_eq!(o.status.unwrap().replicas, 1);
     assert_eq!(o.spec.unwrap().replicas.unwrap(), 2); // we only asked for more
 
@@ -182,7 +182,7 @@ async fn main() -> Result<()> {
         "spec": { "info": "patched qux" }
     });
     let o = foos.patch("qux", &patch_params, &Patch::Merge(&patch)).await?;
-    info!("Patched {} with new name: {}", o.name(), o.spec.name);
+    info!("Patched {} with new name: {}", o.name_unchecked(), o.spec.name);
     assert_eq!(o.spec.info, "patched qux");
     assert_eq!(o.spec.name, "qux"); // didn't blat existing params
 
@@ -214,12 +214,12 @@ async fn main() -> Result<()> {
         Err(e) => bail!("somehow got unexpected error from validation: {:?}", e),
         Ok(o) => bail!("somehow created {:?} despite validation", o),
     }
-    info!("Rejected fx for invalid name {}", fx.name());
+    info!("Rejected fx for invalid name {}", fx.name_unchecked());
 
     // Cleanup the full collection - expect a wait
     match foos.delete_collection(&dp, &lp).await? {
         Left(list) => {
-            let deleted: Vec<_> = list.iter().map(ResourceExt::name).collect();
+            let deleted: Vec<_> = list.iter().map(ResourceExt::name_unchecked).collect();
             info!("Deleting collection of foos: {:?}", deleted);
         }
         Right(status) => {
@@ -232,7 +232,7 @@ async fn main() -> Result<()> {
         Left(o) => {
             info!(
                 "Deleting {} CRD definition: {:?}",
-                o.name(),
+                o.name_unchecked(),
                 o.status.unwrap().conditions.unwrap().last()
             );
         }

--- a/examples/crd_apply.rs
+++ b/examples/crd_apply.rs
@@ -61,7 +61,7 @@ async fn main() -> anyhow::Result<()> {
     info!("Applying 1: \n{}", serde_yaml::to_string(&foo)?);
     let o = foos.patch("baz", &ssapply, &Patch::Apply(&foo)).await?;
     // NB: kubernetes < 1.20 will fail to admit scale subresources - see #387
-    info!("Applied 1 {}: {:?}", o.name(), o.spec);
+    info!("Applied 1 {}: {:?}", o.name_unchecked(), o.spec);
 
     // 2. Apply from partial json!
     let patch = serde_json::json!({
@@ -75,7 +75,7 @@ async fn main() -> anyhow::Result<()> {
 
     info!("Applying 2: \n{}", serde_yaml::to_string(&patch)?);
     let o2 = foos.patch("baz", &ssapply, &Patch::Apply(patch)).await?;
-    info!("Applied 2 {}: {:?}", o2.name(), o2.spec);
+    info!("Applied 2 {}: {:?}", o2.name_unchecked(), o2.spec);
 
     Ok(())
 }

--- a/examples/crd_apply.rs
+++ b/examples/crd_apply.rs
@@ -61,7 +61,7 @@ async fn main() -> anyhow::Result<()> {
     info!("Applying 1: \n{}", serde_yaml::to_string(&foo)?);
     let o = foos.patch("baz", &ssapply, &Patch::Apply(&foo)).await?;
     // NB: kubernetes < 1.20 will fail to admit scale subresources - see #387
-    info!("Applied 1 {}: {:?}", o.name_unchecked(), o.spec);
+    info!("Applied 1 {}: {:?}", o.name_any(), o.spec);
 
     // 2. Apply from partial json!
     let patch = serde_json::json!({
@@ -75,7 +75,7 @@ async fn main() -> anyhow::Result<()> {
 
     info!("Applying 2: \n{}", serde_yaml::to_string(&patch)?);
     let o2 = foos.patch("baz", &ssapply, &Patch::Apply(patch)).await?;
-    info!("Applied 2 {}: {:?}", o2.name_unchecked(), o2.spec);
+    info!("Applied 2 {}: {:?}", o2.name_any(), o2.spec);
 
     Ok(())
 }

--- a/examples/crd_reflector.rs
+++ b/examples/crd_reflector.rs
@@ -44,13 +44,17 @@ async fn main() -> anyhow::Result<()> {
             // Periodically read our state
             // while this runs you can kubectl apply -f crd-baz.yaml or crd-qux.yaml and see it works
             tokio::time::sleep(std::time::Duration::from_secs(5)).await;
-            let crds = reader.state().iter().map(|r| r.name()).collect::<Vec<_>>();
+            let crds = reader
+                .state()
+                .iter()
+                .map(|r| r.name_unchecked())
+                .collect::<Vec<_>>();
             info!("Current crds: {:?}", crds);
         }
     });
     let mut rfa = rf.applied_objects().boxed();
     while let Some(event) = rfa.try_next().await? {
-        info!("saw {}", event.name());
+        info!("saw {}", event.name_unchecked());
     }
     Ok(())
 }

--- a/examples/crd_reflector.rs
+++ b/examples/crd_reflector.rs
@@ -44,17 +44,13 @@ async fn main() -> anyhow::Result<()> {
             // Periodically read our state
             // while this runs you can kubectl apply -f crd-baz.yaml or crd-qux.yaml and see it works
             tokio::time::sleep(std::time::Duration::from_secs(5)).await;
-            let crds = reader
-                .state()
-                .iter()
-                .map(|r| r.name_unchecked())
-                .collect::<Vec<_>>();
+            let crds = reader.state().iter().map(|r| r.name_any()).collect::<Vec<_>>();
             info!("Current crds: {:?}", crds);
         }
     });
     let mut rfa = rf.applied_objects().boxed();
     while let Some(event) = rfa.try_next().await? {
-        info!("saw {}", event.name_unchecked());
+        info!("saw {}", event.name_any());
     }
     Ok(())
 }

--- a/examples/custom_client.rs
+++ b/examples/custom_client.rs
@@ -18,7 +18,7 @@ async fn main() -> anyhow::Result<()> {
 
     let pods: Api<Pod> = Api::default_namespaced(client);
     for p in pods.list(&Default::default()).await? {
-        info!("{}", p.name_unchecked());
+        info!("{}", p.name_any());
     }
 
     Ok(())

--- a/examples/custom_client.rs
+++ b/examples/custom_client.rs
@@ -18,7 +18,7 @@ async fn main() -> anyhow::Result<()> {
 
     let pods: Api<Pod> = Api::default_namespaced(client);
     for p in pods.list(&Default::default()).await? {
-        info!("{}", p.name());
+        info!("{}", p.name_unchecked());
     }
 
     Ok(())

--- a/examples/custom_client_tls.rs
+++ b/examples/custom_client_tls.rs
@@ -31,7 +31,7 @@ async fn main() -> anyhow::Result<()> {
 
     let pods: Api<Pod> = Api::default_namespaced(client);
     for p in pods.list(&Default::default()).await? {
-        info!("{}", p.name());
+        info!("{}", p.name_unchecked());
     }
 
     Ok(())

--- a/examples/custom_client_tls.rs
+++ b/examples/custom_client_tls.rs
@@ -31,7 +31,7 @@ async fn main() -> anyhow::Result<()> {
 
     let pods: Api<Pod> = Api::default_namespaced(client);
     for p in pods.list(&Default::default()).await? {
-        info!("{}", p.name_unchecked());
+        info!("{}", p.name_any());
     }
 
     Ok(())

--- a/examples/custom_client_trace.rs
+++ b/examples/custom_client_trace.rs
@@ -55,7 +55,7 @@ async fn main() -> anyhow::Result<()> {
 
     let pods: Api<Pod> = Api::default_namespaced(client);
     for p in pods.list(&Default::default()).await? {
-        info!("{}", p.name());
+        info!("{}", p.name_unchecked());
     }
 
     Ok(())

--- a/examples/custom_client_trace.rs
+++ b/examples/custom_client_trace.rs
@@ -55,7 +55,7 @@ async fn main() -> anyhow::Result<()> {
 
     let pods: Api<Pod> = Api::default_namespaced(client);
     for p in pods.list(&Default::default()).await? {
-        info!("{}", p.name_unchecked());
+        info!("{}", p.name_any());
     }
 
     Ok(())

--- a/examples/dynamic_api.rs
+++ b/examples/dynamic_api.rs
@@ -28,7 +28,7 @@ async fn main() -> anyhow::Result<()> {
 
             let list = api.list(&Default::default()).await?;
             for item in list.items {
-                let name = item.name();
+                let name = item.name_unchecked();
                 let ns = item.metadata.namespace.map(|s| s + "/").unwrap_or_default();
                 info!("\t\t{}{}", ns, name);
             }

--- a/examples/dynamic_api.rs
+++ b/examples/dynamic_api.rs
@@ -28,7 +28,7 @@ async fn main() -> anyhow::Result<()> {
 
             let list = api.list(&Default::default()).await?;
             for item in list.items {
-                let name = item.name_unchecked();
+                let name = item.name_any();
                 let ns = item.metadata.namespace.map(|s| s + "/").unwrap_or_default();
                 info!("\t\t{}{}", ns, name);
             }

--- a/examples/dynamic_pod.rs
+++ b/examples/dynamic_pod.rs
@@ -25,9 +25,9 @@ async fn main() -> anyhow::Result<()> {
     // Here we simply steal the type info from k8s_openapi, but we could create this from scratch.
     let ar = ApiResource::erase::<k8s_openapi::api::core::v1::Pod>(&());
 
-    let pods: Api<PodSimple> = Api::namespaced_with(client, "default", &ar);
+    let pods: Api<PodSimple> = Api::default_namespaced_with(client, &ar);
     for p in pods.list(&Default::default()).await? {
-        info!("Found pod {} running: {:?}", p.name(), p.spec.containers);
+        info!("Pod {} runs: {:?}", p.name_unchecked(), p.spec.containers);
     }
 
     Ok(())

--- a/examples/dynamic_pod.rs
+++ b/examples/dynamic_pod.rs
@@ -27,7 +27,7 @@ async fn main() -> anyhow::Result<()> {
 
     let pods: Api<PodSimple> = Api::default_namespaced_with(client, &ar);
     for p in pods.list(&Default::default()).await? {
-        info!("Pod {} runs: {:?}", p.name_unchecked(), p.spec.containers);
+        info!("Pod {} runs: {:?}", p.name_any(), p.spec.containers);
     }
 
     Ok(())

--- a/examples/dynamic_watcher.rs
+++ b/examples/dynamic_watcher.rs
@@ -31,9 +31,9 @@ async fn main() -> anyhow::Result<()> {
     let mut items = watcher(api, ListParams::default()).applied_objects().boxed();
     while let Some(p) = items.try_next().await? {
         if caps.scope == Scope::Cluster {
-            info!("saw {}", p.name());
+            info!("saw {}", p.name_unchecked());
         } else {
-            info!("saw {} in {}", p.name(), p.namespace().unwrap());
+            info!("saw {} in {}", p.name_unchecked(), p.namespace().unwrap());
         }
     }
     Ok(())

--- a/examples/dynamic_watcher.rs
+++ b/examples/dynamic_watcher.rs
@@ -31,9 +31,9 @@ async fn main() -> anyhow::Result<()> {
     let mut items = watcher(api, ListParams::default()).applied_objects().boxed();
     while let Some(p) = items.try_next().await? {
         if caps.scope == Scope::Cluster {
-            info!("saw {}", p.name_unchecked());
+            info!("saw {}", p.name_any());
         } else {
-            info!("saw {} in {}", p.name_unchecked(), p.namespace().unwrap());
+            info!("saw {} in {}", p.name_any(), p.namespace().unwrap());
         }
     }
     Ok(())

--- a/examples/kubectl.rs
+++ b/examples/kubectl.rs
@@ -89,12 +89,17 @@ impl App {
         match self.output {
             OutputMode::Yaml => println!("{}", serde_yaml::to_string(&result)?),
             OutputMode::Pretty => {
-                // Display style; size colums according to biggest name
-                let max_name = result.iter().map(|x| x.name().len() + 2).max().unwrap_or(63);
+                // Display style; size columns according to longest name
+                let max_name = result
+                    .iter()
+                    .map(|x| x.name_unchecked().len() + 2)
+                    .max()
+                    .unwrap_or(63);
                 println!("{0:<width$} {1:<20}", "NAME", "AGE", width = max_name);
                 for inst in result {
                     let age = format_creation_since(inst.creation_timestamp());
-                    println!("{0:<width$} {1:<20}", inst.name(), age, width = max_name);
+                    let name = inst.name_unchecked();
+                    println!("{0:<width$} {1:<20}", name, age, width = max_name);
                 }
             }
         }
@@ -122,7 +127,7 @@ impl App {
         println!("{0:<width$} {1:<20}", "NAME", "AGE", width = 63);
         while let Some(inst) = stream.try_next().await? {
             let age = format_creation_since(inst.creation_timestamp());
-            println!("{0:<width$} {1:<20}", inst.name(), age, width = 63);
+            println!("{0:<width$} {1:<20}", inst.name_unchecked(), age, width = 63);
         }
         Ok(())
     }
@@ -132,10 +137,10 @@ impl App {
             let mut orig = api.get(n).await?;
             orig.managed_fields_mut().clear(); // hide managed fields
             let input = serde_yaml::to_string(&orig)?;
-            debug!("opening {} in {:?}", orig.name(), edit::get_editor());
+            debug!("opening {} in {:?}", orig.name_unchecked(), edit::get_editor());
             let edited = edit::edit(&input)?;
             if edited != input {
-                info!("updating changed object {}", orig.name());
+                info!("updating changed object {}", orig.name_unchecked());
                 let data: DynamicObject = serde_yaml::from_str(&edited)?;
                 // NB: simplified kubectl constructs a merge-patch of differences
                 api.replace(n, &Default::default(), &data).await?;
@@ -158,7 +163,7 @@ impl App {
             } else {
                 bail!("cannot apply object without valid TypeMeta {:?}", obj);
             };
-            let name = obj.name();
+            let name = obj.name_unchecked();
             if let Some((ar, caps)) = discovery.resolve_gvk(&gvk) {
                 let api = dynamic_api(ar, caps, client.clone(), &self.namespace, false);
                 trace!("Applying {}: \n{}", gvk.kind, serde_yaml::to_string(&obj)?);

--- a/examples/kubectl.rs
+++ b/examples/kubectl.rs
@@ -90,16 +90,11 @@ impl App {
             OutputMode::Yaml => println!("{}", serde_yaml::to_string(&result)?),
             OutputMode::Pretty => {
                 // Display style; size columns according to longest name
-                let max_name = result
-                    .iter()
-                    .map(|x| x.name_unchecked().len() + 2)
-                    .max()
-                    .unwrap_or(63);
+                let max_name = result.iter().map(|x| x.name_any().len() + 2).max().unwrap_or(63);
                 println!("{0:<width$} {1:<20}", "NAME", "AGE", width = max_name);
                 for inst in result {
                     let age = format_creation_since(inst.creation_timestamp());
-                    let name = inst.name_unchecked();
-                    println!("{0:<width$} {1:<20}", name, age, width = max_name);
+                    println!("{0:<width$} {1:<20}", inst.name_any(), age, width = max_name);
                 }
             }
         }
@@ -127,7 +122,7 @@ impl App {
         println!("{0:<width$} {1:<20}", "NAME", "AGE", width = 63);
         while let Some(inst) = stream.try_next().await? {
             let age = format_creation_since(inst.creation_timestamp());
-            println!("{0:<width$} {1:<20}", inst.name_unchecked(), age, width = 63);
+            println!("{0:<width$} {1:<20}", inst.name_any(), age, width = 63);
         }
         Ok(())
     }
@@ -137,10 +132,10 @@ impl App {
             let mut orig = api.get(n).await?;
             orig.managed_fields_mut().clear(); // hide managed fields
             let input = serde_yaml::to_string(&orig)?;
-            debug!("opening {} in {:?}", orig.name_unchecked(), edit::get_editor());
+            debug!("opening {} in {:?}", orig.name_any(), edit::get_editor());
             let edited = edit::edit(&input)?;
             if edited != input {
-                info!("updating changed object {}", orig.name_unchecked());
+                info!("updating changed object {}", orig.name_any());
                 let data: DynamicObject = serde_yaml::from_str(&edited)?;
                 // NB: simplified kubectl constructs a merge-patch of differences
                 api.replace(n, &Default::default(), &data).await?;
@@ -163,7 +158,7 @@ impl App {
             } else {
                 bail!("cannot apply object without valid TypeMeta {:?}", obj);
             };
-            let name = obj.name_unchecked();
+            let name = obj.name_any();
             if let Some((ar, caps)) = discovery.resolve_gvk(&gvk) {
                 let api = dynamic_api(ar, caps, client.clone(), &self.namespace, false);
                 trace!("Applying {}: \n{}", gvk.kind, serde_yaml::to_string(&obj)?);

--- a/examples/multi_watcher.rs
+++ b/examples/multi_watcher.rs
@@ -37,9 +37,9 @@ async fn main() -> anyhow::Result<()> {
     }
     while let Some(o) = combo_stream.try_next().await? {
         match o {
-            Watched::Config(cm) => info!("Got configmap: {}", cm.name_unchecked()),
-            Watched::Deploy(d) => info!("Got deployment: {}", d.name_unchecked()),
-            Watched::Secret(s) => info!("Got secret: {}", s.name_unchecked()),
+            Watched::Config(cm) => info!("Got configmap: {}", cm.name_any()),
+            Watched::Deploy(d) => info!("Got deployment: {}", d.name_any()),
+            Watched::Secret(s) => info!("Got secret: {}", s.name_any()),
         }
     }
     Ok(())

--- a/examples/multi_watcher.rs
+++ b/examples/multi_watcher.rs
@@ -37,9 +37,9 @@ async fn main() -> anyhow::Result<()> {
     }
     while let Some(o) = combo_stream.try_next().await? {
         match o {
-            Watched::Config(cm) => info!("Got configmap: {}", cm.name()),
-            Watched::Deploy(d) => info!("Got deployment: {}", d.name()),
-            Watched::Secret(s) => info!("Got secret: {}", s.name()),
+            Watched::Config(cm) => info!("Got configmap: {}", cm.name_unchecked()),
+            Watched::Deploy(d) => info!("Got deployment: {}", d.name_unchecked()),
+            Watched::Secret(s) => info!("Got secret: {}", s.name_unchecked()),
         }
     }
     Ok(())

--- a/examples/node_reflector.rs
+++ b/examples/node_reflector.rs
@@ -23,11 +23,7 @@ async fn main() -> anyhow::Result<()> {
     // Periodically read our state in the background
     tokio::spawn(async move {
         loop {
-            let nodes = reader
-                .state()
-                .iter()
-                .map(|r| r.name_unchecked())
-                .collect::<Vec<_>>();
+            let nodes = reader.state().iter().map(|r| r.name_any()).collect::<Vec<_>>();
             info!("Current {} nodes: {:?}", nodes.len(), nodes);
             tokio::time::sleep(std::time::Duration::from_secs(10)).await;
         }
@@ -36,7 +32,7 @@ async fn main() -> anyhow::Result<()> {
     // Drain and log applied events from the reflector
     let mut rfa = rf.applied_objects().boxed();
     while let Some(event) = rfa.try_next().await? {
-        info!("saw {}", event.name_unchecked());
+        info!("saw {}", event.name_any());
     }
 
     Ok(())

--- a/examples/node_reflector.rs
+++ b/examples/node_reflector.rs
@@ -23,7 +23,11 @@ async fn main() -> anyhow::Result<()> {
     // Periodically read our state in the background
     tokio::spawn(async move {
         loop {
-            let nodes = reader.state().iter().map(|r| r.name()).collect::<Vec<_>>();
+            let nodes = reader
+                .state()
+                .iter()
+                .map(|r| r.name_unchecked())
+                .collect::<Vec<_>>();
             info!("Current {} nodes: {:?}", nodes.len(), nodes);
             tokio::time::sleep(std::time::Duration::from_secs(10)).await;
         }
@@ -32,7 +36,7 @@ async fn main() -> anyhow::Result<()> {
     // Drain and log applied events from the reflector
     let mut rfa = rf.applied_objects().boxed();
     while let Some(event) = rfa.try_next().await? {
-        info!("saw {}", event.name());
+        info!("saw {}", event.name_unchecked());
     }
 
     Ok(())

--- a/examples/node_watcher.rs
+++ b/examples/node_watcher.rs
@@ -29,7 +29,7 @@ async fn main() -> anyhow::Result<()> {
 
 // A simple node problem detector
 async fn check_for_node_failures(events: &Api<Event>, o: Node) -> anyhow::Result<()> {
-    let name = o.name_unchecked();
+    let name = o.name_any();
     // Nodes often modify a lot - only print broken nodes
     if let Some(true) = o.spec.unwrap().unschedulable {
         let failed = o

--- a/examples/node_watcher.rs
+++ b/examples/node_watcher.rs
@@ -29,7 +29,7 @@ async fn main() -> anyhow::Result<()> {
 
 // A simple node problem detector
 async fn check_for_node_failures(events: &Api<Event>, o: Node) -> anyhow::Result<()> {
-    let name = o.name();
+    let name = o.name_unchecked();
     // Nodes often modify a lot - only print broken nodes
     if let Some(true) = o.spec.unwrap().unschedulable {
         let failed = o

--- a/examples/pod_api.rs
+++ b/examples/pod_api.rs
@@ -33,8 +33,8 @@ async fn main() -> anyhow::Result<()> {
     let pp = PostParams::default();
     match pods.create(&pp, &p).await {
         Ok(o) => {
-            let name = o.name();
-            assert_eq!(p.name(), name);
+            let name = o.name_unchecked();
+            assert_eq!(p.name_unchecked(), name);
             info!("Created {}", name);
         }
         Err(kube::Error::Api(ae)) => assert_eq!(ae.code, 409), // if you skipped delete, for instance
@@ -69,13 +69,13 @@ async fn main() -> anyhow::Result<()> {
 
     let lp = ListParams::default().fields(&format!("metadata.name={}", "blog")); // only want results for our pod
     for p in pods.list(&lp).await? {
-        info!("Found Pod: {}", p.name());
+        info!("Found Pod: {}", p.name_unchecked());
     }
 
     // Delete it
     let dp = DeleteParams::default();
     pods.delete("blog", &dp).await?.map_left(|pdel| {
-        assert_eq!(pdel.name(), "blog");
+        assert_eq!(pdel.name_unchecked(), "blog");
         info!("Deleting blog pod started: {:?}", pdel);
     });
 

--- a/examples/pod_api.rs
+++ b/examples/pod_api.rs
@@ -33,8 +33,8 @@ async fn main() -> anyhow::Result<()> {
     let pp = PostParams::default();
     match pods.create(&pp, &p).await {
         Ok(o) => {
-            let name = o.name_unchecked();
-            assert_eq!(p.name_unchecked(), name);
+            let name = o.name_any();
+            assert_eq!(p.name_any(), name);
             info!("Created {}", name);
         }
         Err(kube::Error::Api(ae)) => assert_eq!(ae.code, 409), // if you skipped delete, for instance
@@ -69,13 +69,13 @@ async fn main() -> anyhow::Result<()> {
 
     let lp = ListParams::default().fields(&format!("metadata.name={}", "blog")); // only want results for our pod
     for p in pods.list(&lp).await? {
-        info!("Found Pod: {}", p.name_unchecked());
+        info!("Found Pod: {}", p.name_any());
     }
 
     // Delete it
     let dp = DeleteParams::default();
     pods.delete("blog", &dp).await?.map_left(|pdel| {
-        assert_eq!(pdel.name_unchecked(), "blog");
+        assert_eq!(pdel.name_any(), "blog");
         info!("Deleting blog pod started: {:?}", pdel);
     });
 

--- a/examples/pod_attach.rs
+++ b/examples/pod_attach.rs
@@ -40,12 +40,12 @@ async fn main() -> anyhow::Result<()> {
     while let Some(status) = stream.try_next().await? {
         match status {
             WatchEvent::Added(o) => {
-                info!("Added {}", o.name());
+                info!("Added {}", o.name_unchecked());
             }
             WatchEvent::Modified(o) => {
                 let s = o.status.as_ref().expect("status exists on pod");
                 if s.phase.clone().unwrap_or_default() == "Running" {
-                    info!("Ready to attach to {}", o.name());
+                    info!("Ready to attach to {}", o.name_unchecked());
                     break;
                 }
             }
@@ -65,7 +65,7 @@ async fn main() -> anyhow::Result<()> {
     pods.delete("example", &DeleteParams::default())
         .await?
         .map_left(|pdel| {
-            assert_eq!(pdel.name(), "example");
+            assert_eq!(pdel.name_unchecked(), "example");
         });
 
     Ok(())

--- a/examples/pod_attach.rs
+++ b/examples/pod_attach.rs
@@ -40,12 +40,12 @@ async fn main() -> anyhow::Result<()> {
     while let Some(status) = stream.try_next().await? {
         match status {
             WatchEvent::Added(o) => {
-                info!("Added {}", o.name_unchecked());
+                info!("Added {}", o.name_any());
             }
             WatchEvent::Modified(o) => {
                 let s = o.status.as_ref().expect("status exists on pod");
                 if s.phase.clone().unwrap_or_default() == "Running" {
-                    info!("Ready to attach to {}", o.name_unchecked());
+                    info!("Ready to attach to {}", o.name_any());
                     break;
                 }
             }
@@ -65,7 +65,7 @@ async fn main() -> anyhow::Result<()> {
     pods.delete("example", &DeleteParams::default())
         .await?
         .map_left(|pdel| {
-            assert_eq!(pdel.name_unchecked(), "example");
+            assert_eq!(pdel.name_any(), "example");
         });
 
     Ok(())

--- a/examples/pod_cp.rs
+++ b/examples/pod_cp.rs
@@ -39,12 +39,12 @@ async fn main() -> anyhow::Result<()> {
     while let Some(status) = stream.try_next().await? {
         match status {
             WatchEvent::Added(o) => {
-                info!("Added {}", o.name_unchecked());
+                info!("Added {}", o.name_any());
             }
             WatchEvent::Modified(o) => {
                 let s = o.status.as_ref().expect("status exists on pod");
                 if s.phase.clone().unwrap_or_default() == "Running" {
-                    info!("Ready to attach to {}", o.name_unchecked());
+                    info!("Ready to attach to {}", o.name_any());
                     break;
                 }
             }
@@ -90,7 +90,7 @@ async fn main() -> anyhow::Result<()> {
     pods.delete("example", &DeleteParams::default())
         .await?
         .map_left(|pdel| {
-            assert_eq!(pdel.name_unchecked(), "example");
+            assert_eq!(pdel.name_any(), "example");
         });
 
     Ok(())

--- a/examples/pod_cp.rs
+++ b/examples/pod_cp.rs
@@ -39,12 +39,12 @@ async fn main() -> anyhow::Result<()> {
     while let Some(status) = stream.try_next().await? {
         match status {
             WatchEvent::Added(o) => {
-                info!("Added {}", o.name());
+                info!("Added {}", o.name_unchecked());
             }
             WatchEvent::Modified(o) => {
                 let s = o.status.as_ref().expect("status exists on pod");
                 if s.phase.clone().unwrap_or_default() == "Running" {
-                    info!("Ready to attach to {}", o.name());
+                    info!("Ready to attach to {}", o.name_unchecked());
                     break;
                 }
             }
@@ -90,7 +90,7 @@ async fn main() -> anyhow::Result<()> {
     pods.delete("example", &DeleteParams::default())
         .await?
         .map_left(|pdel| {
-            assert_eq!(pdel.name(), "example");
+            assert_eq!(pdel.name_unchecked(), "example");
         });
 
     Ok(())

--- a/examples/pod_evict.rs
+++ b/examples/pod_evict.rs
@@ -42,12 +42,12 @@ async fn main() -> anyhow::Result<()> {
     while let Some(status) = stream.try_next().await? {
         match status {
             WatchEvent::Added(o) => {
-                info!("Added {}", o.name_unchecked());
+                info!("Added {}", o.name_any());
             }
             WatchEvent::Modified(o) => {
                 let s = o.status.as_ref().expect("status exists on pod");
                 if s.phase.clone().unwrap_or_default() == "Running" {
-                    info!("Ready to evict to {}", o.name_unchecked());
+                    info!("Ready to evict to {}", o.name_any());
                     break;
                 }
             }

--- a/examples/pod_evict.rs
+++ b/examples/pod_evict.rs
@@ -42,12 +42,12 @@ async fn main() -> anyhow::Result<()> {
     while let Some(status) = stream.try_next().await? {
         match status {
             WatchEvent::Added(o) => {
-                info!("Added {}", o.name());
+                info!("Added {}", o.name_unchecked());
             }
             WatchEvent::Modified(o) => {
                 let s = o.status.as_ref().expect("status exists on pod");
                 if s.phase.clone().unwrap_or_default() == "Running" {
-                    info!("Ready to evict to {}", o.name());
+                    info!("Ready to evict to {}", o.name_unchecked());
                     break;
                 }
             }

--- a/examples/pod_exec.rs
+++ b/examples/pod_exec.rs
@@ -39,12 +39,12 @@ async fn main() -> anyhow::Result<()> {
     while let Some(status) = stream.try_next().await? {
         match status {
             WatchEvent::Added(o) => {
-                info!("Added {}", o.name_unchecked());
+                info!("Added {}", o.name_any());
             }
             WatchEvent::Modified(o) => {
                 let s = o.status.as_ref().expect("status exists on pod");
                 if s.phase.clone().unwrap_or_default() == "Running" {
-                    info!("Ready to attach to {}", o.name_unchecked());
+                    info!("Ready to attach to {}", o.name_any());
                     break;
                 }
             }
@@ -107,7 +107,7 @@ async fn main() -> anyhow::Result<()> {
     pods.delete("example", &DeleteParams::default())
         .await?
         .map_left(|pdel| {
-            assert_eq!(pdel.name_unchecked(), "example");
+            assert_eq!(pdel.name_any(), "example");
         });
 
     Ok(())

--- a/examples/pod_exec.rs
+++ b/examples/pod_exec.rs
@@ -39,12 +39,12 @@ async fn main() -> anyhow::Result<()> {
     while let Some(status) = stream.try_next().await? {
         match status {
             WatchEvent::Added(o) => {
-                info!("Added {}", o.name());
+                info!("Added {}", o.name_unchecked());
             }
             WatchEvent::Modified(o) => {
                 let s = o.status.as_ref().expect("status exists on pod");
                 if s.phase.clone().unwrap_or_default() == "Running" {
-                    info!("Ready to attach to {}", o.name());
+                    info!("Ready to attach to {}", o.name_unchecked());
                     break;
                 }
             }
@@ -107,7 +107,7 @@ async fn main() -> anyhow::Result<()> {
     pods.delete("example", &DeleteParams::default())
         .await?
         .map_left(|pdel| {
-            assert_eq!(pdel.name(), "example");
+            assert_eq!(pdel.name_unchecked(), "example");
         });
 
     Ok(())

--- a/examples/pod_portforward.rs
+++ b/examples/pod_portforward.rs
@@ -56,7 +56,7 @@ async fn main() -> anyhow::Result<()> {
     pods.delete("example", &DeleteParams::default())
         .await?
         .map_left(|pdel| {
-            assert_eq!(pdel.name(), "example");
+            assert_eq!(pdel.name_unchecked(), "example");
         });
 
     Ok(())

--- a/examples/pod_portforward.rs
+++ b/examples/pod_portforward.rs
@@ -56,7 +56,7 @@ async fn main() -> anyhow::Result<()> {
     pods.delete("example", &DeleteParams::default())
         .await?
         .map_left(|pdel| {
-            assert_eq!(pdel.name_unchecked(), "example");
+            assert_eq!(pdel.name_any(), "example");
         });
 
     Ok(())

--- a/examples/pod_portforward_bind.rs
+++ b/examples/pod_portforward_bind.rs
@@ -94,7 +94,7 @@ async fn main() -> anyhow::Result<()> {
     pods.delete("example", &DeleteParams::default())
         .await?
         .map_left(|pdel| {
-            assert_eq!(pdel.name(), "example");
+            assert_eq!(pdel.name_unchecked(), "example");
         });
 
     Ok(())

--- a/examples/pod_portforward_bind.rs
+++ b/examples/pod_portforward_bind.rs
@@ -94,7 +94,7 @@ async fn main() -> anyhow::Result<()> {
     pods.delete("example", &DeleteParams::default())
         .await?
         .map_left(|pdel| {
-            assert_eq!(pdel.name_unchecked(), "example");
+            assert_eq!(pdel.name_any(), "example");
         });
 
     Ok(())

--- a/examples/pod_portforward_hyper_http.rs
+++ b/examples/pod_portforward_hyper_http.rs
@@ -64,7 +64,7 @@ async fn main() -> anyhow::Result<()> {
     pods.delete("example", &DeleteParams::default())
         .await?
         .map_left(|pdel| {
-            assert_eq!(pdel.name_unchecked(), "example");
+            assert_eq!(pdel.name_any(), "example");
         });
 
     Ok(())

--- a/examples/pod_portforward_hyper_http.rs
+++ b/examples/pod_portforward_hyper_http.rs
@@ -64,7 +64,7 @@ async fn main() -> anyhow::Result<()> {
     pods.delete("example", &DeleteParams::default())
         .await?
         .map_left(|pdel| {
-            assert_eq!(pdel.name(), "example");
+            assert_eq!(pdel.name_unchecked(), "example");
         });
 
     Ok(())

--- a/examples/pod_reflector.rs
+++ b/examples/pod_reflector.rs
@@ -23,7 +23,7 @@ async fn main() -> anyhow::Result<()> {
             // full information with debug logs
             for p in reader.state() {
                 let yaml = serde_yaml::to_string(p.as_ref()).unwrap();
-                debug!("Pod {}: \n{}", p.name(), yaml);
+                debug!("Pod {}: \n{}", p.name_unchecked(), yaml);
             }
         }
     });
@@ -41,7 +41,7 @@ async fn main() -> anyhow::Result<()> {
     futures::pin_mut!(rf);
 
     while let Some(pod) = rf.try_next().await? {
-        info!("saw {}", pod.name());
+        info!("saw {}", pod.name_unchecked());
     }
     Ok(())
 }

--- a/examples/pod_reflector.rs
+++ b/examples/pod_reflector.rs
@@ -23,7 +23,7 @@ async fn main() -> anyhow::Result<()> {
             // full information with debug logs
             for p in reader.state() {
                 let yaml = serde_yaml::to_string(p.as_ref()).unwrap();
-                debug!("Pod {}: \n{}", p.name_unchecked(), yaml);
+                debug!("Pod {}: \n{}", p.name_any(), yaml);
             }
         }
     });
@@ -41,7 +41,7 @@ async fn main() -> anyhow::Result<()> {
     futures::pin_mut!(rf);
 
     while let Some(pod) = rf.try_next().await? {
-        info!("saw {}", pod.name_unchecked());
+        info!("saw {}", pod.name_any());
     }
     Ok(())
 }

--- a/examples/pod_shell.rs
+++ b/examples/pod_shell.rs
@@ -36,12 +36,12 @@ async fn main() -> anyhow::Result<()> {
     while let Some(status) = stream.try_next().await? {
         match status {
             WatchEvent::Added(o) => {
-                info!("Added {}", o.name());
+                info!("Added {}", o.name_unchecked());
             }
             WatchEvent::Modified(o) => {
                 let s = o.status.as_ref().expect("status exists on pod");
                 if s.phase.clone().unwrap_or_default() == "Running" {
-                    info!("Ready to attach to {}", o.name());
+                    info!("Ready to attach to {}", o.name_unchecked());
                     break;
                 }
             }
@@ -78,7 +78,7 @@ async fn main() -> anyhow::Result<()> {
     pods.delete("example", &DeleteParams::default())
         .await?
         .map_left(|pdel| {
-            assert_eq!(pdel.name(), "example");
+            assert_eq!(pdel.name_unchecked(), "example");
         });
 
     Ok(())

--- a/examples/pod_shell.rs
+++ b/examples/pod_shell.rs
@@ -36,12 +36,12 @@ async fn main() -> anyhow::Result<()> {
     while let Some(status) = stream.try_next().await? {
         match status {
             WatchEvent::Added(o) => {
-                info!("Added {}", o.name_unchecked());
+                info!("Added {}", o.name_any());
             }
             WatchEvent::Modified(o) => {
                 let s = o.status.as_ref().expect("status exists on pod");
                 if s.phase.clone().unwrap_or_default() == "Running" {
-                    info!("Ready to attach to {}", o.name_unchecked());
+                    info!("Ready to attach to {}", o.name_any());
                     break;
                 }
             }
@@ -78,7 +78,7 @@ async fn main() -> anyhow::Result<()> {
     pods.delete("example", &DeleteParams::default())
         .await?
         .map_left(|pdel| {
-            assert_eq!(pdel.name_unchecked(), "example");
+            assert_eq!(pdel.name_any(), "example");
         });
 
     Ok(())

--- a/examples/pod_watcher.rs
+++ b/examples/pod_watcher.rs
@@ -16,7 +16,7 @@ async fn main() -> anyhow::Result<()> {
     watcher(api, ListParams::default())
         .applied_objects()
         .try_for_each(|p| async move {
-            info!("saw {}", p.name());
+            info!("saw {}", p.name_unchecked());
             if let Some(unready_reason) = pod_unready(&p) {
                 warn!("{}", unready_reason);
             }
@@ -39,7 +39,7 @@ fn pod_unready(p: &Pod) -> Option<String> {
             if p.metadata.labels.as_ref().unwrap().contains_key("job-name") {
                 return None; // ignore job based pods, they are meant to exit 0
             }
-            return Some(format!("Unready pod {}: {}", p.name(), failed));
+            return Some(format!("Unready pod {}: {}", p.name_unchecked(), failed));
         }
     }
     None

--- a/examples/pod_watcher.rs
+++ b/examples/pod_watcher.rs
@@ -16,7 +16,7 @@ async fn main() -> anyhow::Result<()> {
     watcher(api, ListParams::default())
         .applied_objects()
         .try_for_each(|p| async move {
-            info!("saw {}", p.name_unchecked());
+            info!("saw {}", p.name_any());
             if let Some(unready_reason) = pod_unready(&p) {
                 warn!("{}", unready_reason);
             }
@@ -39,7 +39,7 @@ fn pod_unready(p: &Pod) -> Option<String> {
             if p.metadata.labels.as_ref().unwrap().contains_key("job-name") {
                 return None; // ignore job based pods, they are meant to exit 0
             }
-            return Some(format!("Unready pod {}: {}", p.name_unchecked(), failed));
+            return Some(format!("Unready pod {}: {}", p.name_any(), failed));
         }
     }
     None

--- a/examples/secret_reflector.rs
+++ b/examples/secret_reflector.rs
@@ -39,7 +39,7 @@ fn spawn_periodic_reader(reader: Store<Secret>) {
             let cms: Vec<_> = reader
                 .state()
                 .iter()
-                .map(|s| format!("{}: {:?}", s.name(), decode(s).keys()))
+                .map(|s| format!("{}: {:?}", s.name_unchecked(), decode(s).keys()))
                 .collect();
             info!("Current secrets: {:?}", cms);
             tokio::time::sleep(std::time::Duration::from_secs(15)).await;
@@ -62,7 +62,7 @@ async fn main() -> anyhow::Result<()> {
 
     rf.applied_objects()
         .try_for_each(|s| async move {
-            info!("saw: {}", s.name());
+            info!("saw: {}", s.name_unchecked());
             Ok(())
         })
         .await?;

--- a/examples/secret_reflector.rs
+++ b/examples/secret_reflector.rs
@@ -39,7 +39,7 @@ fn spawn_periodic_reader(reader: Store<Secret>) {
             let cms: Vec<_> = reader
                 .state()
                 .iter()
-                .map(|s| format!("{}: {:?}", s.name_unchecked(), decode(s).keys()))
+                .map(|s| format!("{}: {:?}", s.name_any(), decode(s).keys()))
                 .collect();
             info!("Current secrets: {:?}", cms);
             tokio::time::sleep(std::time::Duration::from_secs(15)).await;
@@ -62,7 +62,7 @@ async fn main() -> anyhow::Result<()> {
 
     rf.applied_objects()
         .try_for_each(|s| async move {
-            info!("saw: {}", s.name_unchecked());
+            info!("saw: {}", s.name_any());
             Ok(())
         })
         .await?;

--- a/kube-core/src/admission.rs
+++ b/kube-core/src/admission.rs
@@ -174,7 +174,7 @@ pub struct AdmissionRequest<T: Resource> {
 }
 
 /// The operation specified in an [`AdmissionRequest`].
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum Operation {
     /// An operation that creates a resource.
@@ -329,7 +329,7 @@ impl AdmissionResponse {
 }
 
 /// The type of patch returned in an [`AdmissionResponse`].
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub enum PatchType {
     /// Specifies the patch body implements JSON Patch under RFC 6902.
     #[serde(rename = "JSONPatch")]

--- a/kube-core/src/params.rs
+++ b/kube-core/src/params.rs
@@ -164,7 +164,7 @@ pub enum ValidationDirective {
 
 impl ValidationDirective {
     /// Returns the string format of the directive
-    pub fn as_str(self: &Self) -> &str {
+    pub fn as_str(&self) -> &str {
         match self {
             Self::Strict => "Strict",
             Self::Warn => "Warn",

--- a/kube-core/src/resource.rs
+++ b/kube-core/src/resource.rs
@@ -145,7 +145,7 @@ pub trait ResourceExt: Resource {
     /// Deprecated fn equivalent to [`name_unchecked`](ResourceExt::name_unchecked)
     #[deprecated(
         since = "0.74.0",
-        note = "ResourceExt::name can panic and has been replaced by ResourceExt::name_any and ResourceExt::name_unchecked. This fn will be removed in 0.77.0."
+        note = "ResourceExt::name can panic and has been replaced by `ResourceExt::name_any` and `ResourceExt::name_unchecked`. This fn will be removed in 0.77.0."
     )]
     fn name(&self) -> String;
 
@@ -164,7 +164,8 @@ pub trait ResourceExt: Resource {
 
     /// Returns the most useful name identifier available
     ///
-    /// This is equivalent  [`name_or`](ResourceExt::name_or) with an empty string as a fallback.
+    /// This is tries `name`, then `generateName`, and falls back on an empty string when neither is set.
+    /// Generally you always have one of the two unless you are creating the object locally.
     ///
     /// This is intended to provide something quick and simple for standard logging purposes.
     /// For more precise use cases, prefer doing your own defaulting.

--- a/kube-core/src/resource.rs
+++ b/kube-core/src/resource.rs
@@ -144,8 +144,8 @@ where
 pub trait ResourceExt: Resource {
     /// Deprecated fn equivalent to [`name_unchecked`](ResourceExt::name_unchecked)
     #[deprecated(
-        since = "0.73.0",
-        note = "ResourceExt::name can panic and has been replaced by ::name_any + ::name_unchecked + ::name_or_generatename. This fn will be removed in 0.76.0."
+        since = "0.74.0",
+        note = "ResourceExt::name can panic and has been replaced by ::name_any + ::name_unchecked + ::name_or_generatename. This fn will be removed in 0.77.0."
     )]
     fn name(&self) -> String;
 

--- a/kube-core/src/resource.rs
+++ b/kube-core/src/resource.rs
@@ -142,30 +142,23 @@ where
 
 /// Helper methods for resources.
 pub trait ResourceExt: Resource {
-    /// Returns the name of the resource, panicking if it is
-    /// missing. Use this function if you know that name is set, for example
-    /// when resource was received from the apiserver.
-    /// Because of `.metadata.generateName` field, in other contexts name
-    /// may be missing.
-    ///
-    /// For non-panicking alternative, you can directly read `name` field
-    /// on the `self.meta()`.
+    /// Deprecated duplicate of [`name_unchecked`](ResourceExt::name_unchecked)
     #[deprecated(
         since = "0.73.0",
-        note = "ResourceExt::name can panic and has been replaced by ::name_unchecked, ::name_or_generatename or meta().name"
+        note = "ResourceExt::name can panic and has been replaced by ::name_unchecked, ::name_or_generatename and meta().name"
     )]
     fn name(&self) -> String;
 
     /// Returns the name of the resource, panicking if it is unset.
     ///
-    /// Only use this function if you know that name is set, for example when
-    /// the resource was received from the apiserver, or you constructed the resource.
+    /// Only use this function if you know that name is set; for example when
+    /// the resource was received from the apiserver (outside of admission),
+    /// or you constructed the resource.
     ///
-    /// Im some contexts `.metadata.generateName` is set instead of name,
-    /// such as for admission controllers.
+    /// Before admission, `.metadata.generateName` can be set instead of name
+    /// and in those cases this function can panic.
     ///
-    /// For non-panicking alternative, you can directly read `name` field
-    /// on the `self.meta()`.
+    /// Prefer using `.meta().name` or [`name_or_generatename()`](ResourceExt::name_or_generatename) for the more general cases.
     fn name_unchecked(&self) -> String;
 
     /// Returns the name or generateName of a resource

--- a/kube-runtime/src/reflector/object_ref.rs
+++ b/kube-runtime/src/reflector/object_ref.rs
@@ -113,7 +113,7 @@ impl<K: Resource> ObjectRef<K> {
         let meta = obj.meta();
         Self {
             dyntype,
-            name: obj.name(),
+            name: obj.name_unchecked(),
             namespace: meta.namespace.clone(),
             extra: Extra::from_obj_meta(meta),
         }


### PR DESCRIPTION
Due to the general awkwardness of having a potentially panicking `::name()` method front and center even though it is generally safe to use. See #634 for initial discussion, and #942 for the most recent confusion.

This adds:

- `ResourceExt::name_any` providing a short & safe drop-in replacement for `name()` (can return empty string) for loggers
- `ResourceExt::name_unchecked` where we explicitly want a crash on missing name (like [internally in runtime::reflector](https://github.com/kube-rs/kube-rs/blob/d8f2f61f27404151fd3342dbe052e322e47744ce/kube-runtime/src/reflector/object_ref.rs#L107-L120)) 

Now the relevant docs from `ResourceExt` looks like:

![Screenshot from 2022-07-02 15-34-41](https://user-images.githubusercontent.com/134092/177005103-9cf826c6-6330-42a0-92c1-77359fcb581d.png)


Then ran a lot of `fastmod` to replace in the codebase. Have set the removal of ::name to the deprecation length we used for [runtime's try_flattens](https://github.com/kube-rs/kube-rs/blob/9f1df5e7c0b1fc92d3f7d883445c25bffd245375/kube-runtime/src/utils/mod.rs#L30-L33); removing on the 4th minor.

## Plan

Long term we can remove `.name()` and maybe reintroduce it later as an option shorthand for `.meta().name` instead.

<details><summary>edited out comments</summary>
<p>

It is also possible we can make `::name` a non-panicing variant:
```rust
self.name.unwrap_or_else(||self.generateName).unwrap_or("<unknown>")
```
Not sure if this is wise. But it would be nice to have something short for all the standard log gunk where this stuff is inevitably used most of the time.

**EDIT**: this is added under `::name_any`

EDIT: removed`ResourceExt::name_or_generatename`.
</p>
</details>
