### PR TITLE
Make `Config::auth_info` public

### DIFF
--- a/kube-client/src/config/mod.rs
+++ b/kube-client/src/config/mod.rs
@@ -135,7 +135,7 @@ pub struct Config {
     /// Whether to accept invalid certificates
     pub accept_invalid_certs: bool,
     /// Stores information to tell the cluster who you are.
-    pub(crate) auth_info: AuthInfo,
+    pub auth_info: AuthInfo,
     // TODO Actually support proxy or create an example with custom client
     /// Optional proxy URL.
     pub proxy_url: Option<http::Uri>,


### PR DESCRIPTION
Signed-off-by: Dan Spencer <danrspen@gmail.com>

<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation

https://github.com/kube-rs/kube-rs/discussions/957

## Solution

Made `auth_info` fully public on the `Config` struct
