### PR TITLE
fix duplicate finalizers race condition

### DIFF
--- a/kube-runtime/src/finalizer.rs
+++ b/kube-runtime/src/finalizer.rs
@@ -167,7 +167,7 @@ where
             } else {
                 vec![
                     // Kubernetes doesn't automatically deduplicate finalizers (see
-                    // https://github.com/kube-rs/kube-rs/issues/964#issuecomment-1197311254), 
+                    // https://github.com/kube-rs/kube-rs/issues/964#issuecomment-1197311254),
                     // so we need to fail and retry if anyone else has added the finalizer in the meantime
                     PatchOperation::Test(TestOperation {
                         path: "/metadata/finalizers".to_string(),

--- a/kube-runtime/src/finalizer.rs
+++ b/kube-runtime/src/finalizer.rs
@@ -166,6 +166,9 @@ where
                 ]
             } else {
                 vec![
+                    // Kubernetes doesn't automatically deduplicate finalizers (see
+                    // https://github.com/kube-rs/kube-rs/issues/964#issuecomment-1197311254), 
+                    // so we need to fail and retry if anyone else has added the finalizer in the meantime
                     PatchOperation::Test(TestOperation {
                         path: "/metadata/finalizers".to_string(),
                         value: obj.finalizers().into(),

--- a/kube-runtime/src/finalizer.rs
+++ b/kube-runtime/src/finalizer.rs
@@ -165,10 +165,16 @@ where
                     }),
                 ]
             } else {
-                vec![PatchOperation::Add(AddOperation {
-                    path: "/metadata/finalizers/-".to_string(),
-                    value: finalizer_name.into(),
-                })]
+                vec![
+                    PatchOperation::Test(TestOperation {
+                        path: "/metadata/finalizers".to_string(),
+                        value: obj.finalizers().into(),
+                    }),
+                    PatchOperation::Add(AddOperation {
+                        path: "/metadata/finalizers/-".to_string(),
+                        value: finalizer_name.into(),
+                    }),
+                ]
             });
             api.patch::<K>(
                 obj.meta().name.as_deref().ok_or(Error::UnnamedObject)?,


### PR DESCRIPTION
Potential fix for duplicate finalizers race condition, by testing that the finalizers haven't changed since we pulled the object.

I have confirmed that this doesn't break anything, but I have no idea how to test that it actually solves the issue.

Resolves https://github.com/kube-rs/kube-rs/issues/964

## Motivation

If multiple controllers attempt to modify the finalizers for an object, they previously could make modifications that conflicted with each other. Finalizers are modified by list index, so we must know that the entire set of finalizers is the same to safely make any modifications.

## Solution

Test that finalizers haven't changed since we pulled the object.