### PR TITLE
`Config`: New `incluster` and `incluster_dns` constructors

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,7 @@
 
 	// These extensions are loaded for all users by default.
 	"extensions": [
-		"matklad.rust-analyzer",
+		"rust-lang.rust-analyzer",
 		"NathanRidley.autotrim",
 		"samverschueren.final-newline",
 		"tamasfe.even-better-toml",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,8 +234,7 @@ jobs:
       # Prevent GitHub from cancelling all in-progress jobs when a matrix job fails.
       fail-fast: false
       matrix:
-        # TODO: Enable rustls https://github.com/kube-rs/kube-rs/issues/1003
-        tls: [openssl]
+        tls: [openssl, rustls]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,7 +234,8 @@ jobs:
       # Prevent GitHub from cancelling all in-progress jobs when a matrix job fails.
       fail-fast: false
       matrix:
-        tls: [openssl, rustls]
+        # TODO: Enable rustls https://github.com/kube-rs/kube-rs/issues/1003
+        tls: [openssl]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2

--- a/kube-client/src/config/incluster_config.rs
+++ b/kube-client/src/config/incluster_config.rs
@@ -33,11 +33,16 @@ pub enum Error {
     ParseCertificates(#[source] pem::PemError),
 }
 
-pub fn kube_dns() -> http::Uri {
+/// Returns the URI of the Kubernetes API server using the in-cluster DNS name
+/// `kubernetes.default.svc`.
+pub(super) fn kube_dns() -> http::Uri {
     http::Uri::from_static("https://kubernetes.default.svc/")
 }
 
-pub fn try_kube_from_env() -> Result<http::Uri, Error> {
+/// Returns the URI of the Kubernetes API server by reading the
+/// `KUBERNETES_SERVICE_HOST` and `KUBERNETES_SERVICE_PORT` environment
+/// variables.
+pub(super) fn try_kube_from_env() -> Result<http::Uri, Error> {
     // client-go requires that both environment variables are set.
     let host = std::env::var("KUBERNETES_SERVICE_HOST").map_err(Error::ReadEnvironmentVariable)?;
     let port = std::env::var("KUBERNETES_SERVICE_PORT")

--- a/kube-client/src/config/incluster_config.rs
+++ b/kube-client/src/config/incluster_config.rs
@@ -1,4 +1,8 @@
+use std::env;
 use thiserror::Error;
+
+const SERVICE_HOSTENV: &str = "KUBERNETES_SERVICE_HOST";
+const SERVICE_PORTENV: &str = "KUBERNETES_SERVICE_PORT";
 
 // Mounted credential files
 const SERVICE_TOKENFILE: &str = "/var/run/secrets/kubernetes.io/serviceaccount/token";
@@ -14,7 +18,7 @@ pub enum Error {
 
     /// Failed to read the in-cluster environment variables
     #[error("failed to read an incluster environment variable: {0}")]
-    ReadEnvironmentVariable(#[source] std::env::VarError),
+    ReadEnvironmentVariable(#[source] env::VarError),
 
     /// Failed to read a certificate bundle
     #[error("failed to read a certificate bundle: {0}")]
@@ -44,12 +48,16 @@ pub(super) fn kube_dns() -> http::Uri {
 /// variables.
 pub(super) fn try_kube_from_env() -> Result<http::Uri, Error> {
     // client-go requires that both environment variables are set.
-    let host = std::env::var("KUBERNETES_SERVICE_HOST").map_err(Error::ReadEnvironmentVariable)?;
-    let port = std::env::var("KUBERNETES_SERVICE_PORT")
+    let host = env::var(SERVICE_HOSTENV).map_err(Error::ReadEnvironmentVariable)?;
+    let port = env::var(SERVICE_PORTENV)
         .map_err(Error::ReadEnvironmentVariable)?
         .parse::<u16>()
         .map_err(Error::ParseClusterPort)?;
 
+    try_uri(&host, port)
+}
+
+fn try_uri(host: &str, port: u16) -> Result<http::Uri, Error> {
     // Format a host and, if not using 443, a port.
     //
     // Ensure that IPv6 addresses are properly bracketed.
@@ -92,4 +100,53 @@ pub fn load_cert() -> Result<Vec<Vec<u8>>, Error> {
 /// Returns the default namespace from specified path in cluster.
 pub fn load_default_ns() -> Result<String, Error> {
     std::fs::read_to_string(SERVICE_DEFAULT_NS).map_err(Error::ReadDefaultNamespace)
+}
+
+#[test]
+fn test_kube_name() {
+    assert_eq!(
+        try_uri("fake.io", 8080).unwrap().to_string(),
+        "https://fake.io:8080/"
+    );
+}
+
+#[test]
+fn test_kube_name_default_port() {
+    assert_eq!(try_uri("kubernetes.default.svc", 443).unwrap(), kube_dns())
+}
+
+#[test]
+fn test_kube_ipv4() {
+    assert_eq!(
+        try_uri("10.11.12.13", 6443).unwrap().to_string(),
+        "https://10.11.12.13:6443/"
+    );
+}
+
+#[test]
+fn test_kube_ipv4_default_port() {
+    assert_eq!(
+        try_uri("10.11.12.13", 443).unwrap().to_string(),
+        "https://10.11.12.13/"
+    );
+}
+
+#[test]
+fn test_kube_ipv6() {
+    assert_eq!(
+        try_uri("2001:0db8:85a3:0000:0000:8a2e:0370:7334", 6443)
+            .unwrap()
+            .to_string(),
+        "https://[2001:db8:85a3::8a2e:370:7334]:6443/"
+    );
+}
+
+#[test]
+fn test_kube_ipv6_default_port() {
+    assert_eq!(
+        try_uri("2001:0db8:85a3:0000:0000:8a2e:0370:7334", 443)
+            .unwrap()
+            .to_string(),
+        "https://[2001:db8:85a3::8a2e:370:7334]/"
+    );
 }

--- a/kube-client/src/config/incluster_config.rs
+++ b/kube-client/src/config/incluster_config.rs
@@ -47,24 +47,25 @@ pub fn try_kube_from_legacy_env_or_dns() -> Result<http::Uri, Error> {
     // Format a host and, if not using 443, a port.
     //
     // Ensure that IPv6 addresses are properly bracketed.
+    const HTTPS: &str = "https";
     let uri = match host.parse::<std::net::IpAddr>() {
         Ok(ip) => {
             if port == 443 {
                 if ip.is_ipv6() {
-                    format!("https://[{ip}]")
+                    format!("{HTTPS}://[{ip}]")
                 } else {
-                    format!("https://{ip}")
+                    format!("{HTTPS}://{ip}")
                 }
             } else {
                 let addr = std::net::SocketAddr::new(ip, port);
-                format!("https://{addr}")
+                format!("{HTTPS}://{addr}")
             }
         }
         Err(_) => {
             if port == 443 {
-                format!("https://{host}")
+                format!("{HTTPS}://{host}")
             } else {
-                format!("https://{host}:{port}")
+                format!("{HTTPS}://{host}:{port}")
             }
         }
     };

--- a/kube-client/src/config/mod.rs
+++ b/kube-client/src/config/mod.rs
@@ -224,6 +224,7 @@ impl Config {
     pub fn incluster() -> Result<Self, InClusterError> {
         Self::incluster_dns()
     }
+
     /// Load an in-cluster config using the `KUBERNETES_SERVICE_HOST` and
     /// `KUBERNETES_SERVICE_PORT` environment variables.
     ///

--- a/kube-client/src/config/mod.rs
+++ b/kube-client/src/config/mod.rs
@@ -222,7 +222,7 @@ impl Config {
     /// <https://github.com/kube-rs/kube-rs/issues/1003>.
     #[cfg(feature = "rustls-tls")]
     pub fn incluster() -> Result<Self, InClusterError> {
-        Self::incluster_dns(incluster_config::kube_dns())
+        Self::incluster_dns()
     }
     /// Load an in-cluster config using the `KUBERNETES_SERVICE_HOST` and
     /// `KUBERNETES_SERVICE_PORT` environment variables.

--- a/kube-client/src/config/mod.rs
+++ b/kube-client/src/config/mod.rs
@@ -218,7 +218,7 @@ impl Config {
     /// `/var/run/secrets/kubernetes.io/serviceaccount/`.
     pub fn from_cluster_env() -> Result<Self, InClusterError> {
         let uri = incluster_config::try_kube_from_env()?;
-        Self::load_inluster_with_uri(uri)
+        Self::load_incluster_with_uri(uri)
     }
 
     /// Load an in-cluster config using the API server at
@@ -230,10 +230,10 @@ impl Config {
     /// A service account's token must be available in
     /// `/var/run/secrets/kubernetes.io/serviceaccount/`.
     pub fn from_cluster_dns() -> Result<Self, InClusterError> {
-        Self::load_inluster_with_uri(incluster_config::kube_dns())
+        Self::load_incluster_with_uri(incluster_config::kube_dns())
     }
 
-    fn load_inluster_with_uri(cluster_url: http::uri::Uri) -> Result<Self, InClusterError> {
+    fn load_incluster_with_uri(cluster_url: http::uri::Uri) -> Result<Self, InClusterError> {
         let default_namespace = incluster_config::load_default_ns()?;
         let root_cert = incluster_config::load_cert()?;
 


### PR DESCRIPTION
This change restores the default behavior of reading the
`KUBERNETES_SERVICE_HOST` and `KUBERNETES_SERVICE_PORT` environment
variables, matching the official Kubernetes client libraries' behavior.
This behavior only applies when the `rustls-tls` feature is not enabled.

When the `rustls-tls` feature is enabled, incluster configurations
reference the DNS name `kubernetes.default.svc`.

Related to #1003  kubernetes/kubernetes#112263
Closes #1000

Signed-off-by: Oliver Gould <ver@buoyant.io>