### PR TITLE
Controller: impl Eq and PartialEq for `Action`

### DIFF
--- a/kube-runtime/src/controller/mod.rs
+++ b/kube-runtime/src/controller/mod.rs
@@ -47,7 +47,7 @@ pub enum Error<ReconcilerErr: std::error::Error + 'static, QueueErr: std::error:
 }
 
 /// Results of the reconciliation attempt
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Action {
     /// Whether (and when) to next trigger the reconciliation if no external watch triggers hit
     ///


### PR DESCRIPTION
let Action supports Eq and PartialEq allow user write unit test when
they want to check the action which returned by their codes

<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation

the `Action` doesn't implement the `Eq` or `PartialEq`, when writing unit test, user can't check the returned `Action` is correct or not.
if `Action` implements  `Eq` and `PartialEq`, user can compare it

## Solution

add `#[derive(Eq, PartialEq)]` for `Action`
