### PR TITLE
Add connect/read/write timeouts to `Config`

### DIFF
--- a/kube-client/src/client/builder.rs
+++ b/kube-client/src/client/builder.rs
@@ -71,7 +71,6 @@ impl TryFrom<Config> for ClientBuilder<BoxService<Request<hyper::Body>, Response
         use http::header::HeaderMap;
         use tracing::Span;
 
-        let timeout = config.timeout;
         let default_ns = config.default_namespace.clone();
 
         let client: hyper::Client<_, hyper::Body> = {
@@ -101,8 +100,24 @@ impl TryFrom<Config> for ClientBuilder<BoxService<Request<hyper::Body>, Response
             ));
 
             let mut connector = TimeoutConnector::new(connector);
-            connector.set_connect_timeout(timeout);
-            connector.set_read_timeout(timeout);
+
+            // Set the timeout for the client and fallback to default deprecated timeout until it's removed
+
+            if config.connect_timeout == None {
+                connector.set_connect_timeout(config.timeout);
+            } else {
+                connector.set_connect_timeout(config.connect_timeout);
+            }
+
+            if config.read_timeout == None {
+                connector.set_read_timeout(config.timeout);
+            } else {
+                connector.set_read_timeout(config.read_timeout);
+            }
+
+            if config.write_timeout != None {
+                connector.set_write_timeout(config.write_timeout);
+            }
 
             hyper::Client::builder().build(connector)
         };

--- a/kube-client/src/client/builder.rs
+++ b/kube-client/src/client/builder.rs
@@ -102,9 +102,12 @@ impl TryFrom<Config> for ClientBuilder<BoxService<Request<hyper::Body>, Response
             let mut connector = TimeoutConnector::new(connector);
 
             // Set the timeout for the client and fallback to default deprecated timeout until it's removed
-            connector.set_connect_timeout(config.connect_timeout.or(config.timeout));
-            connector.set_read_timeout(config.read_timeout.or(config.timeout));
-            connector.set_write_timeout(config.write_timeout);
+            #[allow(deprecated)]
+            {
+                connector.set_connect_timeout(config.connect_timeout.or(config.timeout));
+                connector.set_read_timeout(config.read_timeout.or(config.timeout));
+                connector.set_write_timeout(config.write_timeout);
+            }
 
             hyper::Client::builder().build(connector)
         };

--- a/kube-client/src/client/builder.rs
+++ b/kube-client/src/client/builder.rs
@@ -102,22 +102,9 @@ impl TryFrom<Config> for ClientBuilder<BoxService<Request<hyper::Body>, Response
             let mut connector = TimeoutConnector::new(connector);
 
             // Set the timeout for the client and fallback to default deprecated timeout until it's removed
-
-            if config.connect_timeout == None {
-                connector.set_connect_timeout(config.timeout);
-            } else {
-                connector.set_connect_timeout(config.connect_timeout);
-            }
-
-            if config.read_timeout == None {
-                connector.set_read_timeout(config.timeout);
-            } else {
-                connector.set_read_timeout(config.read_timeout);
-            }
-
-            if config.write_timeout != None {
-                connector.set_write_timeout(config.write_timeout);
-            }
+            connector.set_connect_timeout(config.connect_timeout.or(config.timeout));
+            connector.set_read_timeout(config.read_timeout.or(config.timeout));
+            connector.set_write_timeout(config.write_timeout);
 
             hyper::Client::builder().build(connector)
         };

--- a/kube-client/src/config/mod.rs
+++ b/kube-client/src/config/mod.rs
@@ -128,9 +128,25 @@ pub struct Config {
     pub default_namespace: String,
     /// The configured root certificate
     pub root_cert: Option<Vec<Vec<u8>>>,
+    /// Set the timeout for connecting to the Kubernetes API.
+    ///
+    /// A value of `None` means no timeout
+    pub connect_timeout: Option<std::time::Duration>,
+    /// Set the timeout for the Kubernetes API response.
+    ///
+    /// A value of `None` means no timeout
+    pub read_timeout: Option<std::time::Duration>,
+    /// Set the timeout for the Kubernetes API request.
+    ///
+    /// A value of `None` means no timeout
+    pub write_timeout: Option<std::time::Duration>,
     /// Timeout for calls to the Kubernetes API.
     ///
     /// A value of `None` means no timeout
+    #[deprecated(
+        since = "0.75.0",
+        note = "replaced by more granular timeouts `connect_timeout`, `read_timeout` and `write_timeout`"
+    )]
     pub timeout: Option<std::time::Duration>,
     /// Whether to accept invalid certificates
     pub accept_invalid_certs: bool,
@@ -152,6 +168,9 @@ impl Config {
             cluster_url,
             default_namespace: String::from("default"),
             root_cert: None,
+            connect_timeout: Some(DEFAULT_CONNECT_TIMEOUT),
+            read_timeout: Some(DEFAULT_READ_TIMEOUT),
+            write_timeout: None,
             timeout: Some(DEFAULT_TIMEOUT),
             accept_invalid_certs: false,
             auth_info: AuthInfo::default(),
@@ -200,6 +219,9 @@ impl Config {
             cluster_url,
             default_namespace,
             root_cert: Some(root_cert),
+            connect_timeout: Some(DEFAULT_CONNECT_TIMEOUT),
+            read_timeout: Some(DEFAULT_READ_TIMEOUT),
+            write_timeout: None,
             timeout: Some(DEFAULT_TIMEOUT),
             accept_invalid_certs: false,
             auth_info: AuthInfo {
@@ -258,6 +280,9 @@ impl Config {
             cluster_url,
             default_namespace,
             root_cert,
+            connect_timeout: Some(DEFAULT_CONNECT_TIMEOUT),
+            read_timeout: Some(DEFAULT_READ_TIMEOUT),
+            write_timeout: None,
             timeout: Some(DEFAULT_TIMEOUT),
             accept_invalid_certs,
             proxy_url: loader.proxy_url()?,
@@ -325,6 +350,8 @@ fn certs(data: &[u8]) -> Result<Vec<Vec<u8>>, pem::PemError> {
 // https://github.com/kube-rs/kube-rs/issues/146#issuecomment-590924397
 /// Default Timeout
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(295);
+const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
+const DEFAULT_READ_TIMEOUT: Duration = Duration::from_secs(295);
 
 // temporary catalina hack for openssl only
 #[cfg(all(target_os = "macos", feature = "native-tls"))]

--- a/kube-client/src/config/mod.rs
+++ b/kube-client/src/config/mod.rs
@@ -164,6 +164,7 @@ impl Config {
     /// Most likely you want to use [`Config::infer`] to infer the config from
     /// the environment.
     pub fn new(cluster_url: http::Uri) -> Self {
+        #[allow(deprecated)]
         Self {
             cluster_url,
             default_namespace: String::from("default"),
@@ -215,6 +216,7 @@ impl Config {
         let default_namespace = incluster_config::load_default_ns()?;
         let root_cert = incluster_config::load_cert()?;
 
+        #[allow(deprecated)]
         Ok(Self {
             cluster_url,
             default_namespace,
@@ -276,6 +278,7 @@ impl Config {
             root_cert = Some(ca_bundle);
         }
 
+        #[allow(deprecated)]
         Ok(Self {
             cluster_url,
             default_namespace,

--- a/kube-client/src/config/mod.rs
+++ b/kube-client/src/config/mod.rs
@@ -145,7 +145,7 @@ pub struct Config {
     /// A value of `None` means no timeout
     #[deprecated(
         since = "0.75.0",
-        note = "replaced by more granular timeouts `connect_timeout`, `read_timeout` and `write_timeout`"
+        note = "replaced by more granular members `connect_timeout`, `read_timeout` and `write_timeout`. This member will be removed in 0.78.0."
     )]
     pub timeout: Option<std::time::Duration>,
     /// Whether to accept invalid certificates


### PR DESCRIPTION
Signed-off-by: goenning <me@goenning.net>

<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation

closes https://github.com/kube-rs/kube-rs/issues/969

## Solution

- Basically adding new timeout fields for connect/read/write for more granular control.
- Deprecates the existing `timeout` field.
- connect_timeout to 30s by default, which aligns with client-go and Go's defaultTransporter:
  - https://github.com/kubernetes/client-go/blob/3e9c4b4f174fc7e102dbb53fd39e3714ec70665a/transport/cache.go#L98
  - https://github.com/golang/go/blob/master/src/net/http/transport.go#L45
- write_timeout is set to None by default. It doesn't seem like client-go and Go's http.DefaultClient have a default timeout for it either. And kube-rs didn't have a default before either, so I thought it might be better to not change this.
- read_timeout stays at 295s by default
- DEFAULT_TIMEOUT and the `timeout` property can be removed later.

Note 1: I'm new to Rust, I might have made mistakes :)