### PR TITLE
Document that core `Api` write methods cannot set Status objects

### DIFF
--- a/examples/crd_api.rs
+++ b/examples/crd_api.rs
@@ -125,12 +125,11 @@ async fn main() -> Result<()> {
         replicas: 0,
         info: "unpatched qux".into(),
     });
-    f2.status = Some(FooStatus::default());
 
     let o = foos.create(&pp, &f2).await?;
     info!("Created {}", o.name_any());
 
-    // Update status on qux
+    // Update status on qux (cannot be done through replace/create/patch direct)
     info!("Replace Status on Foo instance qux");
     let fs = json!({
         "apiVersion": "clux.dev/v1",

--- a/kube-client/src/api/core_methods.rs
+++ b/kube-client/src/api/core_methods.rs
@@ -100,6 +100,9 @@ where
     ///     - Tradeoff between the two
     ///     - Easy partially filling of native [`k8s_openapi`] types (most fields optional)
     ///     - Partial safety against runtime errors (at least you must write valid JSON)
+    ///
+    /// Note that this method cannot write to the status object (when it exists) of a resource.
+    /// To set status objects please see [`Api::replace_status`] or [`Api::patch_status`].
     pub async fn create(&self, pp: &PostParams, data: &K) -> Result<K>
     where
         K: Serialize,
@@ -207,6 +210,9 @@ where
     /// ```
     /// [`Patch`]: super::Patch
     /// [`PatchParams`]: super::PatchParams
+    ///
+    /// Note that this method cannot write to the status object (when it exists) of a resource.
+    /// To set status objects please see [`Api::replace_status`] or [`Api::patch_status`].
     pub async fn patch<P: Serialize + Debug>(
         &self,
         name: &str,
@@ -262,6 +268,9 @@ where
     /// ```
     ///
     /// Consider mutating the result of `api.get` rather than recreating it.
+    ///
+    /// Note that this method cannot write to the status object (when it exists) of a resource.
+    /// To set status objects please see [`Api::replace_status`] or [`Api::patch_status`].
     pub async fn replace(&self, name: &str, pp: &PostParams, data: &K) -> Result<K>
     where
         K: Serialize,


### PR DESCRIPTION
Adds a clarification to three methods:

- `Api::create`
- `Api::patch`
- `Api::replace`

and fixes an example that erroneously did this that was noted in https://github.com/kube-rs/kube-rs/discussions/961