### PR TITLE
Add `create_subresource` method to `Api` and `create_token_request` method to `Api<ServiceAccount>`

### DIFF
--- a/kube-client/src/api/subresource.rs
+++ b/kube-client/src/api/subresource.rs
@@ -76,6 +76,25 @@ where
         self.client.request::<K>(req).await
     }
 
+    /// Create an instance of the subresource
+    pub async fn create_subresource<T>(
+        &self,
+        subresource_name: &str,
+        name: &str,
+        pp: &PostParams,
+        data: Vec<u8>,
+    ) -> Result<T>
+    where
+        T: DeserializeOwned,
+    {
+        let mut req = self
+            .request
+            .create_subresource(subresource_name, name, pp, data)
+            .map_err(Error::BuildRequest)?;
+        req.extensions_mut().insert("create_subresource");
+        self.client.request::<T>(req).await
+    }
+
     /// Patch an instance of the subresource
     pub async fn patch_subresource<P: serde::Serialize + Debug>(
         &self,

--- a/kube-core/src/request.rs
+++ b/kube-core/src/request.rs
@@ -210,6 +210,24 @@ impl Request {
         req.body(vec![]).map_err(Error::BuildRequest)
     }
 
+    /// Create an instance of the subresource
+    pub fn create_subresource(
+        &self,
+        subresource_name: &str,
+        name: &str,
+        pp: &PostParams,
+        data: Vec<u8>,
+    ) -> Result<http::Request<Vec<u8>>, Error> {
+        let target = format!("{}/{}/{}?", self.url_path, name, subresource_name);
+        let mut qp = form_urlencoded::Serializer::new(target);
+        if pp.dry_run {
+            qp.append_pair("dryRun", "All");
+        }
+        let urlstr = qp.finish();
+        let req = http::Request::post(urlstr).header(http::header::CONTENT_TYPE, JSON_MIME);
+        req.body(data).map_err(Error::BuildRequest)
+    }
+
     /// Patch an instance of the subresource
     pub fn patch_subresource<P: serde::Serialize>(
         &self,

--- a/kube-core/src/request.rs
+++ b/kube-core/src/request.rs
@@ -547,6 +547,17 @@ mod test {
         assert_eq!(req.method(), "PUT");
     }
 
+    #[test]
+    fn create_subresource_path() {
+        let url = corev1::ServiceAccount::url_path(&(), Some("ns"));
+        let pp = PostParams::default();
+        let data = vec![];
+        let req = Request::new(url)
+            .create_subresource("token", "sa", &pp, data)
+            .unwrap();
+        assert_eq!(req.uri(), "/api/v1/namespaces/ns/serviceaccounts/sa/token");
+    }
+
     // TODO: reinstate if we get scoping in trait
     //#[test]
     //#[should_panic]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem you're trying to solve?
If a new feature is being added, describe the intended use case that feature fulfills.
-->

- Related discussion: #988 
- Related issue: #127 

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand the code change.
-->

- Add `create_subresource` method to `Api` to create arbitrary subresource.
- Add `create_token_request` method to `Api<ServiceAccount>`