### PR TITLE
Decouple port forwarding example from HTTP protocol

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -52,6 +52,7 @@ thiserror = "1.0.29"
 backoff = "0.4.0"
 clap = { version = "3.1.9", default-features = false, features = ["std", "cargo", "derive"] }
 edit = "0.1.3"
+tokio-stream = { version = "0.1.9", features = ["net"] }
 
 [[example]]
 name = "configmapgen_controller"


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation

This makes the example more useful for tunneling other protocols (such as HTTPS) and brings us closer to `kubectl port-forward`.

See https://discord.com/channels/500028886025895936/685161813675212899/993971906342572072

This also changes to a port-forward-per-connection model (like kubectl), since we would otherwise fail if the upstream closed their connection for some reason (see https://discord.com/channels/500028886025895936/993971906342572072/996729897059876864).

<!--
Explain the context and why you're making that change. What is the problem you're trying to solve?
If a new feature is being added, describe the intended use case that feature fulfills.
-->

## Solution

Run a "raw" TCP server and forward those connections byte-for-byte rather than having `hyper` copy each HTTP request.

<!--
Summarize the solution and provide any necessary context needed to understand the code change.
-->
