### PR TITLE
Make raw `Client::send` method public

### DIFF
--- a/kube-client/src/client/mod.rs
+++ b/kube-client/src/client/mod.rs
@@ -132,7 +132,10 @@ impl Client {
         &self.default_ns
     }
 
-    async fn send(&self, request: Request<Body>) -> Result<Response<Body>> {
+    /// Perform a raw HTTP request against the API and return the raw response back.
+    /// This method can be used to get raw access to the API which may be used to, for example,
+    /// create a proxy server or application-level gateway between localhost and the API server.
+    pub async fn send(&self, request: Request<Body>) -> Result<Response<Body>> {
         let mut svc = self.inner.clone();
         let res = svc
             .ready()


### PR DESCRIPTION
This makes the send method public, which can be used to communicate directly with the API server.
This can be used to create a proxy server or application-level gateway between localhost and the
 Kubernetes API server.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation

I came across the need for this while trying to write a proxy to a k8s service using the api-server. Essentially what `kubectl proxy` does.

## Solution

By making the send method public, we can have Service impl that routes requests through the kube-client `send` method.
Now, I also wonder if we could instead provide a means to access the inner service, which could then simply be plugged in?
