### PR TITLE
Upgrade `k8s-openapi` to 0.16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,7 @@ jobs:
         if: matrix.k8s == 'latest'
       - name: Run crd example tests
         run: cargo run -p kube-examples --features=_v1_25_delete --example crd_api
-        if: matrix.k8s = 'latest'
+        if: matrix.k8s == 'latest'
 
       # case 2. older kubernetes version unaffected by it
       - name: Run all default features integration library tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,8 @@ jobs:
         run: cargo build
 
       # Run the equivalent of `just integration`
-      - run: cargo test --lib --all -- --ignored
+      - name: Run all default features integration library tests
+        run: cargo test --lib --all -- --ignored
       - name: Run all facade integration library tests with extra features
         run: cargo test -p kube --lib --features=derive,runtime -- --ignored --nocapture
       - name: Run crd example tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
       fail-fast: false
       matrix:
         # Run these tests against older clusters as well
-        k8s: [v1.19, latest]
+        k8s: [v1.20, latest]
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -201,7 +201,7 @@ jobs:
 
       - uses: nolar/setup-k3d-k3s@v1
         with:
-          version: v1.19
+          version: v1.20
           # k3d-kube
           k3d-name: kube
           # Used to avoid rate limits when fetching the releases from k3s repo.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,7 +207,7 @@ jobs:
           # Used to avoid rate limits when fetching the releases from k3s repo.
           # Anonymous access is limited to 60 requests / hour / worker
           # github-token: ${{ secrets.GITHUB_TOKEN }}
-          k3d-args: "--no-lb --k3s-arg --no-deploy=traefik,servicelb,metrics-server@server:*"
+          k3d-args: "--no-lb --no-rollback --k3s-arg --disable=traefik,servicelb,metrics-server@server:*"
 
       # Real CI work starts here
       - name: Build workspace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,10 +151,23 @@ jobs:
         run: cargo build
 
       # Run the equivalent of `just integration`
+      # case 1. workaround feature for https://github.com/kubernetes/kubernetes/issues/111985
+      - name: Run all default features integration library tests
+        run: cargo test --lib --all --features=_v1_25_delete -- --ignored
+        if: matrix.k8s == 'latest'
+      - name: Run all facade integration library tests with extra features
+        run: cargo test -p kube --lib --features=derive,runtime,_v1_25_delete -- --ignored --nocapture
+        if: matrix.k8s == 'latest'
+
+      # case 2. older kubernetes version unaffected by it
       - name: Run all default features integration library tests
         run: cargo test --lib --all -- --ignored
+        if: matrix.k8s != 'latest'
       - name: Run all facade integration library tests with extra features
         run: cargo test -p kube --lib --features=derive,runtime -- --ignored --nocapture
+        if: matrix.k8s != 'latest'
+
+      # remaining tests not affected by the bug
       - name: Run all client integration library tests with rustls and ws
         run: cargo test -p kube-client --lib --features=rustls-tls,ws -- --ignored
       - name: Run derive example tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,39 +146,27 @@ jobs:
           # github-token: ${{ secrets.GITHUB_TOKEN }}
           k3d-args: "--no-lb --no-rollback --k3s-arg --disable=traefik,servicelb,metrics-server@server:*"
 
+      # Set a hacky workaround evar for https://github.com/kubernetes/kubernetes/issues/111985
+      - name: Workaround upstream Kubernetes 1.25 bug
+        if: matrix.k8s == 'latest'
+        run: echo "KUBE_UNSTABLE_V1_25_DELETE=1" >> $GITHUB_ENV
+
       # Real CI work starts here
       - name: Build workspace
         run: cargo build
 
       # Run the equivalent of `just integration`
-      # case 1. workaround feature for https://github.com/kubernetes/kubernetes/issues/111985
-      - name: Run all default features integration library tests
-        run: cargo test --lib --all --features=_v1_25_delete -- --ignored
-        if: matrix.k8s == 'latest'
-      - name: Run all facade integration library tests with extra features
-        run: cargo test -p kube --lib --features=derive,runtime,_v1_25_delete -- --ignored --nocapture
-        if: matrix.k8s == 'latest'
-      - name: Run crd example tests
-        run: cargo run -p kube-examples --features=_v1_25_delete --example crd_api
-        if: matrix.k8s == 'latest'
-
-      # case 2. older kubernetes version unaffected by it
-      - name: Run all default features integration library tests
-        run: cargo test --lib --all -- --ignored
-        if: matrix.k8s != 'latest'
+      - run: cargo test --lib --all -- --ignored
       - name: Run all facade integration library tests with extra features
         run: cargo test -p kube --lib --features=derive,runtime -- --ignored --nocapture
-        if: matrix.k8s != 'latest'
       - name: Run crd example tests
         run: cargo run -p kube-examples --example crd_api
-        if: matrix.k8s != 'latest'
-
-      # remaining tests not affected by the bug
       - name: Run all client integration library tests with rustls and ws
         run: cargo test -p kube-client --lib --features=rustls-tls,ws -- --ignored
       - name: Run derive example tests
         run: cargo run -p kube-examples --example crd_derive
-
+      - name: Run crd example tests
+        run: cargo run -p kube-examples --example crd_api
 
   mk8sv:
     # comile check e2e tests against mk8sv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,9 @@ jobs:
       - name: Run all facade integration library tests with extra features
         run: cargo test -p kube --lib --features=derive,runtime,_v1_25_delete -- --ignored --nocapture
         if: matrix.k8s == 'latest'
+      - name: Run crd example tests
+        run: cargo run -p kube-examples --features=_v1_25_delete --example crd_api
+        if: matrix.k8s = 'latest'
 
       # case 2. older kubernetes version unaffected by it
       - name: Run all default features integration library tests
@@ -166,14 +169,15 @@ jobs:
       - name: Run all facade integration library tests with extra features
         run: cargo test -p kube --lib --features=derive,runtime -- --ignored --nocapture
         if: matrix.k8s != 'latest'
+      - name: Run crd example tests
+        run: cargo run -p kube-examples --example crd_api
+        if: matrix.k8s != 'latest'
 
       # remaining tests not affected by the bug
       - name: Run all client integration library tests with rustls and ws
         run: cargo test -p kube-client --lib --features=rustls-tls,ws -- --ignored
       - name: Run derive example tests
         run: cargo run -p kube-examples --example crd_derive
-      - name: Run crd example tests
-        run: cargo run -p kube-examples --example crd_api
 
 
   mk8sv:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,11 +146,6 @@ jobs:
           # github-token: ${{ secrets.GITHUB_TOKEN }}
           k3d-args: "--no-lb --no-rollback --k3s-arg --disable=traefik,servicelb,metrics-server@server:*"
 
-      # Set a hacky workaround evar for https://github.com/kubernetes/kubernetes/issues/111985
-      - name: Workaround upstream Kubernetes 1.25 bug
-        if: matrix.k8s == 'latest'
-        run: echo "KUBE_UNSTABLE_V1_25_DELETE=1" >> $GITHUB_ENV
-
       # Real CI work starts here
       - name: Build workspace
         run: cargo build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,7 @@ jobs:
           # Used to avoid rate limits when fetching the releases from k3s repo.
           # Anonymous access is limited to 60 requests / hour / worker
           # github-token: ${{ secrets.GITHUB_TOKEN }}
-          k3d-args: "--no-lb --k3s-arg --no-deploy=traefik,servicelb,metrics-server@server:*"
+          k3d-args: "--no-lb --no-rollback --k3s-arg --disable=traefik,servicelb,metrics-server@server:*"
 
       # Real CI work starts here
       - name: Build workspace
@@ -254,7 +254,7 @@ jobs:
           # Used to avoid rate limits when fetching the releases from k3s repo.
           # Anonymous access is limited to 60 requests / hour / worker
           # github-token: ${{ secrets.GITHUB_TOKEN }}
-          k3d-args: "--no-lb --k3s-arg --no-deploy=traefik,servicelb,metrics-server@server:*"
+          k3d-args: "--no-lb --no-rollback --k3s-arg --disable=traefik,servicelb,metrics-server@server:*"
 
       - name: Compile e2e job against ${{matrix.tls}}
         run: |

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Crates.io](https://img.shields.io/crates/v/kube.svg)](https://crates.io/crates/kube)
 [![Rust 1.60](https://img.shields.io/badge/MSRV-1.60-dea584.svg)](https://github.com/rust-lang/rust/releases/tag/1.60.0)
-[![Tested against Kubernetes 1.19 and above](https://img.shields.io/badge/MK8SV-1.19-326ce5.svg)](https://kube.rs/kubernetes-version)
+[![Tested against Kubernetes v1_20 and above](https://img.shields.io/badge/MK8SV-v1_20-326ce5.svg)](https://kube.rs/kubernetes-version)
 [![Best Practices](https://bestpractices.coreinfrastructure.org/projects/5413/badge)](https://bestpractices.coreinfrastructure.org/projects/5413)
 [![Discord chat](https://img.shields.io/discord/500028886025895936.svg?logo=discord&style=plastic)](https://discord.gg/tokio)
 
@@ -17,7 +17,7 @@ Select a version of `kube` along with the generated [k8s-openapi](https://github
 ```toml
 [dependencies]
 kube = { version = "0.74.0", features = ["runtime", "derive"] }
-k8s-openapi = { version = "0.15.0", features = ["v1_24"] }
+k8s-openapi = { version = "0.15.0", features = ["v1_25"] }
 ```
 
 [Features are available](https://github.com/kube-rs/kube-rs/blob/master/kube/Cargo.toml#L18).
@@ -153,7 +153,7 @@ Kube has basic support ([with caveats](https://github.com/kube-rs/kube-rs/issues
 ```toml
 [dependencies]
 kube = { version = "0.74.0", default-features = false, features = ["client", "rustls-tls"] }
-k8s-openapi = { version = "0.15.0", features = ["v1_24"] }
+k8s-openapi = { version = "0.15.0", features = ["v1_25"] }
 ```
 
 This will pull in `rustls` and `hyper-rustls`.

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -29,6 +29,6 @@ tracing = "0.1.29"
 tracing-subscriber = "0.3.3"
 futures = "0.3.17"
 kube = { path = "../kube", version = "^0.74.0", default-features = false, features = ["client", "runtime", "ws", "admission", "gzip"] }
-k8s-openapi = { version = "0.15.0", default-features = false }
+k8s-openapi = { version = "0.16.0", default-features = false }
 serde_json = "1.0.68"
 tokio = { version = "1.14.0", features = ["full"] }

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -18,8 +18,8 @@ name = "boot"
 path = "boot.rs"
 
 [features]
-latest = ["k8s-openapi/v1_24"]
-mk8sv = ["k8s-openapi/v1_19"]
+latest = ["k8s-openapi/v1_25"]
+mk8sv = ["k8s-openapi/v1_20"]
 rustls = ["kube/rustls-tls"]
 openssl = ["kube/openssl-tls"]
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -20,7 +20,7 @@ openssl-tls = ["kube/client", "kube/openssl-tls"]
 rustls-tls = ["kube/client", "kube/rustls-tls"]
 runtime = ["kube/runtime"]
 ws = ["kube/ws"]
-latest = ["k8s-openapi/v1_24"]
+latest = ["k8s-openapi/v1_25"]
 
 [dev-dependencies]
 tokio-util = "0.7.0"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -31,7 +31,7 @@ futures = "0.3.17"
 jsonpath_lib = "0.3.0"
 kube = { path = "../kube", version = "^0.74.0", default-features = false, features = ["admission"] }
 kube-derive = { path = "../kube-derive", version = "^0.74.0", default-features = false } # only needed to opt out of schema
-k8s-openapi = { version = "0.15.0", default-features = false }
+k8s-openapi = { version = "0.16.0", default-features = false }
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.68"
 serde_yaml = "0.8.21"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -22,6 +22,11 @@ runtime = ["kube/runtime"]
 ws = ["kube/ws"]
 latest = ["k8s-openapi/v1_25"]
 
+# temporary hack for kubernetes 1.25
+# currently this feature is needed for 1.25
+# see https://github.com/kube-rs/kube-rs/issues/997
+_v1_25_delete = ["kube/_v1_25_delete"]
+
 [dev-dependencies]
 tokio-util = "0.7.0"
 assert-json-diff = "2.0.1"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -22,11 +22,6 @@ runtime = ["kube/runtime"]
 ws = ["kube/ws"]
 latest = ["k8s-openapi/v1_25"]
 
-# temporary hack for kubernetes 1.25
-# currently this feature is needed for 1.25
-# see https://github.com/kube-rs/kube-rs/issues/997
-_v1_25_delete = ["kube/_v1_25_delete"]
-
 [dev-dependencies]
 tokio-util = "0.7.0"
 assert-json-diff = "2.0.1"

--- a/justfile
+++ b/justfile
@@ -76,7 +76,8 @@ e2e-job-musl features:
 
 k3d:
   k3d cluster create main --servers 1 --registry-create main \
-    --k3s-arg "--no-deploy=traefik@server:*" \
+    --no-lb --no-rollback \
+    --k3s-arg "--disable=traefik,servicelb,metrics-server@server:*" \
     --k3s-arg '--kubelet-arg=eviction-hard=imagefs.available<1%,nodefs.available<1%@agent:*' \
     --k3s-arg '--kubelet-arg=eviction-minimum-reclaim=imagefs.available=1%,nodefs.available=1%@agent:*'
 

--- a/justfile
+++ b/justfile
@@ -13,7 +13,7 @@ fmt:
   rustfmt +nightly --edition 2021 $(find . -type f -iname *.rs)
 
 doc:
-  RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --lib --workspace --features=derive,ws,oauth,jsonpatch,client,derive,runtime,admission,k8s-openapi/v1_24 --open
+  RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --lib --workspace --features=derive,ws,oauth,jsonpatch,client,derive,runtime,admission,k8s-openapi/v1_25 --open
 
 # Unit tests
 test:

--- a/kube-client/Cargo.toml
+++ b/kube-client/Cargo.toml
@@ -73,7 +73,7 @@ tracing = { version = "0.1.29", features = ["log"], optional = true }
 hyper-openssl = { version = "0.9.2", optional = true }
 
 [dependencies.k8s-openapi]
-version = "0.15.0"
+version = "0.16.0"
 default-features = false
 features = []
 
@@ -86,6 +86,6 @@ tokio-test = "0.4.0"
 tower-test = "0.4.0"
 
 [dev-dependencies.k8s-openapi]
-version = "0.15.0"
+version = "0.16.0"
 default-features = false
 features = ["v1_24"]

--- a/kube-client/Cargo.toml
+++ b/kube-client/Cargo.toml
@@ -32,7 +32,7 @@ config = ["__non_core", "pem", "dirs"]
 __non_core = ["tracing", "serde_yaml", "base64"]
 
 [package.metadata.docs.rs]
-features = ["client", "native-tls", "rustls-tls", "openssl-tls", "ws", "oauth", "jsonpatch", "admission", "k8s-openapi/v1_24"]
+features = ["client", "native-tls", "rustls-tls", "openssl-tls", "ws", "oauth", "jsonpatch", "admission", "k8s-openapi/v1_25"]
 # Define the configuration attribute `docsrs`. Used to enable `doc_cfg` feature.
 rustdoc-args = ["--cfg", "docsrs"]
 
@@ -88,4 +88,4 @@ tower-test = "0.4.0"
 [dev-dependencies.k8s-openapi]
 version = "0.16.0"
 default-features = false
-features = ["v1_24"]
+features = ["v1_25"]

--- a/kube-core/Cargo.toml
+++ b/kube-core/Cargo.toml
@@ -34,12 +34,12 @@ chrono = { version = "0.4.19", default-features = false, features = ["clock"] }
 schemars = { version = "0.8.6", optional = true }
 
 [dependencies.k8s-openapi]
-version = "0.15.0"
+version = "0.16.0"
 default-features = false
 features = []
 
 [dev-dependencies.k8s-openapi]
-version = "0.15.0"
+version = "0.16.0"
 default-features = false
 features = ["v1_24"]
 

--- a/kube-core/Cargo.toml
+++ b/kube-core/Cargo.toml
@@ -21,6 +21,8 @@ ws = []
 admission = ["json-patch"]
 jsonpatch = ["json-patch"]
 schema = ["schemars"]
+# unstable features
+_v1_25_delete = []
 
 [dependencies]
 serde = { version = "1.0.130", features = ["derive"] }

--- a/kube-core/Cargo.toml
+++ b/kube-core/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/kube-rs/kube-rs"
 readme = "../README.md"
 
 [package.metadata.docs.rs]
-features = ["ws", "admission", "jsonpatch", "k8s-openapi/v1_24"]
+features = ["ws", "admission", "jsonpatch", "k8s-openapi/v1_25"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
@@ -41,7 +41,7 @@ features = []
 [dev-dependencies.k8s-openapi]
 version = "0.16.0"
 default-features = false
-features = ["v1_24"]
+features = ["v1_25"]
 
 [dev-dependencies]
 assert-json-diff = "2.0.1"

--- a/kube-core/Cargo.toml
+++ b/kube-core/Cargo.toml
@@ -21,8 +21,6 @@ ws = []
 admission = ["json-patch"]
 jsonpatch = ["json-patch"]
 schema = ["schemars"]
-# unstable features
-_v1_25_delete = []
 
 [dependencies]
 serde = { version = "1.0.130", features = ["derive"] }

--- a/kube-core/src/params.rs
+++ b/kube-core/src/params.rs
@@ -476,6 +476,13 @@ impl DeleteParams {
         self.preconditions = Some(preconditions);
         self
     }
+
+    pub(crate) fn is_default(&self) -> bool {
+        !self.dry_run
+            && self.grace_period_seconds.is_none()
+            && self.propagation_policy.is_none()
+            && self.preconditions.is_none()
+    }
 }
 
 // dryRun serialization differ when used as body parameters and query strings:

--- a/kube-core/src/request.rs
+++ b/kube-core/src/request.rs
@@ -149,19 +149,17 @@ impl Request {
         }
         let urlstr = qp.finish();
 
-        use crate::metadata::TypeMeta;
         #[derive(serde::Serialize)]
-        struct KindWrapper {
-            #[serde(flatten)]
-            types: TypeMeta,
+        #[serde(rename_all = "camelCase")]
+        struct KindWrapper<'a> {
+            api_version: &'a str,
+            kind: &'a str,
             #[serde(flatten)]
             data: serde_json::Value,
         }
         let kind_wrapped_dp = KindWrapper {
-            types: TypeMeta {
-                api_version: "meta.k8s.io/v1".to_string(),
-                kind: "DeleteOptions".to_string(),
-            },
+            api_version: "meta.k8s.io/v1",
+            kind: "DeleteOptions",
             data: serde_json::to_value(&dp).map_err(Error::SerializeBody)?,
         };
         let body = serde_json::to_vec(&kind_wrapped_dp).map_err(Error::SerializeBody)?;

--- a/kube-core/src/request.rs
+++ b/kube-core/src/request.rs
@@ -160,16 +160,15 @@ impl Request {
             data: serde_json::Value,
         }
 
-        k8s_openapi::k8s_if_ge_1_25! {
+        let data = if cfg!(feature = "_v1_25_delete") {
             let kind_wrapped_dp = KindWrapper {
                 api_version: "meta.k8s.io/v1",
                 kind: "DeleteOptions",
                 data: serde_json::to_value(&dp).map_err(Error::SerializeBody)?,
             };
-            let data = serde_json::to_vec(&kind_wrapped_dp).map_err(Error::SerializeBody)?;
-        };
-        k8s_openapi::k8s_if_le_1_24! {
-            let data = serde_json::to_vec(&dp).map_err(Error::SerializeBody)?;
+            serde_json::to_vec(&kind_wrapped_dp).map_err(Error::SerializeBody)?
+        } else {
+            serde_json::to_vec(&dp).map_err(Error::SerializeBody)?
         };
 
         let req = http::Request::delete(urlstr).header(http::header::CONTENT_TYPE, JSON_MIME);

--- a/kube-core/src/request.rs
+++ b/kube-core/src/request.rs
@@ -276,11 +276,10 @@ mod test {
     use crate::{params::PostParams, request::Request, resource::Resource};
     use k8s::{
         admissionregistration::v1 as adregv1, apps::v1 as appsv1, authorization::v1 as authv1,
-        autoscaling::v1 as autoscalingv1, batch::v1beta1 as batchv1beta1, core::v1 as corev1,
+        autoscaling::v1 as autoscalingv1, batch::v1 as batchv1, core::v1 as corev1,
         networking::v1 as networkingv1, rbac::v1 as rbacv1, storage::v1 as storagev1,
     };
     use k8s_openapi::api as k8s;
-    // use k8s::batch::v1 as batchv1;
 
     // NB: stable requires >= 1.17
     use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1 as apiextsv1;
@@ -315,9 +314,9 @@ mod test {
 
     #[test]
     fn api_url_cj() {
-        let url = batchv1beta1::CronJob::url_path(&(), Some("ns"));
+        let url = batchv1::CronJob::url_path(&(), Some("ns"));
         let req = Request::new(url).create(&PostParams::default(), vec![]).unwrap();
-        assert_eq!(req.uri(), "/apis/batch/v1beta1/namespaces/ns/cronjobs?");
+        assert_eq!(req.uri(), "/apis/batch/v1/namespaces/ns/cronjobs?");
     }
     #[test]
     fn api_url_hpa() {

--- a/kube-core/src/request.rs
+++ b/kube-core/src/request.rs
@@ -149,7 +149,9 @@ impl Request {
         }
         let urlstr = qp.finish();
 
-        let data = if std::env::var("KUBE_UNSTABLE_V1_25_DELETE").is_ok() {
+        let data = if dp.is_default() {
+            vec![] // default serialize needs to be empty body
+        } else if std::env::var("KUBE_UNSTABLE_V1_25_DELETE").is_ok() {
             // Empty delete params triggers an error in kubernetes v1.25
             // https://github.com/kubernetes/kubernetes/issues/111985
 

--- a/kube-core/src/request.rs
+++ b/kube-core/src/request.rs
@@ -149,6 +149,8 @@ impl Request {
         }
         let urlstr = qp.finish();
 
+        // Empty delete params triggers an error in kubernetes v1.25
+        // https://github.com/kubernetes/kubernetes/issues/111985
         #[derive(serde::Serialize)]
         #[serde(rename_all = "camelCase")]
         struct KindWrapper<'a> {

--- a/kube-core/src/request.rs
+++ b/kube-core/src/request.rs
@@ -151,11 +151,11 @@ impl Request {
 
         use crate::metadata::TypeMeta;
         #[derive(serde::Serialize)]
-        pub struct KindWrapper {
+        struct KindWrapper {
             #[serde(flatten)]
-            pub types: TypeMeta,
+            types: TypeMeta,
             #[serde(flatten)]
-            pub data: serde_json::Value,
+            data: serde_json::Value,
         }
         let kind_wrapped_dp = KindWrapper {
             types: TypeMeta {

--- a/kube-core/src/request.rs
+++ b/kube-core/src/request.rs
@@ -169,7 +169,7 @@ impl Request {
             let data = serde_json::to_vec(&kind_wrapped_dp).map_err(Error::SerializeBody)?;
         };
         k8s_openapi::k8s_if_le_1_24! {
-            let data = serde_json::to_vec(&dp).map_err(Error::SerializeBody)?
+            let data = serde_json::to_vec(&dp).map_err(Error::SerializeBody)?;
         };
 
         let req = http::Request::delete(urlstr).header(http::header::CONTENT_TYPE, JSON_MIME);

--- a/kube-derive/Cargo.toml
+++ b/kube-derive/Cargo.toml
@@ -26,7 +26,7 @@ proc-macro = true
 serde = { version = "1.0.130", features = ["derive"] }
 serde_yaml = "0.8.21"
 kube = { path = "../kube", default-features = false, version = "<1.0.0, >=0.61.0", features = ["derive"] }
-k8s-openapi = { version = "0.16.0", default-features = false, features = ["v1_24"] }
+k8s-openapi = { version = "0.16.0", default-features = false, features = ["v1_25"] }
 schemars = { version = "0.8.6", features = ["chrono"] }
 validator = { version = "0.16.0", features = ["derive"] }
 chrono = { version = "0.4.19", default-features = false }

--- a/kube-derive/Cargo.toml
+++ b/kube-derive/Cargo.toml
@@ -26,7 +26,7 @@ proc-macro = true
 serde = { version = "1.0.130", features = ["derive"] }
 serde_yaml = "0.8.21"
 kube = { path = "../kube", default-features = false, version = "<1.0.0, >=0.61.0", features = ["derive"] }
-k8s-openapi = { version = "0.15.0", default-features = false, features = ["v1_24"] }
+k8s-openapi = { version = "0.16.0", default-features = false, features = ["v1_24"] }
 schemars = { version = "0.8.6", features = ["chrono"] }
 validator = { version = "0.16.0", features = ["derive"] }
 chrono = { version = "0.4.19", default-features = false }

--- a/kube-runtime/Cargo.toml
+++ b/kube-runtime/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.60.0"
 edition = "2021"
 
 [package.metadata.docs.rs]
-features = ["k8s-openapi/v1_24"]
+features = ["k8s-openapi/v1_25"]
 # Define the configuration attribute `docsrs`. Used to enable `doc_cfg` feature.
 rustdoc-args = ["--cfg", "docsrs"]
 
@@ -50,4 +50,4 @@ schemars = "0.8.6"
 [dev-dependencies.k8s-openapi]
 version = "0.16.0"
 default-features = false
-features = ["v1_24"]
+features = ["v1_25"]

--- a/kube-runtime/Cargo.toml
+++ b/kube-runtime/Cargo.toml
@@ -37,7 +37,7 @@ thiserror = "1.0.29"
 backoff = "0.4.0"
 
 [dependencies.k8s-openapi]
-version = "0.15.0"
+version = "0.16.0"
 default-features = false
 
 [dev-dependencies]
@@ -48,6 +48,6 @@ rand = "0.8.0"
 schemars = "0.8.6"
 
 [dev-dependencies.k8s-openapi]
-version = "0.15.0"
+version = "0.16.0"
 default-features = false
 features = ["v1_24"]

--- a/kube/Cargo.toml
+++ b/kube/Cargo.toml
@@ -29,8 +29,6 @@ admission = ["kube-core/admission"]
 derive = ["kube-derive", "kube-core/schema"]
 config = ["kube-client/config"]
 runtime = ["kube-runtime"]
-# unstable features
-_v1_25_delete = ["kube-core/_v1_25_delete"]
 
 [package.metadata.docs.rs]
 features = ["client", "native-tls", "rustls-tls", "openssl-tls", "derive", "ws", "oauth", "jsonpatch", "admission", "runtime", "k8s-openapi/v1_25"]

--- a/kube/Cargo.toml
+++ b/kube/Cargo.toml
@@ -29,6 +29,8 @@ admission = ["kube-core/admission"]
 derive = ["kube-derive", "kube-core/schema"]
 config = ["kube-client/config"]
 runtime = ["kube-runtime"]
+# unstable features
+_v1_25_delete = ["kube-core/_v1_25_delete"]
 
 [package.metadata.docs.rs]
 features = ["client", "native-tls", "rustls-tls", "openssl-tls", "derive", "ws", "oauth", "jsonpatch", "admission", "runtime", "k8s-openapi/v1_25"]

--- a/kube/Cargo.toml
+++ b/kube/Cargo.toml
@@ -31,7 +31,7 @@ config = ["kube-client/config"]
 runtime = ["kube-runtime"]
 
 [package.metadata.docs.rs]
-features = ["client", "native-tls", "rustls-tls", "openssl-tls", "derive", "ws", "oauth", "jsonpatch", "admission", "runtime", "k8s-openapi/v1_24"]
+features = ["client", "native-tls", "rustls-tls", "openssl-tls", "derive", "ws", "oauth", "jsonpatch", "admission", "runtime", "k8s-openapi/v1_25"]
 # Define the configuration attribute `docsrs`. Used to enable `doc_cfg` feature.
 rustdoc-args = ["--cfg", "docsrs"]
 
@@ -58,4 +58,4 @@ schemars = "0.8.6"
 [dev-dependencies.k8s-openapi]
 version = "0.16.0"
 default-features = false
-features = ["v1_24"]
+features = ["v1_25"]

--- a/kube/Cargo.toml
+++ b/kube/Cargo.toml
@@ -44,7 +44,7 @@ kube-runtime = { path = "../kube-runtime", version = "=0.74.0", optional = true}
 # Not used directly, but required by resolver 2.0 to ensure that the k8s-openapi dependency
 # is considered part of the "deps" graph rather than just the "dev-deps" graph
 [dependencies.k8s-openapi]
-version = "0.15.0"
+version = "0.16.0"
 default-features = false
 
 [dev-dependencies]
@@ -56,6 +56,6 @@ serde = { version = "1.0.130", features = ["derive"] }
 schemars = "0.8.6"
 
 [dev-dependencies.k8s-openapi]
-version = "0.15.0"
+version = "0.16.0"
 default-features = false
 features = ["v1_24"]

--- a/kube/src/lib.rs
+++ b/kube/src/lib.rs
@@ -269,12 +269,14 @@ mod test {
                 }
             });
             let o = foos.patch("baz", &ssapply, &Patch::Apply(patch)).await?;
-            assert_eq!(o.spec.replicas, 2);
+            assert_eq!(o.spec.replicas, 2, "patching spec updated spec.replicas");
         }
         // check subresource
         {
-            assert_eq!(foos.get_scale("baz").await?.spec.unwrap().replicas, Some(2));
-            assert!(foos.get_status("baz").await?.status.is_none()); // nothing has set this
+            let scale = foos.get_scale("baz").await?;
+            assert_eq!(scale.spec.unwrap().replicas, Some(2));
+            let status = foos.get_status("baz").await?;
+            assert!(status.status.is_none(), "nothing has set status");
         }
         // set status subresource
         {
@@ -282,7 +284,7 @@ mod test {
             let o = foos
                 .patch_status("baz", &Default::default(), &Patch::Merge(&fs))
                 .await?;
-            assert!(o.status.is_some());
+            assert!(o.status.is_some(), "status set after patch_status");
         }
         // set scale subresource
         {
@@ -290,8 +292,9 @@ mod test {
             let o = foos
                 .patch_scale("baz", &Default::default(), &Patch::Merge(&fs))
                 .await?;
-            assert_eq!(o.status.unwrap().replicas, 1); // something needs to set the status for this
-            assert_eq!(o.spec.unwrap().replicas.unwrap(), 3); // what we asked for got updated
+            assert_eq!(o.status.unwrap().replicas, 1, "scale replicas got patched");
+            let linked_replicas = o.spec.unwrap().replicas.unwrap();
+            assert_eq!(linked_replicas, 3, "patch_scale updates linked spec.replicas");
         }
 
         // cleanup

--- a/kube/src/lib.rs
+++ b/kube/src/lib.rs
@@ -243,7 +243,6 @@ mod test {
             .await?;
         let establish = await_condition(crds.clone(), "foos.clux.dev", conditions::is_crd_established());
         let _ = tokio::time::timeout(std::time::Duration::from_secs(10), establish).await?;
-
         // Use it
         let foos: Api<Foo> = Api::default_namespaced(client.clone());
         // Apply from generated struct

--- a/release.toml
+++ b/release.toml
@@ -4,7 +4,7 @@
 #
 # 0. (optional) cargo release minor ; verify readme + changelog bumped; then git reset --hard
 # 1. PUBLISH_GRACE_SLEEP=20 cargo release minor --execute
-# 1X.  - on failure: follow plan manually, cd into next dirs and publish insequence with cargo publish --features=k8s-openapi/v1_24
+# 1X.  - on failure: follow plan manually, cd into next dirs and publish insequence with cargo publish --features=k8s-openapi/v1_25
 # 2. check consolidated commit
 # 2X.  - on failure: git commit --amend and insert version
 # 3. ./scripts/release-post.sh
@@ -21,4 +21,4 @@ push = false
 tag = false
 # A Kubernetes version is normally supplied by the application consuming the library in the end.
 # Since we don't have that when verifying, supply one ourselves.
-enable-features = ["k8s-openapi/v1_24"]
+enable-features = ["k8s-openapi/v1_25"]


### PR DESCRIPTION
- [x] `cargo upgrade k8s-openapi --workspace`
- [x] remove references to api resources gone in 1.25
- [x] bump our MK8SV and local pin of k8s-openapi to `v1_25` using `just bump-k8s`
- [x] fix k3d CI issue
- [x] reproduce v1_25 issue #997 (it's worse than expected)
- [x] report findings upstream  https://github.com/kubernetes/kubernetes/issues/111985
- [x] ~~await resolution upstream~~ or do an ugly workaround... (see last comment)

TL;DR: upstream bug is bad, breaking, and we need to do something to support v1_25, but we cannot detect it, so it needs to be user-opt in.