### PR TITLE
fix: portforward connections

### DIFF
--- a/kube-client/src/api/portforward.rs
+++ b/kube-client/src/api/portforward.rs
@@ -310,13 +310,11 @@ where
                             .map_err(Error::InvalidErrorMessage)?;
                         sender.send(s).map_err(Error::ForwardErrorMessage)?;
                     }
-                } else {
-                    if !chan_state[port_index].shutdown {
-                        writers[port_index]
-                            .write_all(&bytes)
-                            .await
-                            .map_err(Error::WriteBytesFromPod)?;
-                    }
+                } else if !chan_state[ch].shutdown {
+                    writers[port_index]
+                        .write_all(&bytes)
+                        .await
+                        .map_err(Error::WriteBytesFromPod)?;
                 }
             }
 
@@ -335,9 +333,9 @@ where
                     return Err(Error::InvalidChannel(ch));
                 }
                 let port_index = ch / 2;
-                if !chan_state[port_index].shutdown {
+                if !chan_state[ch].shutdown {
                     writers[port_index].shutdown().await.map_err(Error::Shutdown)?;
-                    chan_state[port_index].shutdown = true;
+                    chan_state[ch].shutdown = true;
 
                     closed_ports += 1;
                 }


### PR DESCRIPTION
In some situations it was observed that connections lingered in
a CLOSE_WAIT state or even ESTABLISHED state.
In others, an existing connection would be reused and would fail at the time of use.

When the reader half is closed, signal it to the forwarder_loop task.
When a websocket close message is received, signal it to the forwarder_loop task 
so it may shutdown all write half's.
Close the non-taken streams when joining so we may terminate.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation

In some situations it was observed that connections lingered in
a CLOSE_WAIT state or even ESTABLISHED state.
In others, an existing connection would be reused and would fail at the time of use.

## Solution

When the reader half is closed, signal it to the forwarder_loop task.
When a websocket close message is received, signal it to the forwarder_loop task 
so it may shutdown all write half's.
Close the non-taken streams when joining so we may terminate.

When a message is received indicating a closed socket, shutdown all write half's.