### PR TITLE
Update deny.toml for idna

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -79,17 +79,8 @@ allow-git = []
 multiple-versions = "deny"
 
 [[bans.skip]]
-# The following dependencies are still working on upgrading to 0.7:
-# https://github.com/hyperium/h2/pull/603
-# https://github.com/tower-rs/tower/pull/638
-# https://github.com/tower-rs/tower-http/pull/221
-name = "tokio-util"
-version = "0.6"
-
-[[bans.skip]]
-# The following dependencies are still working on upgrading to 0.3
-# https://github.com/rustls/hyper-rustls/pull/165
-name = "rustls-pemfile"
+# Waiting on https://github.com/Keats/validator/pull/233
+name = "idna"
 version = "0.2"
 
 [[bans.skip]]


### PR DESCRIPTION
The new version of `url` pulls in `idna v0.3`, which conflicts with `idna v0.2` pulled in by `validator`.

This change updates deny.toml to remove outdated skips (for `tokio-util` and `rustls-pemfile`) and to add a skip for `idna v0.2`.

This fixes CI.

`idna` can be removed once https://github.com/Keats/validator/pull/233 is released.

Signed-off-by: Oliver Gould <ver@buoyant.io>