### PR TITLE
Remove `tracing::instrument` from `apply_debug_overrides`

### DIFF
--- a/kube-client/src/config/mod.rs
+++ b/kube-client/src/config/mod.rs
@@ -275,7 +275,6 @@ impl Config {
     /// - `KUBE_RS_DEBUG_IMPERSONATE_USER`: A Kubernetes user to impersonate, for example: `system:serviceaccount:default:foo` will impersonate the `ServiceAccount` `foo` in the `Namespace` `default`
     /// - `KUBE_RS_DEBUG_IMPERSONATE_GROUP`: A Kubernetes group to impersonate, multiple groups may be specified by separating them with commas
     /// - `KUBE_RS_DEBUG_OVERRIDE_URL`: A Kubernetes cluster URL to use rather than the one specified in the config, useful for proxying traffic through `kubectl proxy`
-    #[tracing::instrument(level = "warn")]
     pub fn apply_debug_overrides(&mut self) {
         // Log these overrides loudly, to emphasize that this is only a debugging aid, and should not be relied upon in production
         if let Ok(impersonate_user) = std::env::var("KUBE_RS_DEBUG_IMPERSONATE_USER") {


### PR DESCRIPTION
## Motivation

When logs are configured with span events, for example:
```rust
tracing_subscriber::fmt()
    .with_max_level(Level::INFO)
    .with_span_events(FmtSpan::CLOSE)
    .finish();
```

A warning is always logged in `Config::infer()` because `apply_debug_overrides` is always called, and has `#[tracing::instrument(level = "warn")]`.

## Solution

Remove `#[tracing::instrument(level = "warn")]` because I'm not sure how this span is useful.

## Alternate Solution

Only call `apply_debug_overrides` when overrides are defined.

Or add `skip(self)` (`#[tracing::instrument(level = "warn", skip(self))]`) to minimize output.