### PR TITLE
docs: clarify that is_crd_stablished does not imply discovery done

### DIFF
--- a/kube-runtime/src/wait.rs
+++ b/kube-runtime/src/wait.rs
@@ -184,6 +184,9 @@ pub mod conditions {
     }
 
     /// An await condition for `CustomResourceDefinition` that returns `true` once it has been accepted and established
+    ///
+    /// Note that this condition only guarantees you that you can use `Api<CustomResourceDefinition>` when it is ready.
+    /// It usually takes extra time for Discovery to notice the custom resource, and there is no condition for this.
     #[must_use]
     pub fn is_crd_established() -> impl Condition<CustomResourceDefinition> {
         |obj: Option<&CustomResourceDefinition>| {


### PR DESCRIPTION
quick docs clarification as a result of https://github.com/kube-rs/kube-rs/pull/924#issuecomment-1146833752

kubernetes [does not rely on established](https://github.com/kubernetes/kubernetes/blob/eb37a5d9c163ee979194be3d32027fb430faa21a/test/integration/etcd/server.go#L344-L359) when using discovery themselves so we should clarify that to avoid others footgunning themselves.

(currently healing my own feet)