### PR TITLE
Constrain Resource trait and Api::namespaced by Scope

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -41,9 +41,18 @@ allow = [
     "BSD-3-Clause",
     "ISC",
     "LicenseRef-ring",
-    "LicenseRef-webpki"
+    "LicenseRef-webpki",
 ]
 
+exceptions = [
+    # The Unicode-DFS--2016 license is necessary for unicode-ident because they
+    # use data from the unicode tables to generate the tables which are
+    # included in the application. We do not distribute those data files so
+    # this is not a problem for us. See https://github.com/dtolnay/unicode-ident/pull/9/files
+    # for more details.
+    { allow = ["Unicode-DFS-2016"], name = "unicode-ident" }
+
+]
 
 [[licenses.clarify]]
 name = "ring"
@@ -52,13 +61,13 @@ license-files = [
     { path = "LICENSE", hash = 0xbd0eed23 },
 ]
 
+
 [[licenses.clarify]]
 name = "webpki"
 expression = "LicenseRef-webpki"
 license-files = [
     { path = "LICENSE", hash = 0x001c7e6c },
 ]
-
 
 [sources]
 unknown-registry = "deny"

--- a/kube-client/src/api/mod.rs
+++ b/kube-client/src/api/mod.rs
@@ -127,11 +127,47 @@ where
     <K as Resource>::DynamicType: Default,
 {
     /// Cluster level resources, or resources viewed across all namespaces
+    ///
+    /// Namespace scoped resource allowing querying across all namespaces:
+    ///
+    /// ```no_run
+    /// # use kube::{Api, Client};
+    /// # let client: Client = todo!();
+    /// use k8s_openapi::api::core::v1::Pod;
+    /// let api: Api<Pod> = Api::all(client);
+    /// ```
+    ///
+    /// Cluster scoped resources also use this entrypoint:
+    ///
+    /// ```no_run
+    /// # use kube::{Api, Client};
+    /// # let client: Client = todo!();
+    /// use k8s_openapi::api::core::v1::Node;
+    /// let api: Api<Node> = Api::all(client);
+    /// ```
     pub fn all(client: Client) -> Self {
         Self::all_with(client, &K::DynamicType::default())
     }
 
     /// Namespaced resource within a given namespace
+    ///
+    /// ```no_run
+    /// # use kube::{Api, Client};
+    /// # let client: Client = todo!();
+    /// use k8s_openapi::api::core::v1::Pod;
+    /// let api: Api<Pod> = Api::namespaced(client, "default");
+    /// ```
+    ///
+    /// This will ONLY work on namespaced resources as set by `Scope`:
+    ///
+    /// ```compile_fail
+    /// # use kube::{Api, Client};
+    /// # let client: Client = todo!();
+    /// use k8s_openapi::api::core::v1::Node;
+    /// let api: Api<Node> = Api::namespaced(client, "default"); // resource not namespaced!
+    /// ```
+    ///
+    /// For dynamic type information, use [`Api::namespaced_with`] variants.
     pub fn namespaced(client: Client, ns: &str) -> Self
     where
         K: Resource<Scope = NamespaceResourceScope>,
@@ -150,6 +186,22 @@ where
     ///
     /// Unless configured explicitly, the default namespace is either "default"
     /// out of cluster, or the service account's namespace in cluster.
+    ///
+    /// ```no_run
+    /// # use kube::{Api, Client};
+    /// # let client: Client = todo!();
+    /// use k8s_openapi::api::core::v1::Pod;
+    /// let api: Api<Pod> = Api::default_namespaced(client);
+    /// ```
+    ///
+    /// This will ONLY work on namespaced resources as set by `Scope`:
+    ///
+    /// ```compile_fail
+    /// # use kube::{Api, Client};
+    /// # let client: Client = todo!();
+    /// use k8s_openapi::api::core::v1::Node;
+    /// let api: Api<Node> = Api::default_namespaced(client); // resource not namespaced!
+    /// ```
     pub fn default_namespaced(client: Client) -> Self
     where
         K: Resource<Scope = NamespaceResourceScope>,

--- a/kube-client/src/api/mod.rs
+++ b/kube-client/src/api/mod.rs
@@ -181,3 +181,25 @@ impl<K> Debug for Api<K> {
             .finish()
     }
 }
+
+/// Sanity test on scope restrictions
+#[cfg(test)]
+mod test {
+    use crate::{Api, Client};
+    use k8s_openapi::api::core::v1 as corev1;
+
+    use http::{Request, Response};
+    use hyper::Body;
+    use tower_test::mock;
+
+    #[tokio::test]
+    async fn scopes_should_allow_correct_interface() {
+        let (mock_service, _handle) = mock::pair::<Request<Body>, Response<Body>>();
+        let client = Client::new(mock_service, "default");
+
+        let _: Api<corev1::Node> = Api::all(client.clone());
+        let _: Api<corev1::Pod> = Api::default_namespaced(client.clone());
+        let _: Api<corev1::PersistentVolume> = Api::all(client.clone());
+        let _: Api<corev1::ConfigMap> = Api::namespaced(client.clone(), "default");
+    }
+}

--- a/kube-client/src/api/mod.rs
+++ b/kube-client/src/api/mod.rs
@@ -33,7 +33,7 @@ pub use kube_core::{
     watch::WatchEvent,
     Resource, ResourceExt,
 };
-use kube_core::{DynamicScope, NamespaceResourceScope};
+use kube_core::{DynamicResourceScope, NamespaceResourceScope};
 pub use params::{
     DeleteParams, ListParams, Patch, PatchParams, PostParams, Preconditions, PropagationPolicy,
     ValidationDirective,
@@ -81,7 +81,7 @@ impl<K: Resource> Api<K> {
     /// This function accepts `K::DynamicType` so it can be used with dynamic resources.
     pub fn namespaced_with(client: Client, ns: &str, dyntype: &K::DynamicType) -> Self
     where
-        K: Resource<Scope = DynamicScope>,
+        K: Resource<Scope = DynamicResourceScope>,
     {
         // TODO: inspect dyntype scope to verify somehow?
         let url = K::url_path(dyntype, Some(ns));
@@ -102,7 +102,7 @@ impl<K: Resource> Api<K> {
     /// namespace when deployed in-cluster.
     pub fn default_namespaced_with(client: Client, dyntype: &K::DynamicType) -> Self
     where
-        K: Resource<Scope = DynamicScope>,
+        K: Resource<Scope = DynamicResourceScope>,
     {
         let ns = client.default_ns().to_string();
         Self::namespaced_with(client, &ns, dyntype)

--- a/kube-client/src/api/mod.rs
+++ b/kube-client/src/api/mod.rs
@@ -97,8 +97,9 @@ impl<K: Resource> Api<K> {
     ///
     /// This function accepts `K::DynamicType` so it can be used with dynamic resources.
     ///
-    /// Unless configured explicitly, the default namespace is either "default"
-    /// out of cluster, or the service account's namespace in cluster.
+    /// The namespace is either configured on `context` in the kubeconfig
+    /// or falls back to `default` when running locally, and it's using the service account's
+    /// namespace when deployed in-cluster.
     pub fn default_namespaced_with(client: Client, dyntype: &K::DynamicType) -> Self
     where
         K: Resource<Scope = DynamicScope>,
@@ -184,8 +185,9 @@ where
 
     /// Namespaced resource within the default namespace
     ///
-    /// Unless configured explicitly, the default namespace is either "default"
-    /// out of cluster, or the service account's namespace in cluster.
+    /// The namespace is either configured on `context` in the kubeconfig
+    /// or falls back to `default` when running locally, and it's using the service account's
+    /// namespace when deployed in-cluster.
     ///
     /// ```no_run
     /// # use kube::{Api, Client};

--- a/kube-core/src/dynamic.rs
+++ b/kube-core/src/dynamic.rs
@@ -3,7 +3,10 @@
 //! For concrete usage see [examples prefixed with dynamic_](https://github.com/kube-rs/kube-rs/tree/master/examples).
 
 pub use crate::discovery::ApiResource;
-use crate::{metadata::TypeMeta, resource::Resource};
+use crate::{
+    metadata::TypeMeta,
+    resource::{DynamicScope, Resource},
+};
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 use std::borrow::Cow;
 
@@ -57,6 +60,7 @@ impl DynamicObject {
 
 impl Resource for DynamicObject {
     type DynamicType = ApiResource;
+    type Scope = DynamicScope;
 
     fn group(dt: &ApiResource) -> Cow<'_, str> {
         dt.group.as_str().into()

--- a/kube-core/src/dynamic.rs
+++ b/kube-core/src/dynamic.rs
@@ -5,7 +5,7 @@
 pub use crate::discovery::ApiResource;
 use crate::{
     metadata::TypeMeta,
-    resource::{DynamicScope, Resource},
+    resource::{DynamicResourceScope, Resource},
 };
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 use std::borrow::Cow;
@@ -60,7 +60,7 @@ impl DynamicObject {
 
 impl Resource for DynamicObject {
     type DynamicType = ApiResource;
-    type Scope = DynamicScope;
+    type Scope = DynamicResourceScope;
 
     fn group(dt: &ApiResource) -> Cow<'_, str> {
         dt.group.as_str().into()

--- a/kube-core/src/lib.rs
+++ b/kube-core/src/lib.rs
@@ -37,7 +37,10 @@ pub mod request;
 pub use request::Request;
 
 mod resource;
-pub use resource::{Resource, ResourceExt};
+pub use resource::{
+    ClusterResourceScope, DynamicScope, NamespaceResourceScope, Resource, ResourceExt, ResourceScope,
+    SubResourceScope,
+};
 
 pub mod response;
 pub use response::Status;

--- a/kube-core/src/lib.rs
+++ b/kube-core/src/lib.rs
@@ -38,7 +38,7 @@ pub use request::Request;
 
 mod resource;
 pub use resource::{
-    ClusterResourceScope, DynamicScope, NamespaceResourceScope, Resource, ResourceExt, ResourceScope,
+    ClusterResourceScope, DynamicResourceScope, NamespaceResourceScope, Resource, ResourceExt, ResourceScope,
     SubResourceScope,
 };
 

--- a/kube-core/src/object.rs
+++ b/kube-core/src/object.rs
@@ -2,7 +2,7 @@
 use crate::{
     discovery::ApiResource,
     metadata::{ListMeta, ObjectMeta, TypeMeta},
-    resource::{DynamicScope, Resource},
+    resource::{DynamicResourceScope, Resource},
 };
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
@@ -216,7 +216,7 @@ where
     U: Clone,
 {
     type DynamicType = ApiResource;
-    type Scope = DynamicScope;
+    type Scope = DynamicResourceScope;
 
     fn group(dt: &ApiResource) -> Cow<'_, str> {
         dt.group.as_str().into()

--- a/kube-core/src/object.rs
+++ b/kube-core/src/object.rs
@@ -2,7 +2,7 @@
 use crate::{
     discovery::ApiResource,
     metadata::{ListMeta, ObjectMeta, TypeMeta},
-    resource::Resource,
+    resource::{DynamicScope, Resource},
 };
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
@@ -216,6 +216,7 @@ where
     U: Clone,
 {
     type DynamicType = ApiResource;
+    type Scope = DynamicScope;
 
     fn group(dt: &ApiResource) -> Cow<'_, str> {
         dt.group.as_str().into()

--- a/kube-core/src/resource.rs
+++ b/kube-core/src/resource.rs
@@ -6,6 +6,12 @@ use k8s_openapi::{
 
 use std::{borrow::Cow, collections::BTreeMap};
 
+pub use k8s_openapi::{ClusterResourceScope, NamespaceResourceScope, ResourceScope, SubResourceScope};
+
+/// Indicates that a [`Resource`] is of an indeterminate dynamic scope.
+pub struct DynamicScope {}
+impl ResourceScope for DynamicScope {}
+
 /// An accessor trait for a kubernetes Resource.
 ///
 /// This is for a subset of Kubernetes type that do not end in `List`.
@@ -27,6 +33,11 @@ pub trait Resource {
     ///
     /// See [`DynamicObject`](crate::dynamic::DynamicObject) for a valid implementation of non-k8s-openapi resources.
     type DynamicType: Send + Sync + 'static;
+    /// Type information for the api scope of the resource when known at compile time
+    ///
+    /// Types from k8s_openapi come with an explicit k8s_openapi::ResourceScope
+    /// Dynamic types should select `DynamicScope`
+    type Scope;
 
     /// Returns kind of this object
     fn kind(dt: &Self::DynamicType) -> Cow<'_, str>;
@@ -105,11 +116,13 @@ pub trait Resource {
 }
 
 /// Implement accessor trait for any ObjectMeta-using Kubernetes Resource
-impl<K> Resource for K
+impl<K, S> Resource for K
 where
     K: k8s_openapi::Metadata<Ty = ObjectMeta>,
+    K: k8s_openapi::Resource<Scope = S>,
 {
     type DynamicType = ();
+    type Scope = S;
 
     fn kind(_: &()) -> Cow<'_, str> {
         K::KIND.into()

--- a/kube-core/src/resource.rs
+++ b/kube-core/src/resource.rs
@@ -9,8 +9,8 @@ use std::{borrow::Cow, collections::BTreeMap};
 pub use k8s_openapi::{ClusterResourceScope, NamespaceResourceScope, ResourceScope, SubResourceScope};
 
 /// Indicates that a [`Resource`] is of an indeterminate dynamic scope.
-pub struct DynamicScope {}
-impl ResourceScope for DynamicScope {}
+pub struct DynamicResourceScope {}
+impl ResourceScope for DynamicResourceScope {}
 
 /// An accessor trait for a kubernetes Resource.
 ///
@@ -36,7 +36,7 @@ pub trait Resource {
     /// Type information for the api scope of the resource when known at compile time
     ///
     /// Types from k8s_openapi come with an explicit k8s_openapi::ResourceScope
-    /// Dynamic types should select `DynamicScope`
+    /// Dynamic types should select `Scope = DynamicResourceScope`
     type Scope;
 
     /// Returns kind of this object

--- a/kube-derive/src/custom_resource.rs
+++ b/kube-derive/src/custom_resource.rs
@@ -281,12 +281,17 @@ pub(crate) fn derive(input: proc_macro2::TokenStream) -> proc_macro2::TokenStrea
     // 2. Implement Resource trait
     let name = singular.unwrap_or_else(|| kind.to_ascii_lowercase());
     let plural = plural.unwrap_or_else(|| to_plural(&name));
-    let scope = if namespaced { "Namespaced" } else { "Cluster" };
+    let (scope, scope_quote) = if namespaced {
+        ("Namespaced", quote! { #kube_core::NamespaceResourceScope })
+    } else {
+        ("Cluster", quote! { #kube_core::ClusterResourceScope })
+    };
 
     let api_ver = format!("{}/{}", group, version);
     let impl_resource = quote! {
         impl #kube_core::Resource for #rootident {
             type DynamicType = ();
+            type Scope = #scope_quote;
 
             fn group(_: &()) -> std::borrow::Cow<'_, str> {
                #group.into()


### PR DESCRIPTION
To prevent the namespace type errors users run into occassionally (like https://github.com/kube-rs/kube-rs/discussions/952 ), and fixes #194 . k8s-openapi added these a year back but didn't have time to make everything work back then.

- [x] Extend `Resource` with `Scope` associated type
- [x] Add `DynamicScope` as an `impl ResourceScope` for dynamic/unstructured objs
- [x] Use `#[kube(namespaced)]` to decide scope for `kube-derive`
- [x] Some compile time tests + doc tests with `compile_fail` on negative case

Note the extra inlined bodies of `Api::*namespaced` methods now cannot call each other because the `_with` suffixed ones have a signature for dynamic scoped ones only.

The scope type is directly the [`ResourceScope`](https://docs.rs/k8s-openapi/latest/k8s_openapi/trait.ResourceScope.html) trait from `k8s-openapi`. Long term maybe we can get this into a traits crate if we can get consensus, but afaikt it's not possible to have our own trait for this unless it's the same one used downstream. It's not a big deal now, but will be annoying in k8s-pb.

---

One thing we could do is to add an `Api::cluster` ctor with an explicit `ClusterScope` constraint. This might be good, but it leaves `Api::all` in a bad state. Do we put a `NamespaceScope` constraint on `Api::all` after years of users using it for cluster stuff? The migration path is horrible. I found it annoying to even do internally in kube; https://github.com/kube-rs/kube-rs/commit/8613992961a5a5164776b0c31a377a74c0ff3ee5, and dynamic types struggle even more with it. Have opted not to do it for now. There are ultimately no user consequences / benefits in distinguishing cluster resources from all namespaces other than the slight semantic improvement.